### PR TITLE
Compute the types for primitives using the code for Exp Definitions

### DIFF
--- a/src/type.ml
+++ b/src/type.ml
@@ -25,7 +25,7 @@ let rec of_type_expr_new_typ_vars (env : 'a FullEnvi.t) (loc : Loc.t)
   (typ_vars : Name.t Name.Map.t) (typ : Types.type_expr)
   : t * Name.t Name.Map.t * Name.Set.t =
   match typ.desc with
-  | Tvar None ->
+  | Tvar _ ->
     let x = Printf.sprintf "A%d" typ.id in
     let (typ_vars, new_typ_vars, name) =
       if Name.Map.mem x typ_vars then (
@@ -33,7 +33,10 @@ let rec of_type_expr_new_typ_vars (env : 'a FullEnvi.t) (loc : Loc.t)
         (typ_vars, Name.Set.empty, name)
       ) else (
         let n = Name.Map.cardinal typ_vars in
-        let name = String.make 1 (Char.chr (Char.code 'A' + n)) in
+        let name = if n < 25 then
+            String.make 1 (Char.chr (Char.code 'A' + n))
+          else (* We've used all the capital letters, switch to A1.. *)
+            Printf.sprintf "A%d" (n-24) in
         let typ_vars = Name.Map.add x name typ_vars in
         (typ_vars, Name.Set.singleton name, name)) in
     let typ = Variable name in

--- a/tests/ex36.effects
+++ b/tests/ex36.effects
@@ -63,7 +63,7 @@ Value
             ]))
     ])
 
-8 Primitive (op_eq, [ a ], (a -> (a -> Type (bool/1))))
+8 Primitive (op_eq, [ A ], (A -> (A -> Type (bool/1))))
 
 10
 Value

--- a/tests/ex36.exp
+++ b/tests/ex36.exp
@@ -33,7 +33,7 @@ Value
             ]))
     ])
 
-8 Primitive (op_eq, [ a ], (a -> (a -> Type (bool/1))))
+8 Primitive (op_eq, [ A ], (A -> (A -> Type (bool/1))))
 
 10
 Value

--- a/tests/ex36.monadise
+++ b/tests/ex36.monadise
@@ -33,7 +33,7 @@ Value
             ]))
     ])
 
-8 Primitive (op_eq, [ a ], (a -> (a -> Type (bool/1))))
+8 Primitive (op_eq, [ A ], (A -> (A -> Type (bool/1))))
 
 10
 Value

--- a/tests/ex36.v
+++ b/tests/ex36.v
@@ -9,7 +9,7 @@ Parameter op_eq_eq : bool -> bool -> bool.
 Definition all_eqb (x : bool) (y : bool) (z : bool) : bool :=
   andb (op_eq_eq x y) (op_eq_eq y z).
 
-Parameter op_eq : forall {a : Type}, a -> a -> bool.
+Parameter op_eq : forall {A : Type}, A -> A -> bool.
 
 Definition all_equal {A : Type} (x : A) (y : A) (z : A) : bool :=
   andb (op_eq x y) (op_eq y z).


### PR DESCRIPTION
This PR tweaks `of_type_expr_new_typ_vars` to make it work for `PrimitiveDeclaration`s. In line with the style of `Exp.Definition`, primitives' type variables now use `A`,`B`,...,`Z`,`A1`,`A2`, etc. regardless of what the original type variable name was in OCaml.