### PR TITLE
Follow-up to #3

### DIFF
--- a/src/envi.ml
+++ b/src/envi.ml
@@ -32,19 +32,13 @@ let pp (m : 'a t) : SmartPrint.t =
 let open_module (m : 'a t) (module_name : Name.t list) : 'a t =
   { m with opens = module_name :: m.opens }
 
-let map_union (f : PathName.t -> PathName.t) (g : PathName.t -> 'a -> 'a)
-  (m1 : 'a PathName.Map.t) (m2 : 'a PathName.Map.t) : 'a PathName.Map.t =
-  PathName.Map.fold (fun name value newmap ->
-    PathName.Map.add (f name) (g name value) newmap
-  ) m1 m2
-
 let close_module (module_name : Name.t) (prefix : Name.t -> 'a -> 'a)
   (m1 : 'a t) (m2 : 'a t) : 'a t =
   let add_to_path x =
     { x with PathName.path = module_name :: x.PathName.path } in
-  let unit_map_union m1 m2 = map_union add_to_path (fun _ () -> ()) m1 m2 in
+  let unit_map_union = PathName.Map.map_union add_to_path (fun _ () -> ()) in
 { opens = m2.opens;
-  vars = map_union add_to_path (fun _ v -> prefix module_name v)
+  vars = PathName.Map.map_union add_to_path (fun _ v -> prefix module_name v)
     m1.vars m2.vars;
   typs = unit_map_union m1.typs m2.typs;
   descriptors = unit_map_union m1.descriptors m2.descriptors;

--- a/src/envi.ml
+++ b/src/envi.ml
@@ -58,6 +58,9 @@ let find_free_name (base_name : string) (env : 'a PathName.Map.t) : Name.t =
       n in
   prefix_n base_name (first_n 0)
 
+let map (f : 'a -> 'b) (m : 'a t) : 'b t =
+  { m with vars = PathName.Map.map f m.vars }
+
 module Vars = struct
   let add (x : PathName.t) (v : 'a) (m : 'a t) : 'a t =
     { m with vars = PathName.Map.add x v m.vars }
@@ -67,9 +70,6 @@ module Vars = struct
 
   let find (x : PathName.t) (m : 'a t) : 'a =
     PathName.Map.find x m.vars
-
-  let map (f : 'a -> 'b) (m : 'a t) : 'b t =
-    { m with vars = PathName.Map.map f m.vars }
 
   (** Add a fresh local name beginning with [prefix] in [env]. *)
   let fresh (prefix : string) (v : 'a) (env : 'a t) : Name.t * 'a t =
@@ -82,9 +82,6 @@ module Typs = struct
 
   let mem (x : PathName.t) (m : 'a t) : bool =
     PathName.Map.mem x m.typs
-
-  let map (f : unit -> 'b) (m : 'a t) : 'b t =
-    { m with typs = PathName.Map.map f m.typs }
 end
 module Descriptors = struct
   let add (x : PathName.t) (m : 'a t) : 'a t =
@@ -92,9 +89,6 @@ module Descriptors = struct
 
   let mem (x : PathName.t) (m : 'a t) : bool =
     PathName.Map.mem x m.descriptors
-
-  let map (f : unit -> 'b) (m : 'a t) : 'b t =
-    { m with descriptors = PathName.Map.map f m.descriptors }
 end
 module Constructors = struct
   let add (x : PathName.t) (m : 'a t) : 'a t =
@@ -102,9 +96,6 @@ module Constructors = struct
 
   let mem (x : PathName.t) (m : 'a t) : bool =
     PathName.Map.mem x m.constructors
-
-  let map (f : unit -> 'b) (m : 'a t) : 'b t =
-    { m with constructors = PathName.Map.map f m.constructors }
 end
 module Fields = struct
   let add (x : PathName.t) (m : 'a t) : 'a t =
@@ -112,7 +103,4 @@ module Fields = struct
 
   let mem (x : PathName.t) (m : 'a t) : bool =
     PathName.Map.mem x m.fields
-
-  let map (f : unit -> 'b) (m : 'a t) : 'b t =
-    { m with fields = PathName.Map.map f m.fields }
 end

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -135,5 +135,5 @@ let fresh_var  (prefix : string) (v : 'a) (env : 'a t) : Name.t * 'a t =
 
 let rec map (f : 'a -> 'b) (env : 'a t) : 'b t =
   match env with
-  | m :: env -> Envi.Vars.map f m :: map f env
+  | m :: env -> Envi.map f m :: map f env
   | [] -> []

--- a/src/pathName.ml
+++ b/src/pathName.ml
@@ -9,7 +9,13 @@ type t = {
 
 type t' = t
 module Set = Set.Make (struct type t = t' let compare = compare end)
-module Map = Map.Make (struct type t = t' let compare = compare end)
+module Map = struct
+  include Map.Make (struct type t = t' let compare = compare end)
+
+  let map_union (f : t' -> t') (g : t' -> 'a -> 'a) (m1 : 'a t)
+    (m2 : 'a t) : 'a t =
+    fold (fun name value map -> add (f name) (g name value) map) m1 m2
+end
 
 (* Convert an identifier from OCaml to its Coq's equivalent. *)
 let convert (x : t) : t =


### PR DESCRIPTION
Tweaks for #3:
- move `map_union` into `PathName.Map`
- remove the `map` functions from `Envi` that could only resolve to `map (f : unit -> unit) (m : unit Envi.t) : unit Envi.t` (since they are effectively useless)
- promote `Envi.Vars.map` to `Envi.map`