### PR TITLE
Add options to compile multiple modes cumulatively, with output to files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,19 +24,19 @@ vo: $(TESTS_INPUT:.ml=.vo)
 	ocamlc -bin-annot $<
 
 %.exp: %.cmt default
-	./$(OUTPUT) -mode exp $< >$@
+	./$(OUTPUT) --mode exp $< >$@
 
 %.effects: %.cmt default
-	./$(OUTPUT) -mode effects $< >$@
+	./$(OUTPUT) --mode effects $< >$@
 
 %.monadise: %.cmt default
-	./$(OUTPUT) -mode monadise $< >$@
+	./$(OUTPUT) --mode monadise $< >$@
 
 %.interface: %.cmt default
-	./$(OUTPUT) -mode interface $< >$@
+	./$(OUTPUT) --mode interface $< >$@
 
 %.v: %.cmt default
-	./$(OUTPUT) -mode v $< >$@
+	./$(OUTPUT) --mode v $< >$@
 
 %.vo: %.v
 	coqc $<

--- a/src/coqOfOCaml.ml
+++ b/src/coqOfOCaml.ml
@@ -53,23 +53,70 @@ let output_monadise (c : out_channel) (monadise : Loc.t Structure.t list)
   : unit =
   to_out_channel c @@ Structure.pps Loc.pp monadise
 
+type mode_files = {
+  v : string list;
+  interface : string list;
+  exp : string list;
+  effects : string list;
+  monadise : string list
+}
+
+let empty_mode_files : mode_files = {
+  v = [];
+  interface = [];
+  exp = [];
+  effects = [];
+  monadise = []
+}
+
+let mode_files_localise (dir : string) (mode_files : mode_files) : mode_files =
+  let localise file =
+    if Filename.is_implicit file then Filename.concat dir file else file in
+  { v = List.map localise mode_files.v;
+    interface = List.map localise mode_files.interface;
+    exp = List.map localise mode_files.exp;
+    effects = List.map localise mode_files.effects;
+    monadise = List.map localise mode_files.monadise }
+
+let stropt_eq (str : string) (opt_str : string option) : bool =
+  match opt_str with
+  | Some str2 -> String.equal str str2
+  | None -> false
+
+let do_out (f : out_channel -> 'a -> 'b) (file_name : string) (x : 'a) : 'b =
+  let out = open_out file_name in
+  let ret = f out x in
+  close_out out;
+  ret
+
 (** Display on stdout the conversion in Coq of an OCaml structure. *)
-let of_ocaml (structure : Typedtree.structure) (mode : string)
-  (module_name : string) : unit =
+let of_ocaml (structure : Typedtree.structure) (mode : string option)
+  (mode_files : mode_files) (module_name : string) : unit =
   try
     let (exp_l, effects_l, interface_l, monadise_l, coq_l) =
-      if String.equal "exp" mode then
+      if stropt_eq "exp" mode then
         [output_exp stdout], [], [], [], []
-      else if String.equal "effects" mode then
+      else if stropt_eq "effects" mode then
         [], [output_effects stdout], [], [], []
-      else if String.equal "interface" mode then
+      else if stropt_eq "interface" mode then
         [], [], [output_interface stdout], [], []
-      else if String.equal "monadise" mode then
+      else if stropt_eq "monadise" mode then
         [], [], [], [output_monadise stdout], []
-      else if String.equal "v" mode then
+      else if stropt_eq "v" mode then
         [], [], [], [], [to_out_channel stdout]
       else
         [], [], [], [], [] in
+
+    let exp_l = exp_l @
+      (List.map (do_out output_exp) mode_files.exp) in
+    let effects_l = effects_l @
+      (List.map (do_out output_effects) mode_files.effects) in
+    let interface_l = interface_l @
+      (List.map (do_out output_interface) mode_files.interface) in
+    let monadise_l = monadise_l @
+      (List.map (do_out output_monadise) mode_files.monadise) in
+    let coq_l = coq_l @
+      (List.map (do_out to_out_channel) mode_files.v) in
 
     map_apply structure
       (result_map exp (exp_l @
@@ -90,8 +137,11 @@ let parse_cmt (file_name : string) : Typedtree.structure =
     structure
   | _ -> failwith "Cannot extract cmt data."
 
+let bare_file_name (file_name : string) : string =
+  Filename.chop_extension @@ Filename.basename file_name
+
 let module_name (file_name : string) : string =
-  String.capitalize_ascii @@ Filename.chop_extension @@ Filename.basename file_name
+  String.capitalize_ascii file_name
 
 let rec find_interfaces_dir (base : string) : string option =
   let base_path = Filename.dirname base in
@@ -107,26 +157,75 @@ let rec find_interfaces_dir (base : string) : string option =
 (** The main function. *)
 let main () =
   let file_name = ref None in
-  let mode = ref "" in
+  let mode = ref None in
+  let mode_files = ref empty_mode_files in
   let dir = ref "" in
-  let options = [
-    "-mode", Arg.Set_string mode,
-      " v (generate Coq .v files, you probably want this option), exp (the simplified expression tree), effects (the inferred effects), monadise (the expression tree after monadisation), interface (the equivalent of .mli with effects)";
+  let output_dir = ref "" in
+  let stdlib = ref true in
+  let output_all = ref false in
+  let output_default_force = ref false in
+  let options = Arg.align [
+    "--v", Arg.String
+        (fun file -> mode_files := {!mode_files with v = file :: !mode_files.v}),
+      "filename\toutput the generated Coq .v file to filename";
+    "--interface", Arg.String
+        (fun file -> mode_files := {!mode_files with interface = file :: !mode_files.interface}),
+      "filename\toutput the generated interface file (similar to an .mli with effects) to filename";
+    "--exp", Arg.String
+        (fun file -> mode_files := {!mode_files with exp = file :: !mode_files.exp}),
+      "filename\toutput the simplified expression tree to filename";
+    "--effects", Arg.String
+        (fun file -> mode_files := {!mode_files with effects = file :: !mode_files.effects}),
+      "filename\toutput the inferred effects to filename";
+    "--monadise", Arg.String
+        (fun file -> mode_files := {!mode_files with monadise = file :: !mode_files.monadise}),
+      "filename\toutput the expression tree after monadisation to filename";
+    "--all", Arg.Set output_all,
+      "  \toutput all modes to their default filenames in the output directory";
+    "--default", Arg.Set output_default_force,
+      "\toutput v and interface modes to their default filenames in the output directory";
+    "--mode", Arg.Symbol
+        (["v"; "interface"; "exp"; "effects"; "monadise"], fun m -> mode := Some m),
+      "\tdirect the mode's output to stdout";
     "-I", Arg.Tuple [Arg.Set_string dir; Arg.String (fun coq_name ->
         LazyLoader.interfaces := (Name.of_string coq_name, !dir) :: !LazyLoader.interfaces)],
-      "dir coqdir\t\tsearch physical dir for interface files, mapped to logical coqdir"] in
+      "dir coqdir\tsearch physical dir for interface files, mapped to logical coqdir";
+    "-o", Arg.Set_string output_dir,
+      "dir\tset the output directory to dir";
+    "--no-stdlib", Arg.Clear stdlib,
+      "\tdon't include the interfaces directory containing the standard interfaces"] in
   let usage_msg = "Usage: ./coqOfOCaml.native file.cmt\nOptions are:" in
 
-  (* Add the default interfaces directory to the interfaces list. *)
-  (match find_interfaces_dir Sys.executable_name with
-  | Some interfaces_dir ->
-    LazyLoader.interfaces := ("OCaml", interfaces_dir) :: !LazyLoader.interfaces
-  | None ->
-    prerr_endline @@ to_string 80 2 (!^ "Warning: interfaces directory was not found"));
+  if !stdlib then begin
+    (* Add the default interfaces directory to the interfaces list. *)
+    (match find_interfaces_dir Sys.executable_name with
+    | Some interfaces_dir ->
+      LazyLoader.interfaces := ("OCaml", interfaces_dir) :: !LazyLoader.interfaces
+    | None ->
+      prerr_endline @@ to_string 80 2 (!^ "Warning: interfaces directory was not found"));
+  end else ();
 
   Arg.parse options (fun arg -> file_name := Some arg) usage_msg;
   match !file_name with
   | None -> Arg.usage options usage_msg
-  | Some file_name -> of_ocaml (parse_cmt file_name) !mode (module_name file_name);
+  | Some file_name ->
+    let bare_file_name = bare_file_name file_name in
+    if !output_all then
+      mode_files := {
+        v = !mode_files.v @ [module_name bare_file_name ^ ".v"];
+        interface = !mode_files.interface @ [bare_file_name ^ ".interface"];
+        exp = !mode_files.exp @ [bare_file_name ^ ".exp"];
+        effects = !mode_files.effects @ [bare_file_name ^ ".effects"];
+        monadise = !mode_files.monadise @ [bare_file_name ^ ".monadise"]
+      }
+    else if !output_default_force ||
+           (!mode_files == empty_mode_files && !mode == None) then
+      mode_files := {!mode_files with
+        v = !mode_files.v @ [module_name bare_file_name ^ ".v"];
+        interface = !mode_files.interface @ [bare_file_name ^ ".interface"]
+      };
+    if !output_dir != "" then
+      mode_files := mode_files_localise !output_dir !mode_files;
+    of_ocaml (parse_cmt file_name) !mode !mode_files (module_name bare_file_name);
 
 ;;main ()

--- a/test.rb
+++ b/test.rb
@@ -24,7 +24,7 @@ class Test
   end
 
   def coq_of_ocaml_cmd(mode)
-    cmd = ['./coqOfOCaml.native', '-mode', mode, extension('.cmt')]
+    cmd = ['./coqOfOCaml.native', '--mode', mode, extension('.cmt')]
   end
 
   def coq_of_ocaml(mode)


### PR DESCRIPTION
This PR
* adds several options for compiling specific modes to files
* reformats the `-mode` option to the POSIX standard `--mode` format
* rework code so that re-usable computations are reused, by cascading through the modes
  - the `result_map`/`map_apply` functions are the key to this 

The output of all modes is unaffected.