### PR TITLE
Use the local OCaml coq code for tests and extraction 

### DIFF
--- a/test.rb
+++ b/test.rb
@@ -42,7 +42,7 @@ class Test
   end
 
   def coq_cmd
-    "coqc #{extension('.v')} -R tests Tests"
+    "coqc #{extension('.v')} -R tests Tests -R OCaml OCaml"
   end
 
   def coq


### PR DESCRIPTION
This prevents extraction from failing with an `inconsistent assumptions` error if the system's library and the local library differ.