### PR TITLE
Add support for the OCaml 'include' statement

### DIFF
--- a/src/envi.ml
+++ b/src/envi.ml
@@ -107,7 +107,7 @@ module Modules = struct
     PathName.Map.find x m.modules
 end
 
-let close_module (module_name : Name.t) (prefix : Name.t -> 'a -> 'a)
+let finish_module (module_name : Name.t) (prefix : Name.t -> 'a -> 'a)
   (m1 : 'a t) (m2 : 'a t) : 'a t =
   let add_to_path x =
     { x with PathName.path = module_name :: x.PathName.path } in

--- a/src/envi.ml
+++ b/src/envi.ml
@@ -127,7 +127,7 @@ let finish_module (module_name : Name.t) (prefix : Name.t -> 'a -> 'a)
 exception NameConflict of string * PathName.t
 
 let include_module (m_incl : 'a t) (m : 'a t) : 'a t =
-  let reject_dups typ key _ _ = raise (Failure typ) in
+  let reject_dups typ key _ _ = raise (NameConflict (typ, key)) in
   { opens = m.opens;
     vars = PathName.Map.union (reject_dups "variable")
       m_incl.vars m.vars;

--- a/src/envi.ml
+++ b/src/envi.ml
@@ -123,3 +123,21 @@ let finish_module (module_name : Name.t) (prefix : Name.t -> 'a -> 'a)
     modules = PathName.Map.map_union add_to_path (fun _ v -> v)
       m1.modules m2.modules } in
   Modules.add (PathName.of_name [] module_name) m1 m
+
+exception NameConflict of string * PathName.t
+
+let include_module (m_incl : 'a t) (m : 'a t) : 'a t =
+  let reject_dups typ key _ _ = raise (Failure typ) in
+  { opens = m.opens;
+    vars = PathName.Map.union (reject_dups "variable")
+      m_incl.vars m.vars;
+    typs = PathName.Map.union (reject_dups "type")
+      m_incl.typs m.typs;
+    descriptors = PathName.Map.union (reject_dups "descriptor")
+      m_incl.descriptors m.descriptors;
+    constructors = PathName.Map.union (reject_dups "constructor")
+      m_incl.constructors m.constructors;
+    fields = PathName.Map.union (reject_dups "field")
+      m_incl.fields m.fields;
+    modules = PathName.Map.union (reject_dups "module")
+      m_incl.modules m.modules }

--- a/src/envi.ml
+++ b/src/envi.ml
@@ -40,6 +40,10 @@ let close_module (module_name : Name.t) (prefix : Name.t -> 'a -> 'a)
   let add_to_path x =
     { x with PathName.path = module_name :: x.PathName.path } in
   let unit_map_union = PathName.Map.map_union add_to_path (fun _ () -> ()) in
+  let modules = PathName.Map.map_union add_to_path (fun _ v -> v)
+    m1.modules m2.modules in
+  let modules = PathName.Map.add (PathName.of_name [] module_name) m1
+    modules in
 { opens = m2.opens;
   vars = PathName.Map.map_union add_to_path (fun _ v -> prefix module_name v)
     m1.vars m2.vars;
@@ -47,8 +51,7 @@ let close_module (module_name : Name.t) (prefix : Name.t -> 'a -> 'a)
   descriptors = unit_map_union m1.descriptors m2.descriptors;
   constructors = unit_map_union m1.constructors m2.constructors;
   fields = unit_map_union m1.fields m2.fields;
-  modules = PathName.Map.map_union add_to_path (fun _ v -> v)
-    m1.modules m2.modules }
+  modules }
 
 let find_free_name (base_name : string) (env : 'a PathName.Map.t) : Name.t =
   let prefix_n s n =

--- a/src/envi.ml
+++ b/src/envi.ml
@@ -114,3 +114,13 @@ module Fields = struct
   let mem (x : PathName.t) (m : 'a t) : bool =
     PathName.Map.mem x m.fields
 end
+module Modules = struct
+  let add (x : PathName.t) (v : 'a t) (m : 'a t) : 'a t =
+    { m with modules = PathName.Map.add x v m.modules }
+
+  let mem (x : PathName.t) (m : 'a t) : bool =
+    PathName.Map.mem x m.modules
+
+  let find (x : PathName.t) (m : 'a t) : 'a t =
+    PathName.Map.find x m.modules
+end

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -48,7 +48,7 @@ let leave_module (module_name : Name.t) (prefix : Name.t -> 'a -> 'a)
   (env : 'a t) : 'a t =
   match env with
   | m1 :: m2 :: env ->
-    let m = Envi.close_module module_name prefix m1 m2 in
+    let m = Envi.finish_module module_name prefix m1 m2 in
     m :: env
   | _ -> failwith "You should have entered in at least one module."
 

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -159,3 +159,13 @@ let rec map (f : 'a -> 'b) (env : 'a t) : 'b t =
   match env with
   | m :: env -> Envi.map f m :: map f env
   | [] -> []
+
+let include_module (loc : Loc.t) (x : 'a Envi.t) (env : 'a t) : 'a t =
+  match env with
+  | m :: env ->
+      (try Envi.include_module x m :: env with
+      | Envi.NameConflict (typ, name) ->
+        let message = !^ "Could not include module: the" ^^ !^ typ ^^
+          PathName.pp name ^^ !^ "is already declared." in
+        Error.raise loc (SmartPrint.to_string 80 2 message))
+  | [] -> failwith "The environment must be a non-empty list."

--- a/src/include.ml
+++ b/src/include.ml
@@ -1,0 +1,23 @@
+open Typedtree
+open SmartPrint
+
+type t = PathName.t
+
+let pp (incl : t) : SmartPrint.t =
+  nest (!^ "Include" ^^ (PathName.pp incl))
+
+let of_ocaml (loc : Loc.t) (path : Path.t) : t =
+  PathName.of_path loc path
+
+let update_env (loc : Loc.t) (incl : t) (env : 'a FullEnvi.t)
+  : 'a FullEnvi.t =
+  let bound_mod = FullEnvi.bound_module loc incl env in
+  let mod_body = FullEnvi.find_module bound_mod env (fun x -> x) in
+  FullEnvi.include_module loc mod_body env
+
+let of_interface (path : PathName.t) (env : 'a FullEnvi.t) =
+  update_env Loc.Unknown path env
+
+(** Pretty-print an open construct to Coq. *)
+let to_coq (incl : t): SmartPrint.t =
+  nest (!^ "Include" ^^ PathName.pp incl ^-^ !^ ".")

--- a/src/structure.ml
+++ b/src/structure.ml
@@ -104,13 +104,19 @@ let rec of_structure (env : unit FullEnvi.t) (structure : structure)
     | Tstr_module { mb_expr = { mod_desc = Tmod_functor _ }} ->
       Error.raise loc "Functors not handled."
     | Tstr_module _ -> Error.raise loc "This kind of module is not handled."
+    | Tstr_include { incl_mod = { mod_desc = Tmod_ident (path, longident) } } ->
+      let name = PathName.of_longident longident.txt in
+      let bound_mod = FullEnvi.bound_module loc name env in
+      let mod_body = FullEnvi.find_module bound_mod env (fun x -> x) in
+      let env = FullEnvi.include_module loc mod_body env in
+      env |> FullEnvi.pp |> to_string 80 2 |> Error.raise loc
+    | Tstr_include _ -> Error.raise loc "This kind of include is not handled"
     | Tstr_eval _ -> Error.raise loc "Structure item `eval` not handled."
     | Tstr_primitive _ -> Error.raise loc "Structure item `primitive` not handled."
     | Tstr_typext _ -> Error.raise loc "Structure item `typext` not handled."
     | Tstr_recmodule _ -> Error.raise loc "Structure item `recmodule` not handled."
     | Tstr_class _ -> Error.raise loc "Structure item `class` not handled."
     | Tstr_class_type _ -> Error.raise loc "Structure item `class_type` not handled."
-    | Tstr_include _ -> Error.raise loc "Structure item `include` not handled."
     | Tstr_attribute _ -> Error.raise loc "Structure item `attribute` not handled." in
   let (env, defs) =
     List.fold_left (fun (env, defs) item ->

--- a/tests/ex37.effects
+++ b/tests/ex37.effects
@@ -1,0 +1,57 @@
+3 Module A:
+  4
+  Value
+    (non_rec, @.,
+      [
+        ((a, [ ], [ ], Some Type (Z/2)), Constant ((4, Effect ([ ], .)), Int(5)))
+      ])
+  
+  6
+  Value
+    (non_rec, @.,
+      [
+        ((c, [ A ], [ (x, Type (string/2)) ], Some A),
+          Apply
+            ((6, Effect ([ OCaml.Failure/2 ], .)),
+              Variable
+                ((6, Effect ([ ], . -[ OCaml.Failure/2 ]-> .)),
+                  OCaml.Pervasives.failwith/2),
+              [ Variable ((6, Effect ([ ], .)), x/0) ]))
+      ])
+
+9 Include A
+
+11
+Value
+  (non_rec, @.,
+    [
+      ((b, [ ], [ ], Some Type (Z/1)),
+        Apply
+          ((11, Effect ([ ], .)), Variable ((11, Effect ([ ], .)), Z.add/1),
+            [
+              Variable ((11, Effect ([ ], .)), a/0);
+              Constant ((11, Effect ([ ], .)), Int(2))
+            ]))
+    ])
+
+13
+Value
+  (non_rec, @.,
+    [
+      ((d, [ A ], [ (b, Type (bool/1)) ], Some A),
+        IfThenElse
+          ((13, Effect ([ OCaml.Failure/2 ], .)),
+            Variable ((13, Effect ([ ], .)), b/0),
+            Apply
+              ((13, Effect ([ OCaml.Failure/2 ], .)),
+                Variable
+                  ((13, Effect ([ ], . -[ OCaml.Failure/2 ]-> .)),
+                    c/0),
+                [ Constant ((13, Effect ([ ], .)), String("true")) ]),
+            Apply
+              ((13, Effect ([ OCaml.Failure/2 ], .)),
+                Variable
+                  ((13, Effect ([ ], . -[ OCaml.Failure/2 ]-> .)),
+                    c/0),
+                [ Constant ((13, Effect ([ ], .)), String("false")) ])))
+    ])

--- a/tests/ex37.exp
+++ b/tests/ex37.exp
@@ -1,0 +1,40 @@
+3 Module A:
+  4
+  Value
+    (non_rec, @., [ ((a, [ ], [ ], Some Type (Z/2)), Constant (4, Int(5))) ])
+  
+  6
+  Value
+    (non_rec, @.,
+      [
+        ((c, [ A ], [ (x, Type (string/2)) ], Some A),
+          Apply
+            (6, Variable (6, OCaml.Pervasives.failwith/2),
+              [ Variable (6, x/0) ]))
+      ])
+
+9 Include A
+
+11
+Value
+  (non_rec, @.,
+    [
+      ((b, [ ], [ ], Some Type (Z/1)),
+        Apply
+          (11, Variable (11, Z.add/1),
+            [ Variable (11, a/0); Constant (11, Int(2)) ]))
+    ])
+
+13
+Value
+  (non_rec, @.,
+    [
+      ((d, [ A ], [ (b, Type (bool/1)) ], Some A),
+        IfThenElse
+          (13, Variable (13, b/0),
+            Apply
+              (13, Variable (13, c/0), [ Constant (13, String("true")) ]),
+            Apply
+              (13, Variable (13, c/0),
+                [ Constant (13, String("false")) ])))
+    ])

--- a/tests/ex37.interface
+++ b/tests/ex37.interface
@@ -1,0 +1,13 @@
+{
+  "version": "1",
+  "content": [
+    "Interface",
+    "Ex37",
+    [
+      [ "Interface", "A", [ [ "Var", "a", [] ], [ "Var", "c", [ [ "OCaml.Failure" ] ] ] ] ],
+      [ "Include", "A" ],
+      [ "Var", "b", [] ],
+      [ "Var", "d", [ [ "OCaml.Failure" ] ] ]
+    ]
+  ]
+}

--- a/tests/ex37.ml
+++ b/tests/ex37.ml
@@ -1,0 +1,13 @@
+(** Include modules *)
+
+module A = struct
+  let a = 5
+
+  let c x = failwith x
+end
+
+include A
+
+let b = a + 2
+
+let d b = if b then c "true" else c "false"

--- a/tests/ex37.monadise
+++ b/tests/ex37.monadise
@@ -1,0 +1,41 @@
+3 Module A:
+  4
+  Value
+    (non_rec, @., [ ((a, [ ], [ ], Some Type (Z/2)), Constant (4, Int(5))) ])
+  
+  6
+  Value
+    (non_rec, @.,
+      [
+        ((c, [ A ], [ (x, Type (string/2)) ],
+          Some Monad ([ OCaml.Failure/2 ], A)),
+          Apply
+            (6, Variable (6, OCaml.Pervasives.failwith/2),
+              [ Variable (6, x/0) ]))
+      ])
+
+9 Include A
+
+11
+Value
+  (non_rec, @.,
+    [
+      ((b, [ ], [ ], Some Type (Z/1)),
+        Apply
+          (11, Variable (11, Z.add/1),
+            [ Variable (11, a/0); Constant (11, Int(2)) ]))
+    ])
+
+13
+Value
+  (non_rec, @.,
+    [
+      ((d, [ A ], [ (b, Type (bool/1)) ], Some Monad ([ OCaml.Failure/2 ], A)),
+        IfThenElse
+          (13, Variable (13, b/0),
+            Apply
+              (13, Variable (13, c/0), [ Constant (13, String("true")) ]),
+            Apply
+              (13, Variable (13, c/0),
+                [ Constant (13, String("false")) ])))
+    ])

--- a/tests/ex37.v
+++ b/tests/ex37.v
@@ -1,0 +1,22 @@
+Require Import OCaml.OCaml.
+
+Local Open Scope Z_scope.
+Local Open Scope type_scope.
+Import ListNotations.
+
+Module A.
+  Definition a : Z := 5.
+  
+  Definition c {A : Type} (x : string) : M [ OCaml.Failure ] A :=
+    OCaml.Pervasives.failwith x.
+End A.
+
+Include A.
+
+Definition b : Z := Z.add a 2.
+
+Definition d {A : Type} (b : bool) : M [ OCaml.Failure ] A :=
+  if b then
+    c "true" % string
+  else
+    c "false" % string.


### PR DESCRIPTION
This builds upon the work in PRs #3 and #4, which make `Envi.t` represent an entire module.

This PR
* adds a `modules` field to `Envi.t`
* stores child modules in the `modules` field when they are closed
* adds mechanisms to merge `Envi.t`s
* implements `include` statements by looking up the relevant module in the environment's `modules` fields and merging it into the active `Envi.t`
* adds some tests (which pass)

NB: This changes the format of the output files (in particular, the `interface` file) to describe files with `include`s properly. There should probably be a version bump of some kind for this.