### PR TITLE
Support 'external' definitions

### DIFF
--- a/src/interface.ml
+++ b/src/interface.ml
@@ -75,6 +75,9 @@ and of_structure (def : ('a * Effect.t) Structure.t) : t list =
         Effect.function_typ header.Exp.Header.args (snd (Exp.annotation e)) in
       (name, Shape.of_effect_typ @@ Effect.Type.compress typ)) in
     values |> List.map (fun (name, typ) -> Var (name, typ))
+  | Structure.Primitive (_, prim) ->
+    (* TODO: Update to reflect that primitives are not usually pure. *)
+    [Var (prim.PrimitiveDeclaration.name, [])]
   | Structure.TypeDefinition (_, typ_def) -> of_typ_definition typ_def
   | Structure.Exception (_, exn) ->
     let name = exn.Exception.name in

--- a/src/primitiveDeclaration.ml
+++ b/src/primitiveDeclaration.ml
@@ -5,3 +5,7 @@ type t = unit
 let pp (value : t) : SmartPrint.t = nest (!^ "Primitive")
 
 let to_coq (value : t) : SmartPrint.t = !^ ""
+
+let of_ocaml env loc val_desc = ()
+
+let update_env prim env = env

--- a/src/primitiveDeclaration.ml
+++ b/src/primitiveDeclaration.ml
@@ -1,0 +1,7 @@
+open SmartPrint
+
+type t = unit
+
+let pp (value : t) : SmartPrint.t = nest (!^ "Primitive")
+
+let to_coq (value : t) : SmartPrint.t = !^ ""

--- a/src/primitiveDeclaration.ml
+++ b/src/primitiveDeclaration.ml
@@ -4,19 +4,41 @@ open SmartPrint
 
 type t = {
   name : Name.t;
+  typ_args : Name.t list;
   typ : Type.t }
 
 let pp (prim : t) : SmartPrint.t =
-  nest (!^ "Primitive" ^^ OCaml.tuple [Name.pp prim.name; Type.pp prim.typ])
+  nest (!^ "Primitive" ^^
+    OCaml.tuple
+      [Name.pp prim.name; OCaml.list Name.pp prim.typ_args; Type.pp prim.typ])
+
+
+let get_type_params (typ : type_expr) : Name.t list =
+  let params = ref Name.Set.empty in
+  let rec get_params typ =
+    match typ.desc with
+    | Tvar (Some name) -> params := Name.Set.add (Name.of_string name) !params
+    | _ -> Btype.iter_type_expr get_params typ
+  in get_params typ;
+  Name.Set.elements !params
 
 let to_coq (prim : t) : SmartPrint.t =
-  concat [!^ "Parameter" ^^ Name.to_coq prim.name ^^ !^ ":" ^^
-  Type.to_coq true prim.typ; !^ "."]
+  nest (
+    !^ "Parameter" ^^ Name.to_coq prim.name ^^ !^ ":" ^^
+    (match prim.typ_args with
+    | [] -> empty
+    | _ :: _ ->
+      !^ "forall" ^^ braces (group (
+        separate space (List.map Name.to_coq prim.typ_args) ^^
+        !^ ":" ^^ !^ "Type")) ^-^ !^ ",") ^^
+    Type.to_coq false prim.typ ^-^ !^ ".")
 
 let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t) (desc : value_description)
   : t =
+    let type_expr = desc.val_val.val_type in
     { name = Name.of_ident desc.val_id;
-      typ = Type.of_type_expr env loc desc.val_val.val_type }
+      typ_args = get_type_params type_expr;
+      typ = Type.of_type_expr env loc type_expr }
 
 let update_env (prim : t) (env : unit FullEnvi.t) : unit FullEnvi.t =
   FullEnvi.add_var [] prim.name () env

--- a/src/primitiveDeclaration.ml
+++ b/src/primitiveDeclaration.ml
@@ -1,11 +1,27 @@
+open Types
+open Typedtree
 open SmartPrint
 
-type t = unit
+type t = {
+  name : Name.t;
+  typ : Type.t }
 
-let pp (value : t) : SmartPrint.t = nest (!^ "Primitive")
+let pp (prim : t) : SmartPrint.t =
+  nest (!^ "Primitive" ^^ OCaml.tuple [Name.pp prim.name; Type.pp prim.typ])
 
-let to_coq (value : t) : SmartPrint.t = !^ ""
+let to_coq (prim : t) : SmartPrint.t =
+  concat [!^ "Parameter" ^^ Name.to_coq prim.name ^^ !^ ":" ^^
+  Type.to_coq true prim.typ; !^ "."]
 
-let of_ocaml env loc val_desc = ()
+let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t) (desc : value_description)
+  : t =
+    { name = Name.of_ident desc.val_id;
+      typ = Type.of_type_expr env loc desc.val_val.val_type }
 
-let update_env prim env = env
+let update_env (prim : t) (env : unit FullEnvi.t) : unit FullEnvi.t =
+  FullEnvi.add_var [] prim.name () env
+
+(* TODO: Update to reflect that primitives are not usually pure. *)
+let update_env_with_effects (prim : t) (env : Effect.Type.t FullEnvi.t)
+  : Effect.Type.t FullEnvi.t =
+  FullEnvi.add_var [] prim.name Effect.Type.Pure env

--- a/src/structure.ml
+++ b/src/structure.ml
@@ -40,6 +40,7 @@ end
 (** A structure. *)
 type 'a t =
   | Value of Loc.t * 'a Value.t
+  | Primitive of Loc.t * PrimitiveDeclaration.t
   | TypeDefinition of Loc.t * TypeDefinition.t
   | Exception of Loc.t * Exception.t
   | Reference of Loc.t * Reference.t
@@ -53,6 +54,8 @@ and pp (pp_a : 'a -> SmartPrint.t) (def : 'a t) : SmartPrint.t =
   match def with
   | Value (loc, value) ->
     group (Loc.pp loc ^^ Value.pp pp_a value)
+  | Primitive (loc, prim) ->
+    group (Loc.pp loc ^^ PrimitiveDeclaration.pp prim)
   | TypeDefinition (loc, typ_def) ->
     group (Loc.pp loc ^^ TypeDefinition.pp typ_def)
   | Exception (loc, exn) -> group (Loc.pp loc ^^ Exception.pp exn)
@@ -131,6 +134,8 @@ let rec monadise_let_rec (env : unit FullEnvi.t) (defs : Loc.t t list)
     | Value (loc, def) ->
       let (env, defs) = Exp.monadise_let_rec_definition env def in
       (env, defs |> List.rev |> List.map (fun def -> Value (loc, def)))
+    | Primitive (loc, prim) ->
+      (env, [def])
     | TypeDefinition (loc, typ_def) ->
       (TypeDefinition.update_env typ_def env, [def])
     | Exception (loc, exn) -> (Exception.update_env exn env, [def])
@@ -160,6 +165,8 @@ let rec effects (env : Effect.Type.t FullEnvi.t) (defs : 'a t list)
         Error.warn loc "Toplevel effects are forbidden.");
       let env = Exp.env_after_def_with_effects env def in
       (env, Value (loc, def))
+    | Primitive (loc, prim) ->
+      (env, Primitive (loc, prim))
     | TypeDefinition (loc, typ_def) ->
       (TypeDefinition.update_env typ_def env, TypeDefinition (loc, typ_def))
     | Exception (loc, exn) ->
@@ -201,6 +208,8 @@ let rec monadise (env : unit FullEnvi.t) (defs : (Loc.t * Effect.t) t list)
         (header, e)) } in
       let env = Exp.Definition.env_after_def def env in
       (env, Value (loc, def))
+    | Primitive (loc, prim) ->
+      (env, Primitive (loc, prim))
     | TypeDefinition (loc, typ_def) ->
       (TypeDefinition.update_env typ_def env, TypeDefinition (loc, typ_def))
     | Exception (loc, exn) ->
@@ -222,6 +231,7 @@ let rec to_coq (defs : 'a t list) : SmartPrint.t =
   let to_coq_one (def : 'a t) : SmartPrint.t =
     match def with
     | Value (_, value) -> Value.to_coq value
+    | Primitive (_, prim) -> PrimitiveDeclaration.to_coq prim
     | TypeDefinition (_, typ_def) -> TypeDefinition.to_coq typ_def
     | Exception (_, exn) -> Exception.to_coq exn
     | Reference (_, r) -> Reference.to_coq r

--- a/src/structure.ml
+++ b/src/structure.ml
@@ -138,7 +138,7 @@ let rec monadise_let_rec (env : unit FullEnvi.t) (defs : Loc.t t list)
       let (env, defs) = Exp.monadise_let_rec_definition env def in
       (env, defs |> List.rev |> List.map (fun def -> Value (loc, def)))
     | Primitive (loc, prim) ->
-      (env, [def])
+      (PrimitiveDeclaration.update_env prim env, [def])
     | TypeDefinition (loc, typ_def) ->
       (TypeDefinition.update_env typ_def env, [def])
     | Exception (loc, exn) -> (Exception.update_env exn env, [def])
@@ -169,7 +169,7 @@ let rec effects (env : Effect.Type.t FullEnvi.t) (defs : 'a t list)
       let env = Exp.env_after_def_with_effects env def in
       (env, Value (loc, def))
     | Primitive (loc, prim) ->
-      (env, Primitive (loc, prim))
+      (PrimitiveDeclaration.update_env_with_effects prim env, Primitive (loc, prim))
     | TypeDefinition (loc, typ_def) ->
       (TypeDefinition.update_env typ_def env, TypeDefinition (loc, typ_def))
     | Exception (loc, exn) ->
@@ -212,7 +212,7 @@ let rec monadise (env : unit FullEnvi.t) (defs : (Loc.t * Effect.t) t list)
       let env = Exp.Definition.env_after_def def env in
       (env, Value (loc, def))
     | Primitive (loc, prim) ->
-      (env, Primitive (loc, prim))
+      (PrimitiveDeclaration.update_env prim env, Primitive (loc, prim))
     | TypeDefinition (loc, typ_def) ->
       (TypeDefinition.update_env typ_def env, TypeDefinition (loc, typ_def))
     | Exception (loc, exn) ->

--- a/src/structure.ml
+++ b/src/structure.ml
@@ -108,7 +108,10 @@ let rec of_structure (env : unit FullEnvi.t) (structure : structure)
       Error.raise loc "Functors not handled."
     | Tstr_module _ -> Error.raise loc "This kind of module is not handled."
     | Tstr_eval _ -> Error.raise loc "Structure item `eval` not handled."
-    | Tstr_primitive _ -> Error.raise loc "Structure item `primitive` not handled."
+    | Tstr_primitive val_desc ->
+      let prim = PrimitiveDeclaration.of_ocaml env loc val_desc in
+      let env = PrimitiveDeclaration.update_env prim env in
+      (env, Primitive (loc, prim))
     | Tstr_typext _ -> Error.raise loc "Structure item `typext` not handled."
     | Tstr_recmodule _ -> Error.raise loc "Structure item `recmodule` not handled."
     | Tstr_class _ -> Error.raise loc "Structure item `class` not handled."

--- a/tests/ex36.effects
+++ b/tests/ex36.effects
@@ -1,0 +1,127 @@
+3 Primitive (op_eq_eq, [ ], (Type (bool/1) -> (Type (bool/1) -> Type (bool/1))))
+
+5
+Value
+  (non_rec, @.,
+    [
+      ((all_eqb, [ ],
+        [ (x, Type (bool/1)); (y, Type (bool/1)); (z, Type (bool/1)) ],
+        Some Type (bool/1)),
+        Apply
+          ((5, Effect ([ ], .)), Variable ((5, Effect ([ ], .)), andb/1),
+            [
+              Apply
+                ((5, Effect ([ ], .)),
+                  Variable
+                    ((5,
+                      Effect
+                        ([
+                        ],
+                          .)),
+                      op_eq_eq/0),
+                  [
+                    Variable
+                      ((5,
+                        Effect
+                          ([
+                          ],
+                            .)),
+                        x/0);
+                    Variable
+                      ((5,
+                        Effect
+                          ([
+                          ],
+                            .)),
+                        y/0)
+                  ]);
+              Apply
+                ((5, Effect ([ ], .)),
+                  Variable
+                    ((5,
+                      Effect
+                        ([
+                        ],
+                          .)),
+                      op_eq_eq/0),
+                  [
+                    Variable
+                      ((5,
+                        Effect
+                          ([
+                          ],
+                            .)),
+                        y/0);
+                    Variable
+                      ((5,
+                        Effect
+                          ([
+                          ],
+                            .)),
+                        z/0)
+                  ])
+            ]))
+    ])
+
+8 Primitive (op_eq, [ a ], (a -> (a -> Type (bool/1))))
+
+10
+Value
+  (non_rec, @.,
+    [
+      ((all_equal, [ A ], [ (x, A); (y, A); (z, A) ], Some Type (bool/1)),
+        Apply
+          ((10, Effect ([ ], .)), Variable ((10, Effect ([ ], .)), andb/1),
+            [
+              Apply
+                ((10, Effect ([ ], .)),
+                  Variable
+                    ((10,
+                      Effect
+                        ([
+                        ],
+                          .)),
+                      op_eq/0),
+                  [
+                    Variable
+                      ((10,
+                        Effect
+                          ([
+                          ],
+                            .)),
+                        x/0);
+                    Variable
+                      ((10,
+                        Effect
+                          ([
+                          ],
+                            .)),
+                        y/0)
+                  ]);
+              Apply
+                ((10, Effect ([ ], .)),
+                  Variable
+                    ((10,
+                      Effect
+                        ([
+                        ],
+                          .)),
+                      op_eq/0),
+                  [
+                    Variable
+                      ((10,
+                        Effect
+                          ([
+                          ],
+                            .)),
+                        y/0);
+                    Variable
+                      ((10,
+                        Effect
+                          ([
+                          ],
+                            .)),
+                        z/0)
+                  ])
+            ]))
+    ])

--- a/tests/ex36.exp
+++ b/tests/ex36.exp
@@ -1,0 +1,67 @@
+3 Primitive (op_eq_eq, [ ], (Type (bool/1) -> (Type (bool/1) -> Type (bool/1))))
+
+5
+Value
+  (non_rec, @.,
+    [
+      ((all_eqb, [ ],
+        [ (x, Type (bool/1)); (y, Type (bool/1)); (z, Type (bool/1)) ],
+        Some Type (bool/1)),
+        Apply
+          (5, Variable (5, andb/1),
+            [
+              Apply
+                (5, Variable (5, op_eq_eq/0),
+                  [
+                    Variable
+                      (5,
+                        x/0);
+                    Variable
+                      (5,
+                        y/0)
+                  ]);
+              Apply
+                (5, Variable (5, op_eq_eq/0),
+                  [
+                    Variable
+                      (5,
+                        y/0);
+                    Variable
+                      (5,
+                        z/0)
+                  ])
+            ]))
+    ])
+
+8 Primitive (op_eq, [ a ], (a -> (a -> Type (bool/1))))
+
+10
+Value
+  (non_rec, @.,
+    [
+      ((all_equal, [ A ], [ (x, A); (y, A); (z, A) ], Some Type (bool/1)),
+        Apply
+          (10, Variable (10, andb/1),
+            [
+              Apply
+                (10, Variable (10, op_eq/0),
+                  [
+                    Variable
+                      (10,
+                        x/0);
+                    Variable
+                      (10,
+                        y/0)
+                  ]);
+              Apply
+                (10, Variable (10, op_eq/0),
+                  [
+                    Variable
+                      (10,
+                        y/0);
+                    Variable
+                      (10,
+                        z/0)
+                  ])
+            ]))
+    ])

--- a/tests/ex36.interface
+++ b/tests/ex36.interface
@@ -1,0 +1,8 @@
+{
+  "version": "1",
+  "content": [
+    "Interface",
+    "Ex36",
+    [ [ "Var", "op_eq_eq", [] ], [ "Var", "all_eqb", [] ], [ "Var", "op_eq", [] ], [ "Var", "all_equal", [] ] ]
+  ]
+}

--- a/tests/ex36.ml
+++ b/tests/ex36.ml
@@ -1,0 +1,10 @@
+(** external definitions *)
+
+external ( == ) : bool -> bool -> bool = "%eq"
+
+let all_eqb x y z = x == y && y == z
+
+(* external with polymorphic parameters *)
+external ( = ) : 'a -> 'a -> bool = "%eq"
+
+let all_equal x y z = x = y && y = z

--- a/tests/ex36.monadise
+++ b/tests/ex36.monadise
@@ -1,0 +1,67 @@
+3 Primitive (op_eq_eq, [ ], (Type (bool/1) -> (Type (bool/1) -> Type (bool/1))))
+
+5
+Value
+  (non_rec, @.,
+    [
+      ((all_eqb, [ ],
+        [ (x, Type (bool/1)); (y, Type (bool/1)); (z, Type (bool/1)) ],
+        Some Type (bool/1)),
+        Apply
+          (5, Variable (5, andb/1),
+            [
+              Apply
+                (5, Variable (5, op_eq_eq/0),
+                  [
+                    Variable
+                      (5,
+                        x/0);
+                    Variable
+                      (5,
+                        y/0)
+                  ]);
+              Apply
+                (5, Variable (5, op_eq_eq/0),
+                  [
+                    Variable
+                      (5,
+                        y/0);
+                    Variable
+                      (5,
+                        z/0)
+                  ])
+            ]))
+    ])
+
+8 Primitive (op_eq, [ a ], (a -> (a -> Type (bool/1))))
+
+10
+Value
+  (non_rec, @.,
+    [
+      ((all_equal, [ A ], [ (x, A); (y, A); (z, A) ], Some Type (bool/1)),
+        Apply
+          (10, Variable (10, andb/1),
+            [
+              Apply
+                (10, Variable (10, op_eq/0),
+                  [
+                    Variable
+                      (10,
+                        x/0);
+                    Variable
+                      (10,
+                        y/0)
+                  ]);
+              Apply
+                (10, Variable (10, op_eq/0),
+                  [
+                    Variable
+                      (10,
+                        y/0);
+                    Variable
+                      (10,
+                        z/0)
+                  ])
+            ]))
+    ])

--- a/tests/ex36.v
+++ b/tests/ex36.v
@@ -1,0 +1,15 @@
+Require Import OCaml.OCaml.
+
+Local Open Scope Z_scope.
+Local Open Scope type_scope.
+Import ListNotations.
+
+Parameter op_eq_eq : bool -> bool -> bool.
+
+Definition all_eqb (x : bool) (y : bool) (z : bool) : bool :=
+  andb (op_eq_eq x y) (op_eq_eq y z).
+
+Parameter op_eq : forall {a : Type}, a -> a -> bool.
+
+Definition all_equal {A : Type} (x : A) (y : A) (z : A) : bool :=
+  andb (op_eq x y) (op_eq y z).


### PR DESCRIPTION
This PR adds support for `external` (internally `Tstr_primitive`). This is a fairly straightforward change, with the only complication being that we have to manually extract the type parameters (`get_type_params`), because the `.cmt` files don't already contain them.

Some limitations:
* side-effects aren't implemented
  - there should probably be a catch-all 'anything could happen' effects monad that all of these go into
  - this could be toggled by an OCaml annotation on the declaration
* the extraction test fails.
  - there is no way currently to extract from Coq to an OCaml `external` declaration. Adding one of these upstream would be the tidiest fix.
  - there's no attempt to do any linking (ie. looking for an appropriate definition and binding that to the name). Since there isn't a way to include extra interfaces in `master` yet, this isn't a priority.

This is part of the work necessary to fix #1, getting us sightly further into compiling the OCaml stdlib.