### PR TITLE
Make References more like normal values

### DIFF
--- a/OCaml/Effect.v
+++ b/OCaml/Effect.v
@@ -309,7 +309,7 @@ End Run.
 Module State.
   Unset Implicit Arguments.
 
-  Definition read (state : Effect.t) (_ : unit) : M [ state ] (Effect.S state) :=
+  Definition read (state : Effect.t) : M [ state ] (Effect.S state) :=
     fun s => (inl (fst s), s).
 
   Definition write (state : Effect.t) (x : Effect.S state) : M [ state ] unit :=

--- a/OCaml/Effect.v
+++ b/OCaml/Effect.v
@@ -306,6 +306,18 @@ Module Run.
       end.
 End Run.
 
+Module State.
+  Unset Implicit Arguments.
+
+  Definition read (state : Effect.t) (_ : unit) : M [ state ] (Effect.S state) :=
+    fun s => (inl (fst s), s).
+
+  Definition write (state : Effect.t) (x : Effect.S state) : M [ state ] unit :=
+    fun s => (inl tt, (x, tt)).
+
+  Set Implicit Arguments.
+End State.
+
 (** A stream which may be finite. *)
 Module FiniteStream.
   CoInductive t (A : Type) : Type :=

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -87,10 +87,7 @@ and of_structure (def : ('a * Effect.t) Structure.t) : t list =
     [ Descriptor name; Var (name, [[PathName.of_name [] name]]) ]
   | Structure.Reference (_, r) ->
     let name = r.Reference.name in
-    let shape = [[PathName.of_name [] name]] in
-    [ Descriptor name;
-      Var ("read_" ^ name, shape);
-      Var ("write_" ^ name, shape) ]
+    [ Var (name, []); Descriptor name ]
   | Structure.Open _ -> []
   | Structure.Include (_, name) -> [Include name]
   | Structure.Module (_, name, defs) -> [Interface (name, of_structures defs)]

--- a/src/pathName.ml
+++ b/src/pathName.ml
@@ -20,8 +20,10 @@ end
 (* Convert an identifier from OCaml to its Coq's equivalent. *)
 let convert (x : t) : t =
   match x with
-  | { path = ["Pervasives"]; base = "!" } -> { path = ["Pervasives"]; base = "!" }
-  | { path = ["Pervasives"]; base = ":=" } -> { path = ["Pervasives"]; base = ":=" }
+  | { path = ["Pervasives"]; base = "!" } ->
+    { path = ["OCaml"; "Effect"; "State"]; base = "read" }
+  | { path = ["Pervasives"]; base = ":=" } ->
+    { path = ["OCaml"; "Effect"; "State"]; base = "write" }
   (* The core library *)
   (* Built-in types *)
   | { path = []; base = "int" } -> { path = []; base = "Z" }

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -57,6 +57,9 @@ let env_with_effects : Effect.Type.t FullEnvi.t =
   |> add_exn ["OCaml"] "Division_by_zero"
   |> add_exn ["OCaml"] "Sys_blocked_io"
   |> add_exn ["OCaml"] "Undefined_recursive_module"
+  (* State *)
+  |> add_var ["OCaml"; "Effect"; "State"] "read" Pure
+  |> add_var ["OCaml"; "Effect"; "State"] "write" Pure
 
   (* Pervasives *)
   (* Exceptions *)

--- a/src/reference.ml
+++ b/src/reference.ml
@@ -33,27 +33,10 @@ let update_env (r : t) (env : unit FullEnvi.t) : unit FullEnvi.t =
 let update_env_with_effects (r : t) (env : Effect.Type.t FullEnvi.t)
   (id : Effect.Descriptor.Id.t) : Effect.Type.t FullEnvi.t =
   let env = FullEnvi.add_descriptor [] r.name env in
-  let effect_typ =
-    Effect.Type.Arrow (
-      Effect.Descriptor.singleton
-        id
-        (FullEnvi.bound_descriptor Loc.Unknown (PathName.of_name [] r.name) env),
-      Effect.Type.Pure) in
   env
   |> FullEnvi.add_var [] r.name Effect.Type.Pure
   |> FullEnvi.add_descriptor [] r.name
 
 let to_coq (r : t) : SmartPrint.t =
   !^ "Definition" ^^ Name.to_coq r.name ^^ !^ ":=" ^^
-    !^ "Effect.make" ^^ Type.to_coq true r.typ ^^ !^ "Empty_set" ^-^ !^ "." ^^
-  newline ^^ newline ^^
-  !^ "Definition" ^^ Name.to_coq ("read_" ^ r.name) ^^ !^ "(_ : unit)" ^^ !^ ":" ^^
-    !^ "M" ^^ !^ "[" ^^ Name.to_coq r.name ^^ !^ "]" ^^ Type.to_coq true r.typ ^^ !^ ":=" ^^
-  newline ^^ indent (
-    !^ "State.read" ^^ Name.to_coq r.name ^^ !^ "tt.") ^^
-  newline ^^ newline ^^
-  !^ "Definition" ^^ Name.to_coq ("write_" ^ r.name) ^^
-    parens (!^ "x" ^^ !^ ":" ^^ Type.to_coq false r.typ) ^^ !^ ":" ^^
-    !^ "M" ^^ !^ "[" ^^ Name.to_coq r.name ^^ !^ "]" ^^ !^ "unit" ^^ !^ ":=" ^^
-  newline ^^ indent (
-    !^ "State.write" ^^ Name.to_coq r.name ^^ !^ "x.")
+    !^ "Effect.make" ^^ Type.to_coq true r.typ ^^ !^ "Empty_set" ^-^ !^ "."

--- a/src/reference.ml
+++ b/src/reference.ml
@@ -51,10 +51,10 @@ let to_coq (r : t) : SmartPrint.t =
   !^ "Definition" ^^ Name.to_coq ("read_" ^ r.name) ^^ !^ "(_ : unit)" ^^ !^ ":" ^^
     !^ "M" ^^ !^ "[" ^^ Name.to_coq r.name ^^ !^ "]" ^^ Type.to_coq true r.typ ^^ !^ ":=" ^^
   newline ^^ indent (
-    !^ "fun s => (inl (fst s), s).") ^^
+    !^ "State.read" ^^ Name.to_coq r.name ^^ !^ "tt.") ^^
   newline ^^ newline ^^
   !^ "Definition" ^^ Name.to_coq ("write_" ^ r.name) ^^
     parens (!^ "x" ^^ !^ ":" ^^ Type.to_coq false r.typ) ^^ !^ ":" ^^
     !^ "M" ^^ !^ "[" ^^ Name.to_coq r.name ^^ !^ "]" ^^ !^ "unit" ^^ !^ ":=" ^^
   newline ^^ indent (
-    !^ "fun s => (inl tt, (x, tt)).")
+    !^ "State.write" ^^ Name.to_coq r.name ^^ !^ "x.")

--- a/src/reference.ml
+++ b/src/reference.ml
@@ -27,8 +27,7 @@ let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t) (cases : value_binding list)
 
 let update_env (r : t) (env : unit FullEnvi.t) : unit FullEnvi.t =
   env
-  |> FullEnvi.add_var [] ("read_" ^ r.name) ()
-  |> FullEnvi.add_var [] ("write_" ^ r.name) ()
+  |> FullEnvi.add_var [] r.name ()
   |> FullEnvi.add_descriptor [] r.name
 
 let update_env_with_effects (r : t) (env : Effect.Type.t FullEnvi.t)
@@ -41,8 +40,8 @@ let update_env_with_effects (r : t) (env : Effect.Type.t FullEnvi.t)
         (FullEnvi.bound_descriptor Loc.Unknown (PathName.of_name [] r.name) env),
       Effect.Type.Pure) in
   env
-  |> FullEnvi.add_var [] ("read_" ^ r.name) effect_typ
-  |> FullEnvi.add_var [] ("write_" ^ r.name) effect_typ
+  |> FullEnvi.add_var [] r.name Effect.Type.Pure
+  |> FullEnvi.add_descriptor [] r.name
 
 let to_coq (r : t) : SmartPrint.t =
   !^ "Definition" ^^ Name.to_coq r.name ^^ !^ ":=" ^^

--- a/tests/ex18.effects
+++ b/tests/ex18.effects
@@ -32,17 +32,26 @@ Value
                             ],
                               .)),
                           Variable
-                            ((?,
+                            ((4,
                               Effect
                                 ([
                                 ],
                                   .
-                                    -[
-                                      r/0
-                                    ]->
-                                    .)),
-                              read_r/0),
+                                    ->
+                                    .
+                                      -[
+                                        r/0
+                                      ]->
+                                      .)),
+                              OCaml.Effect.State.read/1),
                           [
+                            Variable
+                              ((4,
+                                Effect
+                                  ([
+                                  ],
+                                    .)),
+                                r/0);
                             Tuple
                               ((?,
                                 Effect
@@ -69,7 +78,7 @@ Value
     [
       ((fail, [ A; B ], [ (x, A) ], B),
         Match
-          ((?, Effect ([ OCaml.Failure/1; s/0 ], .)),
+          ((?, Effect ([ s/0; OCaml.Failure/1 ], .)),
             Variable ((?, Effect ([ ], .)), x/0),
             [
               (Any,
@@ -77,8 +86,8 @@ Value
                   ((8,
                     Effect
                       ([
-                        OCaml.Failure/1;
-                        s/0
+                        s/0;
+                        OCaml.Failure/1
                       ],
                         .)),
                     Variable
@@ -101,17 +110,26 @@ Value
                             ],
                               .)),
                           Variable
-                            ((?,
+                            ((8,
                               Effect
                                 ([
                                 ],
                                   .
-                                    -[
-                                      s/0
-                                    ]->
-                                    .)),
-                              read_s/0),
+                                    ->
+                                    .
+                                      -[
+                                        s/0
+                                      ]->
+                                      .)),
+                              OCaml.Effect.State.read/1),
                           [
+                            Variable
+                              ((8,
+                                Effect
+                                  ([
+                                  ],
+                                    .)),
+                                s/0);
                             Tuple
                               ((?,
                                 Effect
@@ -140,17 +158,26 @@ Value
                       ],
                         .)),
                     Variable
-                      ((?,
+                      ((11,
                         Effect
                           ([
                           ],
                             .
-                              -[
-                                r/0
-                              ]->
-                              .)),
-                        write_r/0),
+                              ->
+                              .
+                                -[
+                                  r/0
+                                ]->
+                                .)),
+                        OCaml.Effect.State.write/1),
                     [
+                      Variable
+                        ((11,
+                          Effect
+                            ([
+                            ],
+                              .)),
+                          r/0);
                       Constant
                         ((11,
                           Effect
@@ -179,17 +206,26 @@ Value
                       ],
                         .)),
                     Variable
-                      ((?,
+                      ((14,
                         Effect
                           ([
                           ],
                             .
-                              -[
-                                r/0
-                              ]->
-                              .)),
-                        write_r/0),
+                              ->
+                              .
+                                -[
+                                  r/0
+                                ]->
+                                .)),
+                        OCaml.Effect.State.write/1),
                     [
+                      Variable
+                        ((14,
+                          Effect
+                            ([
+                            ],
+                              .)),
+                          r/0);
                       Apply
                         ((14,
                           Effect
@@ -213,17 +249,26 @@ Value
                                   ],
                                     .)),
                                 Variable
-                                  ((?,
+                                  ((14,
                                     Effect
                                       ([
                                       ],
                                         .
-                                          -[
-                                            r/0
-                                          ]->
-                                          .)),
-                                    read_r/0),
+                                          ->
+                                          .
+                                            -[
+                                              r/0
+                                            ]->
+                                            .)),
+                                    OCaml.Effect.State.read/1),
                                 [
+                                  Variable
+                                    ((14,
+                                      Effect
+                                        ([
+                                        ],
+                                          .)),
+                                      r/0);
                                   Tuple
                                     ((?,
                                       Effect

--- a/tests/ex18.effects
+++ b/tests/ex18.effects
@@ -37,12 +37,10 @@ Value
                                 ([
                                 ],
                                   .
-                                    ->
-                                    .
-                                      -[
-                                        r/0
-                                      ]->
-                                      .)),
+                                    -[
+                                      r/0
+                                    ]->
+                                    .)),
                               OCaml.Effect.State.read/1),
                           [
                             Variable
@@ -51,13 +49,7 @@ Value
                                   ([
                                   ],
                                     .)),
-                                r/0);
-                            Tuple
-                              ((?,
-                                Effect
-                                  ([
-                                  ],
-                                    .)))
+                                r/0)
                           ]);
                       Constant
                         ((4,
@@ -115,12 +107,10 @@ Value
                                 ([
                                 ],
                                   .
-                                    ->
-                                    .
-                                      -[
-                                        s/0
-                                      ]->
-                                      .)),
+                                    -[
+                                      s/0
+                                    ]->
+                                    .)),
                               OCaml.Effect.State.read/1),
                           [
                             Variable
@@ -129,13 +119,7 @@ Value
                                   ([
                                   ],
                                     .)),
-                                s/0);
-                            Tuple
-                              ((?,
-                                Effect
-                                  ([
-                                  ],
-                                    .)))
+                                s/0)
                           ])
                     ]))
             ]))
@@ -254,12 +238,10 @@ Value
                                       ([
                                       ],
                                         .
-                                          ->
-                                          .
-                                            -[
-                                              r/0
-                                            ]->
-                                            .)),
+                                          -[
+                                            r/0
+                                          ]->
+                                          .)),
                                     OCaml.Effect.State.read/1),
                                 [
                                   Variable
@@ -268,13 +250,7 @@ Value
                                         ([
                                         ],
                                           .)),
-                                      r/0);
-                                  Tuple
-                                    ((?,
-                                      Effect
-                                        ([
-                                        ],
-                                          .)))
+                                      r/0)
                                 ]);
                             Constant
                               ((14,

--- a/tests/ex18.exp
+++ b/tests/ex18.exp
@@ -18,9 +18,12 @@ Value
                       Apply
                         (4,
                           Variable
-                            (?,
-                              read_r/0),
+                            (4,
+                              OCaml.Effect.State.read/1),
                           [
+                            Variable
+                              (4,
+                                r/0);
                             Tuple
                               (?)
                           ]);
@@ -51,9 +54,12 @@ Value
                       Apply
                         (8,
                           Variable
-                            (?,
-                              read_s/0),
+                            (8,
+                              OCaml.Effect.State.read/1),
                           [
+                            Variable
+                              (8,
+                                s/0);
                             Tuple
                               (?)
                           ])
@@ -74,8 +80,11 @@ Value
                   (11,
                     Variable
                       (?,
-                        write_r/0),
+                        OCaml.Effect.State.write/1),
                     [
+                      Variable
+                        (11,
+                          r/0);
                       Constant
                         (11,
                           Int(0))
@@ -96,8 +105,11 @@ Value
                   (14,
                     Variable
                       (?,
-                        write_r/0),
+                        OCaml.Effect.State.write/1),
                     [
+                      Variable
+                        (14,
+                          r/0);
                       Apply
                         (14,
                           Variable
@@ -107,9 +119,12 @@ Value
                             Apply
                               (14,
                                 Variable
-                                  (?,
-                                    read_r/0),
+                                  (14,
+                                    OCaml.Effect.State.read/1),
                                 [
+                                  Variable
+                                    (14,
+                                      r/0);
                                   Tuple
                                     (?)
                                 ]);

--- a/tests/ex18.exp
+++ b/tests/ex18.exp
@@ -23,9 +23,7 @@ Value
                           [
                             Variable
                               (4,
-                                r/0);
-                            Tuple
-                              (?)
+                                r/0)
                           ]);
                       Constant
                         (4,
@@ -59,9 +57,7 @@ Value
                           [
                             Variable
                               (8,
-                                s/0);
-                            Tuple
-                              (?)
+                                s/0)
                           ])
                     ]))
             ]))
@@ -79,7 +75,7 @@ Value
                 Apply
                   (11,
                     Variable
-                      (?,
+                      (11,
                         OCaml.Effect.State.write/1),
                     [
                       Variable
@@ -104,7 +100,7 @@ Value
                 Apply
                   (14,
                     Variable
-                      (?,
+                      (14,
                         OCaml.Effect.State.write/1),
                     [
                       Variable
@@ -124,9 +120,7 @@ Value
                                 [
                                   Variable
                                     (14,
-                                      r/0);
-                                  Tuple
-                                    (?)
+                                      r/0)
                                 ]);
                             Constant
                               (14,

--- a/tests/ex18.interface
+++ b/tests/ex18.interface
@@ -11,7 +11,7 @@
       [ "Descriptor", "s" ],
       [ "Var", "read_s", [ [ "s" ] ] ],
       [ "Var", "write_s", [ [ "s" ] ] ],
-      [ "Var", "fail", [ [ "OCaml.Failure", "s" ] ] ],
+      [ "Var", "fail", [ [ "s", "OCaml.Failure" ] ] ],
       [ "Var", "reset", [ [ "r" ] ] ],
       [ "Var", "incr", [ [ "r" ] ] ]
     ]

--- a/tests/ex18.interface
+++ b/tests/ex18.interface
@@ -4,13 +4,11 @@
     "Interface",
     "Ex18",
     [
+      [ "Var", "r", [] ],
       [ "Descriptor", "r" ],
-      [ "Var", "read_r", [ [ "r" ] ] ],
-      [ "Var", "write_r", [ [ "r" ] ] ],
       [ "Var", "plus_one", [ [ "r" ] ] ],
+      [ "Var", "s", [] ],
       [ "Descriptor", "s" ],
-      [ "Var", "read_s", [ [ "s" ] ] ],
-      [ "Var", "write_s", [ [ "s" ] ] ],
       [ "Var", "fail", [ [ "s", "OCaml.Failure" ] ] ],
       [ "Var", "reset", [ [ "r" ] ] ],
       [ "Var", "incr", [ [ "r" ] ] ]

--- a/tests/ex18.monadise
+++ b/tests/ex18.monadise
@@ -19,9 +19,7 @@ Value
                         [
                           Variable
                             (4,
-                              r/0);
-                          Tuple
-                            (?)
+                              r/0)
                         ]),
                     Some
                       x_1,
@@ -73,9 +71,7 @@ Value
                             [
                               Variable
                                 (8,
-                                  s/0);
-                              Tuple
-                                (?)
+                                  s/0)
                             ])),
                     Some
                       x_1,
@@ -147,9 +143,7 @@ Value
                             [
                               Variable
                                 (14,
-                                  r/0);
-                              Tuple
-                                (?)
+                                  r/0)
                             ]),
                         Some
                           x_1,

--- a/tests/ex18.monadise
+++ b/tests/ex18.monadise
@@ -14,9 +14,12 @@ Value
                     Apply
                       (4,
                         Variable
-                          (?,
-                            read_r/0),
+                          (4,
+                            OCaml.Effect.State.read/1),
                         [
+                          Variable
+                            (4,
+                              r/0);
                           Tuple
                             (?)
                         ]),
@@ -46,7 +49,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((fail, [ A; B ], [ (x, A) ], Monad ([ OCaml.Failure/1; s/0 ], B)),
+      ((fail, [ A; B ], [ (x, A) ], Monad ([ s/0; OCaml.Failure/1 ], B)),
         Match
           (?, Variable (?, x/0),
             [
@@ -59,15 +62,18 @@ Value
                           s/0
                         ],
                         [
-                          OCaml.Failure/1;
-                          s/0
+                          s/0;
+                          OCaml.Failure/1
                         ],
                         Apply
                           (8,
                             Variable
-                              (?,
-                                read_s/0),
+                              (8,
+                                OCaml.Effect.State.read/1),
                             [
+                              Variable
+                                (8,
+                                  s/0);
                               Tuple
                                 (?)
                             ])),
@@ -79,8 +85,8 @@ Value
                           OCaml.Failure/1
                         ],
                         [
-                          OCaml.Failure/1;
-                          s/0
+                          s/0;
+                          OCaml.Failure/1
                         ],
                         Apply
                           (8,
@@ -107,9 +113,12 @@ Value
                 Apply
                   (11,
                     Variable
-                      (?,
-                        write_r/0),
+                      (11,
+                        OCaml.Effect.State.write/1),
                     [
+                      Variable
+                        (11,
+                          r/0);
                       Constant
                         (11,
                           Int(0))
@@ -133,9 +142,12 @@ Value
                         Apply
                           (14,
                             Variable
-                              (?,
-                                read_r/0),
+                              (14,
+                                OCaml.Effect.State.read/1),
                             [
+                              Variable
+                                (14,
+                                  r/0);
                               Tuple
                                 (?)
                             ]),
@@ -161,9 +173,12 @@ Value
                     Apply
                       (14,
                         Variable
-                          (?,
-                            write_r/0),
+                          (14,
+                            OCaml.Effect.State.write/1),
                         [
+                          Variable
+                            (14,
+                              r/0);
                           Variable
                             (?,
                               x_1/0)

--- a/tests/ex18.v
+++ b/tests/ex18.v
@@ -7,10 +7,10 @@ Import ListNotations.
 Definition r := Effect.make Z Empty_set.
 
 Definition read_r (_ : unit) : M [ r ] Z :=
-  fun s => (inl (fst s), s).
+  Effect.State.read r tt.
 
 Definition write_r (x : Z) : M [ r ] unit :=
-  fun s => (inl tt, (x, tt)).
+  Effect.State.write r x.
 
 Definition plus_one {A : Type} (x : A) : M [ r ] Z :=
   match x with
@@ -22,10 +22,10 @@ Definition plus_one {A : Type} (x : A) : M [ r ] Z :=
 Definition s := Effect.make string Empty_set.
 
 Definition read_s (_ : unit) : M [ s ] string :=
-  fun s => (inl (fst s), s).
+  Effect.State.read s tt.
 
 Definition write_s (x : string) : M [ s ] unit :=
-  fun s => (inl tt, (x, tt)).
+  Effect.State.write s x.
 
 Definition fail {A B : Type} (x : A) : M [ OCaml.Failure; s ] B :=
   match x with

--- a/tests/ex18.v
+++ b/tests/ex18.v
@@ -7,43 +7,43 @@ Import ListNotations.
 Definition r := Effect.make Z Empty_set.
 
 Definition read_r (_ : unit) : M [ r ] Z :=
-  Effect.State.read r tt.
+  State.read r tt.
 
 Definition write_r (x : Z) : M [ r ] unit :=
-  Effect.State.write r x.
+  State.write r x.
 
 Definition plus_one {A : Type} (x : A) : M [ r ] Z :=
   match x with
   | _ =>
-    let! x_1 := read_r tt in
+    let! x_1 := OCaml.Effect.State.read r tt in
     ret (Z.add x_1 1)
   end.
 
 Definition s := Effect.make string Empty_set.
 
 Definition read_s (_ : unit) : M [ s ] string :=
-  Effect.State.read s tt.
+  State.read s tt.
 
 Definition write_s (x : string) : M [ s ] unit :=
-  Effect.State.write s x.
+  State.write s x.
 
-Definition fail {A B : Type} (x : A) : M [ OCaml.Failure; s ] B :=
+Definition fail {A B : Type} (x : A) : M [ s; OCaml.Failure ] B :=
   match x with
   | _ =>
-    let! x_1 := lift [_;_] "01" (read_s tt) in
-    lift [_;_] "10" (OCaml.Pervasives.failwith x_1)
+    let! x_1 := lift [_;_] "10" (OCaml.Effect.State.read s tt) in
+    lift [_;_] "01" (OCaml.Pervasives.failwith x_1)
   end.
 
 Definition reset {A : Type} (x : A) : M [ r ] unit :=
   match x with
-  | _ => write_r 0
+  | _ => OCaml.Effect.State.write r 0
   end.
 
 Definition incr {A : Type} (x : A) : M [ r ] unit :=
   match x with
   | _ =>
     let! x_1 :=
-      let! x_1 := read_r tt in
+      let! x_1 := OCaml.Effect.State.read r tt in
       ret (Z.add x_1 1) in
-    write_r x_1
+    OCaml.Effect.State.write r x_1
   end.

--- a/tests/ex18.v
+++ b/tests/ex18.v
@@ -9,7 +9,7 @@ Definition r := Effect.make Z Empty_set.
 Definition plus_one {A : Type} (x : A) : M [ r ] Z :=
   match x with
   | _ =>
-    let! x_1 := OCaml.Effect.State.read r tt in
+    let! x_1 := OCaml.Effect.State.read r in
     ret (Z.add x_1 1)
   end.
 
@@ -18,7 +18,7 @@ Definition s := Effect.make string Empty_set.
 Definition fail {A B : Type} (x : A) : M [ s; OCaml.Failure ] B :=
   match x with
   | _ =>
-    let! x_1 := lift [_;_] "10" (OCaml.Effect.State.read s tt) in
+    let! x_1 := lift [_;_] "10" (OCaml.Effect.State.read s) in
     lift [_;_] "01" (OCaml.Pervasives.failwith x_1)
   end.
 
@@ -31,7 +31,7 @@ Definition incr {A : Type} (x : A) : M [ r ] unit :=
   match x with
   | _ =>
     let! x_1 :=
-      let! x_1 := OCaml.Effect.State.read r tt in
+      let! x_1 := OCaml.Effect.State.read r in
       ret (Z.add x_1 1) in
     OCaml.Effect.State.write r x_1
   end.

--- a/tests/ex18.v
+++ b/tests/ex18.v
@@ -6,12 +6,6 @@ Import ListNotations.
 
 Definition r := Effect.make Z Empty_set.
 
-Definition read_r (_ : unit) : M [ r ] Z :=
-  State.read r tt.
-
-Definition write_r (x : Z) : M [ r ] unit :=
-  State.write r x.
-
 Definition plus_one {A : Type} (x : A) : M [ r ] Z :=
   match x with
   | _ =>
@@ -20,12 +14,6 @@ Definition plus_one {A : Type} (x : A) : M [ r ] Z :=
   end.
 
 Definition s := Effect.make string Empty_set.
-
-Definition read_s (_ : unit) : M [ s ] string :=
-  State.read s tt.
-
-Definition write_s (x : string) : M [ s ] unit :=
-  State.write s x.
 
 Definition fail {A B : Type} (x : A) : M [ s; OCaml.Failure ] B :=
   match x with


### PR DESCRIPTION
This PR introduces `OCaml.Effect.State.read`/`write` and uses them to implement the OCaml `!` and `:=` operators in a general way. This replaces the previous `*_read` and `*_write` methods for `Ref` values, and moves the Reference implementation closer to being values.