### PR TITLE
Prevent name collisions

### DIFF
--- a/src/coqName.ml
+++ b/src/coqName.ml
@@ -1,0 +1,46 @@
+(** Local identifiers, used for variable names in patterns for example. *)
+open SmartPrint
+open Yojson.Basic
+
+type t =
+  | Name of Name.t
+  | Alias of Name.t * Name.t (* (OCaml name, Coq name) *)
+
+let of_names (name : Name.t) (coq_name : Name.t) : t =
+  if name = coq_name then
+    Name coq_name
+  else
+    Alias (name, coq_name)
+
+let ocaml_name (x : t) : Name.t =
+  match x with
+  | Name name -> name
+  | Alias (name, _) -> name
+
+let assoc_names (x : t) : Name.t * Name.t =
+  match x with
+  | Name name -> (name, name)
+  | Alias (name, coq_name) -> (name, coq_name)
+
+let pp (x : t) : SmartPrint.t =
+  match x with
+  | Name name -> Name.pp name
+  | Alias (name, coq_name) ->
+    group @@ Name.pp name ^^ parens @@ !^ "=" ^^ Name.pp coq_name
+
+(** Pretty-print a name to Coq. *)
+let to_coq (x : t) : SmartPrint.t =
+  match x with
+  | Name name -> Name.to_coq name
+  | Alias (_, coq_name) -> Name.to_coq coq_name
+
+let to_json (x : t) : json =
+  match x with
+  | Name name -> `String name
+  | Alias (name, coq_name) -> `List [`String name; `String coq_name]
+
+let of_json (json : json) : t =
+  match json with
+  | `String x -> Name x
+  | `List [`String name; `String coq_name] -> Alias (name, coq_name)
+  | _ -> raise (Error.Json "String or string 2-tuple expected.")

--- a/src/exception.ml
+++ b/src/exception.ml
@@ -2,44 +2,55 @@ open Typedtree
 open SmartPrint
 
 type t = {
-  name : Name.t;
+  name : CoqName.t;
+  raise_name : CoqName.t;
   typ : Type.t }
 
 let pp (exn : t) : SmartPrint.t =
-  nest (!^ "Exception" ^^ OCaml.tuple [Name.pp exn.name; Type.pp exn.typ])
+  nest (!^ "Exception" ^^
+    OCaml.tuple [CoqName.pp exn.name; CoqName.pp exn.raise_name; Type.pp exn.typ])
 
 let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t)
   (exn : extension_constructor) : t =
   let name = Name.of_ident exn.ext_id in
+  let coq_name = (FullEnvi.resolve_descriptor [] name env).base in
+  let raise_name = "raise_" ^ name in
+  let coq_raise_name = (FullEnvi.resolve_var [] raise_name env).base in
   let typs =
     match exn.ext_type.Types.ext_args with
     | Types.Cstr_tuple typs -> typs
     | Types.Cstr_record _ -> Error.raise loc "Unhandled named constructor parameters." in
   let typ = Type.Tuple (typs |> List.map (fun typ -> Type.of_type_expr env loc typ)) in
-  { name = name; typ = typ}
+  { name = CoqName.of_names name coq_name;
+    raise_name = CoqName.of_names raise_name coq_raise_name;
+    typ = typ}
 
 let update_env (exn : t) (env : unit FullEnvi.t) : unit FullEnvi.t =
+  let (name, coq_name) = CoqName.assoc_names exn.name in
+  let (raise_name, coq_raise_name) = CoqName.assoc_names exn.raise_name in
   env
-  |> FullEnvi.add_descriptor [] exn.name
-  |> FullEnvi.add_var [] ("raise_" ^ exn.name) ()
+  |> FullEnvi.assoc_descriptor [] name coq_name
+  |> FullEnvi.assoc_var [] raise_name coq_raise_name ()
 
 let update_env_with_effects (exn : t) (env : Effect.Type.t FullEnvi.t)
   (id : Effect.Descriptor.Id.t) : Effect.Type.t FullEnvi.t =
-  let env = FullEnvi.add_descriptor [] exn.name env in
+  let (name, coq_name) = CoqName.assoc_names exn.name in
+  let (raise_name, coq_raise_name) = CoqName.assoc_names exn.raise_name in
+  let env = FullEnvi.assoc_descriptor [] name coq_name env in
   let effect_typ =
     Effect.Type.Arrow (
       Effect.Descriptor.singleton
         id
-        (FullEnvi.bound_descriptor Loc.Unknown (PathName.of_name [] exn.name) env),
+        (FullEnvi.bound_descriptor Loc.Unknown (PathName.of_name [] name) env),
       Effect.Type.Pure) in
-  FullEnvi.add_var [] ("raise_" ^ exn.name) effect_typ env
+  FullEnvi.assoc_var [] raise_name coq_raise_name effect_typ env
 
 let to_coq (exn : t) : SmartPrint.t =
-  !^ "Definition" ^^ Name.to_coq exn.name ^^ !^ ":=" ^^
+  !^ "Definition" ^^ CoqName.to_coq exn.name ^^ !^ ":=" ^^
     !^ "Effect.make" ^^ !^ "unit" ^^ Type.to_coq true exn.typ ^-^ !^ "." ^^
   newline ^^ newline ^^
-  !^ "Definition" ^^ Name.to_coq ("raise_" ^ exn.name) ^^ !^ "{A : Type}" ^^
+  !^ "Definition" ^^ CoqName.to_coq exn.raise_name ^^ !^ "{A : Type}" ^^
     nest (parens (!^ "x" ^^ !^ ":" ^^ Type.to_coq false exn.typ)) ^^ !^ ":" ^^
-    !^ "M" ^^ !^ "[" ^^ Name.to_coq exn.name ^^ !^ "]" ^^ !^ "A" ^^ !^ ":=" ^^
+    !^ "M" ^^ !^ "[" ^^ CoqName.to_coq exn.name ^^ !^ "]" ^^ !^ "A" ^^ !^ ":=" ^^
   newline ^^ indent (
     !^ "fun s => (inr (inl x), s).")

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -76,8 +76,15 @@ let assoc_var (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
   (v : 'a) (env : 'a t) : 'a t =
   {env with active_module = FullMod.assoc_var path base assoc_base v env.active_module}
 
+let assoc_typ (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
+  (v : 'a) (env : 'a t) : 'a t =
+  {env with active_module = FullMod.assoc_typ path base assoc_base v env.active_module}
+
 let resolve_var (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
   FullMod.resolve_var path base env.active_module
+
+let resolve_typ (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
+  FullMod.resolve_typ path base env.active_module
 
 let enter_module (env : 'a t) : 'a t =
   {env with active_module = FullMod.enter_module env.active_module}

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -80,11 +80,18 @@ let assoc_typ (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
   (v : 'a) (env : 'a t) : 'a t =
   {env with active_module = FullMod.assoc_typ path base assoc_base v env.active_module}
 
+let assoc_constructor (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
+  (env : 'a t) : 'a t =
+  {env with active_module = FullMod.assoc_constructor path base assoc_base env.active_module}
+
 let resolve_var (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
   FullMod.resolve_var path base env.active_module
 
 let resolve_typ (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
   FullMod.resolve_typ path base env.active_module
+
+let resolve_constructor (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
+  FullMod.resolve_constructor path base env.active_module
 
 let enter_module (env : 'a t) : 'a t =
   {env with active_module = FullMod.enter_module env.active_module}

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -96,27 +96,26 @@ let find_external_module_path (x : PathName.t) (env : 'a t)
   | None ->
     failwith ("Could not find include for " ^ to_string 80 2 (PathName.pp x) ^ ".")
 
-let bound_name_external_opt (find : PathName.t -> 'a Mod.t -> bool)
+let bound_name_external_opt (find : PathName.t -> 'a Mod.t -> PathName.t option)
   (x : PathName.t) (env : 'a t) : BoundName.t option =
   find_first (fun open_name ->
     let x = { x with PathName.path = open_name @ x.PathName.path } in
     match find_external_module_path_opt x env with
     | Some (external_module, x) ->
-      if find x external_module.m then
+      find x external_module.m |> option_map (fun (x : PathName.t) ->
         let x = { x with path = external_module.coq_name :: x.path } in
         module_required external_module.coq_name env;
-        Some { BoundName.path_name = x; BoundName.depth = -1 }
-      else None
+        { BoundName.path_name = x; BoundName.depth = -1 })
     | None -> None) (FullMod.external_opens env.active_module)
 
-let bound_name_opt (find : PathName.t -> 'a Mod.t -> bool)
+let bound_name_opt (find : PathName.t -> 'a Mod.t -> PathName.t option)
   (x : PathName.t) (env : 'a t) : BoundName.t option =
   match FullMod.bound_name_opt find x env.active_module with
   | Some name -> Some name
   | None -> bound_name_external_opt find x env
 
-let bound_name (find : PathName.t -> 'a Mod.t -> bool) (loc : Loc.t)
-  (x : PathName.t) (env : 'a t) : BoundName.t =
+let bound_name (find : PathName.t -> 'a Mod.t -> PathName.t option)
+  (loc : Loc.t) (x : PathName.t) (env : 'a t) : BoundName.t =
   match bound_name_opt find x env with
   | Some name -> name
   | None ->
@@ -124,22 +123,22 @@ let bound_name (find : PathName.t -> 'a Mod.t -> bool) (loc : Loc.t)
     Error.raise loc (SmartPrint.to_string 80 2 message)
 
 let bound_var (loc : Loc.t) (x : PathName.t) (env : 'a t) : BoundName.t =
-  bound_name Mod.Vars.mem loc x env
+  bound_name Mod.Vars.resolve_opt loc x env
 
 let bound_typ (loc : Loc.t) (x : PathName.t) (env : 'a t) : BoundName.t =
-  bound_name Mod.Typs.mem loc x env
+  bound_name Mod.Typs.resolve_opt loc x env
 
 let bound_descriptor_opt (x : PathName.t) (env : 'a t) : BoundName.t option =
-  bound_name_opt Mod.Descriptors.mem x env
+  bound_name_opt Mod.Descriptors.resolve_opt x env
 
 let bound_descriptor (loc : Loc.t) (x : PathName.t) (env : 'a t) : BoundName.t =
-  bound_name Mod.Descriptors.mem loc x env
+  bound_name Mod.Descriptors.resolve_opt loc x env
 
 let bound_constructor (loc : Loc.t) (x : PathName.t) (env : 'a t) : BoundName.t =
-  bound_name Mod.Constructors.mem loc x env
+  bound_name Mod.Constructors.resolve_opt loc x env
 
 let bound_field (loc : Loc.t) (x : PathName.t) (env : 'a t) : BoundName.t =
-  bound_name Mod.Fields.mem loc x env
+  bound_name Mod.Fields.resolve_opt loc x env
 
 let bound_external_module_opt (x : PathName.t) (env : 'a t) : BoundName.t option =
   match x.path, find_wrapped_mod_opt x.base env with
@@ -157,7 +156,7 @@ let bound_external_module (loc : Loc.t) (x : PathName.t) (env : 'a t) : BoundNam
       Error.raise loc (SmartPrint.to_string 80 2 message)
 
 let bound_module_opt (x : PathName.t) (env : 'a t) : BoundName.t option =
-  match bound_name_opt Mod.Modules.mem x env with
+  match bound_name_opt Mod.Modules.resolve_opt x env with
   | Some name -> Some name
   | None -> bound_external_module_opt x env
 

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -72,6 +72,13 @@ let add_module (path : Name.t list) (base : Name.t) (v : 'a Mod.t) (env : 'a t)
   : 'a t =
   {env with active_module = FullMod.add_module path base v env.active_module}
 
+let assoc_var (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
+  (v : 'a) (env : 'a t) : 'a t =
+  {env with active_module = FullMod.assoc_var path base assoc_base v env.active_module}
+
+let resolve_var (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
+  FullMod.resolve_var path base env.active_module
+
 let enter_module (env : 'a t) : 'a t =
   {env with active_module = FullMod.enter_module env.active_module}
 

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -84,6 +84,10 @@ let assoc_constructor (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
   (env : 'a t) : 'a t =
   {env with active_module = FullMod.assoc_constructor path base assoc_base env.active_module}
 
+let assoc_field (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
+  (env : 'a t) : 'a t =
+  {env with active_module = FullMod.assoc_field path base assoc_base env.active_module}
+
 let resolve_var (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
   FullMod.resolve_var path base env.active_module
 
@@ -92,6 +96,9 @@ let resolve_typ (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
 
 let resolve_constructor (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
   FullMod.resolve_constructor path base env.active_module
+
+let resolve_field (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
+  FullMod.resolve_field path base env.active_module
 
 let enter_module (env : 'a t) : 'a t =
   {env with active_module = FullMod.enter_module env.active_module}

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -80,6 +80,10 @@ let assoc_typ (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
   (v : 'a) (env : 'a t) : 'a t =
   {env with active_module = FullMod.assoc_typ path base assoc_base v env.active_module}
 
+let assoc_descriptor (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
+  (env : 'a t) : 'a t =
+  {env with active_module = FullMod.assoc_descriptor path base assoc_base env.active_module}
+
 let assoc_constructor (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
   (env : 'a t) : 'a t =
   {env with active_module = FullMod.assoc_constructor path base assoc_base env.active_module}
@@ -93,6 +97,9 @@ let resolve_var (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
 
 let resolve_typ (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
   FullMod.resolve_typ path base env.active_module
+
+let resolve_descriptor (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
+  FullMod.resolve_descriptor path base env.active_module
 
 let resolve_constructor (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
   FullMod.resolve_constructor path base env.active_module

--- a/src/fullMod.ml
+++ b/src/fullMod.ml
@@ -68,6 +68,14 @@ let assoc_constructor (path : Name.t list) (base : Name.t)
       (PathName.of_name path assoc_base) m :: env
   | [] -> failwith "The environment must be a non-empty list."
 
+let assoc_field (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
+  (env : 'a t) : 'a t =
+  match env with
+  | m :: env ->
+    Mod.Fields.assoc (PathName.of_name path base)
+      (PathName.of_name path assoc_base) m :: env
+  | [] -> failwith "The environment must be a non-empty list."
+
 let resolve_var (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
   match env with
   | m :: env -> Mod.Vars.resolve (PathName.of_name path base) m
@@ -82,6 +90,12 @@ let resolve_constructor (path : Name.t list) (base : Name.t) (env : 'a t)
   : PathName.t =
   match env with
   | m :: env -> Mod.Constructors.resolve (PathName.of_name path base) m
+  | [] -> failwith "The environment must be a non-empty list."
+
+let resolve_field (path : Name.t list) (base : Name.t) (env : 'a t)
+  : PathName.t =
+  match env with
+  | m :: env -> Mod.Fields.resolve (PathName.of_name path base) m
   | [] -> failwith "The environment must be a non-empty list."
 
 let enter_module (env : 'a t) : 'a t = Mod.empty :: env

--- a/src/fullMod.ml
+++ b/src/fullMod.ml
@@ -60,6 +60,14 @@ let assoc_typ (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
       (PathName.of_name path assoc_base) v m :: env
   | [] -> failwith "The environment must be a non-empty list."
 
+let assoc_descriptor (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
+  (env : 'a t) : 'a t =
+  match env with
+  | m :: env ->
+    Mod.Descriptors.assoc (PathName.of_name path base)
+      (PathName.of_name path assoc_base) m :: env
+  | [] -> failwith "The environment must be a non-empty list."
+
 let assoc_constructor (path : Name.t list) (base : Name.t)
   (assoc_base : Name.t) (env : 'a t) : 'a t =
   match env with
@@ -84,6 +92,12 @@ let resolve_var (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
 let resolve_typ (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
   match env with
   | m :: env -> Mod.Typs.resolve (PathName.of_name path base) m
+  | [] -> failwith "The environment must be a non-empty list."
+
+let resolve_descriptor (path : Name.t list) (base : Name.t) (env : 'a t)
+  : PathName.t =
+  match env with
+  | m :: env -> Mod.Descriptors.resolve (PathName.of_name path base) m
   | [] -> failwith "The environment must be a non-empty list."
 
 let resolve_constructor (path : Name.t list) (base : Name.t) (env : 'a t)

--- a/src/fullMod.ml
+++ b/src/fullMod.ml
@@ -60,6 +60,14 @@ let assoc_typ (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
       (PathName.of_name path assoc_base) v m :: env
   | [] -> failwith "The environment must be a non-empty list."
 
+let assoc_constructor (path : Name.t list) (base : Name.t)
+  (assoc_base : Name.t) (env : 'a t) : 'a t =
+  match env with
+  | m :: env ->
+    Mod.Constructors.assoc (PathName.of_name path base)
+      (PathName.of_name path assoc_base) m :: env
+  | [] -> failwith "The environment must be a non-empty list."
+
 let resolve_var (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
   match env with
   | m :: env -> Mod.Vars.resolve (PathName.of_name path base) m
@@ -68,6 +76,12 @@ let resolve_var (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
 let resolve_typ (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
   match env with
   | m :: env -> Mod.Typs.resolve (PathName.of_name path base) m
+  | [] -> failwith "The environment must be a non-empty list."
+
+let resolve_constructor (path : Name.t list) (base : Name.t) (env : 'a t)
+  : PathName.t =
+  match env with
+  | m :: env -> Mod.Constructors.resolve (PathName.of_name path base) m
   | [] -> failwith "The environment must be a non-empty list."
 
 let enter_module (env : 'a t) : 'a t = Mod.empty :: env

--- a/src/fullMod.ml
+++ b/src/fullMod.ml
@@ -52,9 +52,22 @@ let assoc_var (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
       (PathName.of_name path assoc_base) v m :: env
   | [] -> failwith "The environment must be a non-empty list."
 
+let assoc_typ (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
+  (v : 'a) (env : 'a t) : 'a t =
+  match env with
+  | m :: env ->
+    Mod.Typs.assoc (PathName.of_name path base)
+      (PathName.of_name path assoc_base) v m :: env
+  | [] -> failwith "The environment must be a non-empty list."
+
 let resolve_var (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
   match env with
   | m :: env -> Mod.Vars.resolve (PathName.of_name path base) m
+  | [] -> failwith "The environment must be a non-empty list."
+
+let resolve_typ (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
+  match env with
+  | m :: env -> Mod.Typs.resolve (PathName.of_name path base) m
   | [] -> failwith "The environment must be a non-empty list."
 
 let enter_module (env : 'a t) : 'a t = Mod.empty :: env

--- a/src/fullMod.ml
+++ b/src/fullMod.ml
@@ -167,8 +167,8 @@ let include_module (loc : Loc.t) (x : 'a Mod.t) (env : 'a t) : 'a t =
   match env with
   | m :: env ->
       (try Mod.include_module x m :: env with
-      | Mod.NameConflict (typ, name) ->
-        let message = !^ "Could not include module: the" ^^ !^ typ ^^
-          PathName.pp name ^^ !^ "is already declared." in
+      | Mod.NameConflict (typ1, typ2, name) ->
+        let message = !^ "Could not include module: the" ^^ !^ typ1 ^^
+          PathName.pp name ^^ !^ "is already declared as a" ^^ !^ (typ2 ^ ".") in
         Error.raise loc (SmartPrint.to_string 80 2 message))
   | [] -> failwith "The environment must be a non-empty list."

--- a/src/fullMod.ml
+++ b/src/fullMod.ml
@@ -44,6 +44,19 @@ let add_module (path : Name.t list) (base : Name.t) (v : 'a Mod.t) (env : 'a t)
   | m :: env -> Mod.Modules.add (PathName.of_name path base) v m :: env
   | [] -> failwith "The environment must be a non-empty list."
 
+let assoc_var (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
+  (v : 'a) (env : 'a t) : 'a t =
+  match env with
+  | m :: env ->
+    Mod.Vars.assoc (PathName.of_name path base)
+      (PathName.of_name path assoc_base) v m :: env
+  | [] -> failwith "The environment must be a non-empty list."
+
+let resolve_var (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
+  match env with
+  | m :: env -> Mod.Vars.resolve (PathName.of_name path base) m
+  | [] -> failwith "The environment must be a non-empty list."
+
 let enter_module (env : 'a t) : 'a t = Mod.empty :: env
 
 let open_module (module_name : Name.t list) (env : 'a t) : 'a t =

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -59,11 +59,12 @@ let rec pp (interface : t) : SmartPrint.t =
 let of_typ_definition (typ_def : TypeDefinition.t) : t list =
   match typ_def with
   | TypeDefinition.Inductive (name, _, constructors) ->
-    Typ name :: List.map (fun (x, _) -> Constructor x) constructors
+    Typ (CoqName.ocaml_name name) ::
+      List.map (fun (x, _) -> Constructor x) constructors
   | TypeDefinition.Record (name, fields) ->
-    Typ name :: List.map (fun (x, _) -> Field x) fields
+    Typ (CoqName.ocaml_name name) :: List.map (fun (x, _) -> Field x) fields
   | TypeDefinition.Synonym (name, _, _) | TypeDefinition.Abstract (name, _) ->
-    [Typ name]
+    [Typ (CoqName.ocaml_name name)]
 
 let rec of_structures (defs : ('a * Effect.t) Structure.t list) : t list =
   List.flatten (List.map of_structure defs)

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -82,7 +82,7 @@ and of_structure (def : ('a * Effect.t) Structure.t) : t list =
     values |> List.map (fun (name, typ) -> Var (name, typ))
   | Structure.Primitive (_, prim) ->
     (* TODO: Update to reflect that primitives are not usually pure. *)
-    [Var (prim.PrimitiveDeclaration.name, [])]
+    [Var (CoqName.ocaml_name prim.PrimitiveDeclaration.name, [])]
   | Structure.TypeDefinition (_, typ_def) -> of_typ_definition typ_def
   | Structure.Exception (_, exn) ->
     let name = CoqName.ocaml_name exn.Exception.name in

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -60,7 +60,7 @@ let of_typ_definition (typ_def : TypeDefinition.t) : t list =
   match typ_def with
   | TypeDefinition.Inductive (name, _, constructors) ->
     Typ (CoqName.ocaml_name name) ::
-      List.map (fun (x, _) -> Constructor x) constructors
+      List.map (fun (x, _) -> Constructor (CoqName.ocaml_name x)) constructors
   | TypeDefinition.Record (name, fields) ->
     Typ (CoqName.ocaml_name name) :: List.map (fun (x, _) -> Field x) fields
   | TypeDefinition.Synonym (name, _, _) | TypeDefinition.Abstract (name, _) ->

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -73,7 +73,7 @@ and of_structure (def : ('a * Effect.t) Structure.t) : t list =
   | Structure.Require names -> []
   | Structure.Value (_, value) ->
     let values = value.Exp.Definition.cases |> List.map (fun (header, e) ->
-      let name = header.Exp.Header.name in
+      let name = CoqName.ocaml_name header.Exp.Header.name in
       let typ =
         Effect.function_typ header.Exp.Header.args (snd (Exp.annotation e)) in
       (name, Shape.of_effect_typ @@ Effect.Type.compress typ)) in

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -62,7 +62,8 @@ let of_typ_definition (typ_def : TypeDefinition.t) : t list =
     Typ (CoqName.ocaml_name name) ::
       List.map (fun (x, _) -> Constructor (CoqName.ocaml_name x)) constructors
   | TypeDefinition.Record (name, fields) ->
-    Typ (CoqName.ocaml_name name) :: List.map (fun (x, _) -> Field x) fields
+    Typ (CoqName.ocaml_name name) ::
+      List.map (fun (x, _) -> Field (CoqName.ocaml_name x)) fields
   | TypeDefinition.Synonym (name, _, _) | TypeDefinition.Abstract (name, _) ->
     [Typ (CoqName.ocaml_name name)]
 

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -85,8 +85,9 @@ and of_structure (def : ('a * Effect.t) Structure.t) : t list =
     [Var (prim.PrimitiveDeclaration.name, [])]
   | Structure.TypeDefinition (_, typ_def) -> of_typ_definition typ_def
   | Structure.Exception (_, exn) ->
-    let name = exn.Exception.name in
-    [ Descriptor name; Var (name, [[PathName.of_name [] name]]) ]
+    let name = CoqName.ocaml_name exn.Exception.name in
+    let raise_name = CoqName.ocaml_name exn.Exception.raise_name in
+    [ Descriptor name; Var (raise_name, [[PathName.of_name [] name]]) ]
   | Structure.Reference (_, r) ->
     let name = r.Reference.name in
     [ Var (name, []); Descriptor name ]

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -89,8 +89,9 @@ and of_structure (def : ('a * Effect.t) Structure.t) : t list =
     let raise_name = CoqName.ocaml_name exn.Exception.raise_name in
     [ Descriptor name; Var (raise_name, [[PathName.of_name [] name]]) ]
   | Structure.Reference (_, r) ->
-    let name = r.Reference.name in
-    [ Var (name, []); Descriptor name ]
+    let name = CoqName.ocaml_name r.Reference.name in
+    let state_name = CoqName.ocaml_name r.Reference.state_name in
+    [ Var (name, []); Descriptor state_name ]
   | Structure.Open _ -> []
   | Structure.Include (_, name) -> [Include name]
   | Structure.Module (_, name, defs) -> [Interface (name, of_structures defs)]

--- a/src/mod.ml
+++ b/src/mod.ml
@@ -1,28 +1,54 @@
 open SmartPrint
 
+type 'a value =
+  | Variable of 'a
+  | Type of 'a
+  | Descriptor
+  | Constructor
+  | Field
+
+let value_map (f : 'a -> 'b) (v : 'a value) : 'b value =
+  match v with
+  | Variable a -> Variable (f a)
+  | Type a -> Type (f a)
+  | Descriptor -> Descriptor
+  | Constructor -> Constructor
+  | Field -> Field
+
+let string_of_value (v : 'a value) : string =
+  match v with
+  | Variable _ -> "variable"
+  | Type _ -> "type"
+  | Descriptor -> "descriptor"
+  | Constructor -> "constructor"
+  | Field -> "field"
+
 type 'a t = {
   opens : Name.t list list;
   external_opens : Name.t list list;
-  vars : 'a PathName.Map.t;
-  typs : 'a PathName.Map.t;
-  descriptors: unit PathName.Map.t;
-  constructors : unit PathName.Map.t;
-  fields : unit PathName.Map.t;
+  values : 'a value PathName.Map.t;
   modules : 'a t PathName.Map.t }
 
 let empty : 'a t = {
   opens = [[]]; (** By default we open the empty path. *)
   external_opens = [[]];
-  vars = PathName.Map.empty;
-  typs = PathName.Map.empty;
-  descriptors = PathName.Map.empty;
-  constructors = PathName.Map.empty;
-  fields = PathName.Map.empty;
+  values = PathName.Map.empty;
   modules = PathName.Map.empty }
 
 let pp (m : 'a t) : SmartPrint.t =
-  let pp_map map = OCaml.list (fun (x, _) -> PathName.pp x)
-    (PathName.Map.bindings map) in
+  let pp_map = OCaml.list PathName.pp in
+  let vars = ref [] in
+  let typs = ref [] in
+  let descriptors = ref [] in
+  let constructors = ref [] in
+  let fields = ref [] in
+  m.values |> PathName.Map.iter (fun x v ->
+    match v with
+    | Variable _ -> vars := x :: !vars
+    | Type _ -> typs := x :: !typs
+    | Descriptor -> descriptors := x :: !descriptors
+    | Constructor -> constructors := x :: !constructors
+    | Field -> fields := x :: !fields);
   group (
     nest (!^ "open" ^^ OCaml.list (fun path ->
       double_quotes (separate (!^ ".") (List.map Name.pp path)))
@@ -30,12 +56,13 @@ let pp (m : 'a t) : SmartPrint.t =
     nest (!^ "open (external)" ^^ OCaml.list (fun path ->
       double_quotes (separate (!^ ".") (List.map Name.pp path)))
       m.external_opens) ^^ newline ^^
-    !^ "vars:" ^^ nest (pp_map m.vars) ^^ newline ^^
-    !^ "typs:" ^^ nest (pp_map m.typs) ^^ newline ^^
-    !^ "descriptors:" ^^ nest (pp_map m.descriptors) ^^ newline ^^
-    !^ "constructors:" ^^ nest (pp_map m.constructors) ^^ newline ^^
-    !^ "fields:" ^^ nest (pp_map m.fields) ^^ newline ^^
-    !^ "modules:" ^^ nest (pp_map m.modules))
+    !^ "vars:" ^^ nest (pp_map !vars) ^^ newline ^^
+    !^ "typs:" ^^ nest (pp_map !typs) ^^ newline ^^
+    !^ "descriptors:" ^^ nest (pp_map !descriptors) ^^ newline ^^
+    !^ "constructors:" ^^ nest (pp_map !constructors) ^^ newline ^^
+    !^ "fields:" ^^ nest (pp_map !fields) ^^ newline ^^
+    !^ "modules:" ^^ nest (OCaml.list (fun (x, _) -> PathName.pp x) @@
+      PathName.Map.bindings m.modules))
 
 let open_module (m : 'a t) (module_name : Name.t list) : 'a t =
   { m with opens = module_name :: m.opens }
@@ -58,55 +85,70 @@ let find_free_name (base_name : string) (env : 'a PathName.Map.t) : Name.t =
 
 let rec map (f : 'a -> 'b) (m : 'a t) : 'b t =
   { m with
-    vars = PathName.Map.map f m.vars;
-    typs = PathName.Map.map f m.typs;
+    values = m.values |> PathName.Map.map (value_map f);
     modules = PathName.Map.map (map f) m.modules }
 
 module Vars = struct
   let add (x : PathName.t) (v : 'a) (m : 'a t) : 'a t =
-    { m with vars = PathName.Map.add x v m.vars }
+    { m with values = PathName.Map.add x (Variable v) m.values }
 
   let mem (x : PathName.t) (m : 'a t) : bool =
-    PathName.Map.mem x m.vars
+    match PathName.Map.find_opt x m.values with
+    | Some (Variable _) -> true
+    | _ -> false
 
   let find (x : PathName.t) (m : 'a t) : 'a =
-    PathName.Map.find x m.vars
+    match PathName.Map.find x m.values with
+    | Variable a -> a
+    | _ -> failwith @@
+      String.concat "." x.PathName.path ^ "." ^ x.PathName.base ^ " is not a Variable"
 
   (** Add a fresh local name beginning with [prefix] in [env]. *)
   let fresh (prefix : string) (v : 'a) (env : 'a t) : Name.t * 'a t =
-    let name = find_free_name prefix env.vars in
+    let name = find_free_name prefix env.values in
     (name, add (PathName.of_name [] name) v env)
 end
 module Typs = struct
   let add (x : PathName.t) (v : 'a) (m : 'a t) : 'a t =
-    { m with typs = PathName.Map.add x v m.typs }
+    { m with values = PathName.Map.add x (Type v) m.values }
 
   let mem (x : PathName.t) (m : 'a t) : bool =
-    PathName.Map.mem x m.typs
+    match PathName.Map.find_opt x m.values with
+    | Some (Type _) -> true
+    | _ -> false
 
   let find (x : PathName.t) (m : 'a t) : 'a =
-    PathName.Map.find x m.typs
+    match PathName.Map.find x m.values with
+    | Type a -> a
+    | _ -> failwith @@
+      String.concat "." x.PathName.path ^ "." ^ x.PathName.base ^ " is not a Type"
 end
 module Descriptors = struct
   let add (x : PathName.t) (m : 'a t) : 'a t =
-    { m with descriptors = PathName.Map.add x () m.descriptors }
+    { m with values = PathName.Map.add x Descriptor m.values }
 
   let mem (x : PathName.t) (m : 'a t) : bool =
-    PathName.Map.mem x m.descriptors
+    match PathName.Map.find_opt x m.values with
+    | Some Descriptor -> true
+    | _ -> false
 end
 module Constructors = struct
   let add (x : PathName.t) (m : 'a t) : 'a t =
-    { m with constructors = PathName.Map.add x () m.constructors }
+    { m with values = PathName.Map.add x Constructor m.values }
 
   let mem (x : PathName.t) (m : 'a t) : bool =
-    PathName.Map.mem x m.constructors
+    match PathName.Map.find_opt x m.values with
+    | Some Constructor -> true
+    | _ -> false
 end
 module Fields = struct
   let add (x : PathName.t) (m : 'a t) : 'a t =
-    { m with fields = PathName.Map.add x () m.fields }
+    { m with values = PathName.Map.add x Field m.values }
 
   let mem (x : PathName.t) (m : 'a t) : bool =
-    PathName.Map.mem x m.fields
+    match PathName.Map.find_opt x m.values with
+    | Some Field -> true
+    | _ -> false
 end
 module Modules = struct
   let add (x : PathName.t) (v : 'a t) (m : 'a t) : 'a t =
@@ -123,36 +165,24 @@ let finish_module (module_name : Name.t) (prefix : Name.t -> 'a -> 'a)
   (m1 : 'a t) (m2 : 'a t) : 'a t =
   let add_to_path x =
     { x with PathName.path = module_name :: x.PathName.path } in
-  let unit_map_union = PathName.Map.map_union add_to_path (fun _ () -> ()) in
   let m =
   { opens = m2.opens;
     external_opens = m2.external_opens;
-    vars = PathName.Map.map_union add_to_path
-      (fun _ v -> prefix module_name v) m1.vars m2.vars;
-    typs = PathName.Map.map_union add_to_path
-      (fun _ v -> prefix module_name v) m1.typs m2.typs;
-    descriptors = unit_map_union m1.descriptors m2.descriptors;
-    constructors = unit_map_union m1.constructors m2.constructors;
-    fields = unit_map_union m1.fields m2.fields;
+    values = PathName.Map.map_union add_to_path
+      (fun _ v -> value_map (prefix module_name) v)
+      m1.values m2.values;
     modules = PathName.Map.map_union add_to_path (fun _ v -> v)
       m1.modules m2.modules } in
   Modules.add (PathName.of_name [] module_name) m1 m
 
-exception NameConflict of string * PathName.t
+exception NameConflict of string * string * PathName.t
 
 let include_module (m_incl : 'a t) (m : 'a t) : 'a t =
-  let reject_dups typ key _ _ = raise (NameConflict (typ, key)) in
   { opens = m.opens;
     external_opens = m.external_opens;
-    vars = PathName.Map.union (reject_dups "variable")
-      m_incl.vars m.vars;
-    typs = PathName.Map.union (reject_dups "type")
-      m_incl.typs m.typs;
-    descriptors = PathName.Map.union (reject_dups "descriptor")
-      m_incl.descriptors m.descriptors;
-    constructors = PathName.Map.union (reject_dups "constructor")
-      m_incl.constructors m.constructors;
-    fields = PathName.Map.union (reject_dups "field")
-      m_incl.fields m.fields;
-    modules = PathName.Map.union (reject_dups "module")
+    values = PathName.Map.union (fun key v1 v2 ->
+      raise (NameConflict (string_of_value v1, string_of_value v2, key)))
+     m_incl.values m.values;
+    modules = PathName.Map.union (fun key _ _ ->
+        raise (NameConflict ("module", "module", key)))
       m_incl.modules m.modules }

--- a/src/mod.ml
+++ b/src/mod.ml
@@ -243,14 +243,22 @@ module Fields = struct
     option_map (fun name -> { x with base = name }) @@
       PathName.Map.find_opt x m.locator.fields
 
-  let add (x : PathName.t) (m : 'a t) : 'a t =
-    let y = match resolve_opt x m with
-      | Some path -> path
-      | None -> find_free_path x m in
+  let resolve (x : PathName.t) (m : 'a t) : PathName.t =
+    match resolve_opt x m with
+    | Some path -> path
+    | None -> find_free_path x m
+
+  let assoc (x : PathName.t) (y : PathName.t) (m : 'a t) : 'a t =
     { m with
       values = PathName.Map.add y Field m.values;
       locator = { m.locator with
         fields = PathName.Map.add x y.base m.locator.fields } }
+
+  let add (x : PathName.t) (m : 'a t) : 'a t =
+    let y = match resolve_opt x m with
+      | Some path -> path
+      | None -> find_free_path x m in
+    assoc x y m
 
   let mem (x : PathName.t) (m : 'a t) : bool =
     match PathName.Map.find_opt x m.values with

--- a/src/mod.ml
+++ b/src/mod.ml
@@ -216,14 +216,22 @@ module Constructors = struct
     option_map (fun name -> { x with base = name }) @@
       PathName.Map.find_opt x m.locator.constructors
 
-  let add (x : PathName.t) (m : 'a t) : 'a t =
-    let y = match resolve_opt x m with
-      | Some path -> path
-      | None -> find_free_path x m in
+  let resolve (x : PathName.t) (m : 'a t) : PathName.t =
+    match resolve_opt x m with
+    | Some path -> path
+    | None -> find_free_path x m
+
+  let assoc (x : PathName.t) (y : PathName.t) (m : 'a t) : 'a t =
     { m with
       values = PathName.Map.add y Constructor m.values;
       locator = { m.locator with
         constructors = PathName.Map.add x y.base m.locator.constructors } }
+
+  let add (x : PathName.t) (m : 'a t) : 'a t =
+    let y = match resolve_opt x m with
+      | Some path -> path
+      | None -> find_free_path x m in
+    assoc x y m
 
   let mem (x : PathName.t) (m : 'a t) : bool =
     match PathName.Map.find_opt x m.values with

--- a/src/mod.ml
+++ b/src/mod.ml
@@ -164,14 +164,22 @@ module Typs = struct
     option_map (fun name -> { x with base = name }) @@
       PathName.Map.find_opt x m.locator.typs
 
-  let add (x : PathName.t) (v : 'a) (m : 'a t) : 'a t =
-    let y = match resolve_opt x m with
-      | Some path -> path
-      | None -> find_free_path x m in
+  let resolve (x : PathName.t) (m : 'a t) : PathName.t =
+    match resolve_opt x m with
+    | Some path -> path
+    | None -> find_free_path x m
+
+  let assoc (x : PathName.t) (y : PathName.t) (v : 'a) (m : 'a t) : 'a t =
     { m with
       values = PathName.Map.add y (Type v) m.values;
       locator = { m.locator with
         typs = PathName.Map.add x y.base m.locator.typs } }
+
+  let add (x : PathName.t) (v : 'a) (m : 'a t) : 'a t =
+    let y = match resolve_opt x m with
+      | Some path -> path
+      | None -> find_free_path x m in
+    assoc x y v m
 
   let mem (x : PathName.t) (m : 'a t) : bool =
     match PathName.Map.find_opt x m.values with

--- a/src/mod.ml
+++ b/src/mod.ml
@@ -197,14 +197,22 @@ module Descriptors = struct
     option_map (fun name -> { x with base = name }) @@
       PathName.Map.find_opt x m.locator.descriptors
 
-  let add (x : PathName.t) (m : 'a t) : 'a t =
-    let y = match resolve_opt x m with
-      | Some path -> path
-      | None -> find_free_path x m in
+  let resolve (x : PathName.t) (m : 'a t) : PathName.t =
+    match resolve_opt x m with
+    | Some path -> path
+    | None -> find_free_path x m
+
+  let assoc (x : PathName.t) (y : PathName.t) (m : 'a t) : 'a t =
     { m with
       values = PathName.Map.add y Descriptor m.values;
       locator = { m.locator with
         descriptors = PathName.Map.add x y.base m.locator.descriptors } }
+
+  let add (x : PathName.t) (m : 'a t) : 'a t =
+    let y = match resolve_opt x m with
+      | Some path -> path
+      | None -> find_free_path x m in
+    assoc x y m
 
   let mem (x : PathName.t) (m : 'a t) : bool =
     match PathName.Map.find_opt x m.values with

--- a/src/pattern.ml
+++ b/src/pattern.ml
@@ -5,10 +5,10 @@ open SmartPrint
 type t =
   | Any
   | Constant of Constant.t
-  | Variable of Name.t
+  | Variable of CoqName.t
   | Tuple of t list
   | Constructor of BoundName.t * t list (** A constructor name and a list of pattern in arguments. *)
-  | Alias of t * Name.t
+  | Alias of t * CoqName.t
   | Record of (BoundName.t * t) list (** A list of fields from a record with their expected patterns. *)
   | Or of t * t
 
@@ -16,11 +16,11 @@ let rec pp (p : t) : SmartPrint.t =
   match p with
   | Any -> !^ "Any"
   | Constant c -> Constant.pp c
-  | Variable x -> Name.pp x
+  | Variable x -> CoqName.pp x
   | Tuple ps -> nest (!^ "Tuple" ^^ OCaml.tuple (List.map pp ps))
   | Constructor (x, ps) ->
     nest (!^ "Constructor" ^^ OCaml.tuple (BoundName.pp x :: List.map pp ps))
-  | Alias (p, x) -> nest (!^ "Alias" ^^ OCaml.tuple [pp p; Name.pp x])
+  | Alias (p, x) -> nest (!^ "Alias" ^^ OCaml.tuple [pp p; CoqName.pp x])
   | Record fields ->
     nest (!^ "Record" ^^ OCaml.tuple (fields |> List.map (fun (x, p) ->
       nest @@ parens (BoundName.pp x ^-^ !^ "," ^^ pp p))))
@@ -31,12 +31,18 @@ let rec of_pattern (env : 'a FullEnvi.t) (p : pattern) : t =
   let l = Loc.of_location p.pat_loc in
   match p.pat_desc with
   | Tpat_any -> Any
-  | Tpat_var (x, _) -> Variable (Name.of_ident x)
+  | Tpat_var (x, _) ->
+      let x = Name.of_ident x in
+      let x = CoqName.of_names x (FullEnvi.resolve_var [] x env).base in
+      Variable x
   | Tpat_tuple ps -> Tuple (List.map (of_pattern env) ps)
   | Tpat_construct (x, _, ps) ->
     let x = FullEnvi.bound_constructor l (PathName.of_loc x) env in
     Constructor (x, List.map (of_pattern env) ps)
-  | Tpat_alias (p, x, _) -> Alias (of_pattern env p, Name.of_ident x)
+  | Tpat_alias (p, x, _) ->
+    let x = Name.of_ident x in
+    let x = CoqName.of_names x (FullEnvi.resolve_var [] x env).base in
+    Alias (of_pattern env p, x)
   | Tpat_constant c -> Constant (Constant.of_constant l c)
   | Tpat_record (fields, _) ->
     Record (fields |> List.map (fun (x, _, p) ->
@@ -52,9 +58,11 @@ let rec free_variables (p : t) : Name.Set.t =
     Name.Set.empty ps in
   match p with
   | Any | Constant _ -> Name.Set.empty
-  | Variable x -> Name.Set.singleton x
+  | Variable x -> Name.Set.singleton (CoqName.ocaml_name x)
   | Tuple ps | Constructor (_, ps) -> aux ps
-  | Alias (p, x) -> Name.Set.union (Name.Set.singleton x) (free_variables p)
+  | Alias (p, x) ->
+    Name.Set.union (Name.Set.singleton (CoqName.ocaml_name x))
+      (free_variables p)
   | Record fields -> aux (List.map snd fields)
   | Or (p1, p2) -> Name.Set.inter (free_variables p1) (free_variables p2)
 
@@ -67,7 +75,7 @@ let rec to_coq (paren : bool) (p : t) : SmartPrint.t =
   match p with
   | Any -> !^ "_"
   | Constant c -> Constant.to_coq c
-  | Variable x -> Name.to_coq x
+  | Variable x -> CoqName.to_coq x
   | Tuple ps ->
     if ps = [] then
       !^ "tt"
@@ -79,7 +87,7 @@ let rec to_coq (paren : bool) (p : t) : SmartPrint.t =
     else
       Pp.parens paren @@ nest @@ separate space (BoundName.to_coq x :: List.map (to_coq true) ps)
   | Alias (p, x) ->
-    Pp.parens paren @@ nest (to_coq false p ^^ !^ "as" ^^ Name.to_coq x)
+    Pp.parens paren @@ nest (to_coq false p ^^ !^ "as" ^^ CoqName.to_coq x)
   | Record fields ->
     !^ "{|" ^^
     nest_all @@ separate (!^ ";" ^^ space) (fields |> List.map (fun (x, p) ->

--- a/src/primitiveDeclaration.ml
+++ b/src/primitiveDeclaration.ml
@@ -3,18 +3,18 @@ open Typedtree
 open SmartPrint
 
 type t = {
-  name : Name.t;
+  name : CoqName.t;
   typ_args : Name.t list;
   typ : Type.t }
 
 let pp (prim : t) : SmartPrint.t =
   nest (!^ "Primitive" ^^
-    OCaml.tuple
-      [Name.pp prim.name; OCaml.list Name.pp prim.typ_args; Type.pp prim.typ])
+    OCaml.tuple [CoqName.pp prim.name; OCaml.list Name.pp prim.typ_args;
+      Type.pp prim.typ])
 
 let to_coq (prim : t) : SmartPrint.t =
   nest (
-    !^ "Parameter" ^^ Name.to_coq prim.name ^^ !^ ":" ^^
+    !^ "Parameter" ^^ CoqName.to_coq prim.name ^^ !^ ":" ^^
     (match prim.typ_args with
     | [] -> empty
     | _ :: _ ->
@@ -28,14 +28,18 @@ let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t) (desc : value_description)
     let type_expr = desc.val_val.val_type in
     let (typ, _, new_typ_vars) =
       Type.of_type_expr_new_typ_vars env loc Name.Map.empty type_expr in
-    { name = Name.of_ident desc.val_id;
+    let name = Name.of_ident desc.val_id in
+    let coq_name = (FullEnvi.resolve_var [] name env).base in
+    { name = CoqName.of_names name coq_name;
       typ_args = Name.Set.elements new_typ_vars;
       typ }
 
 let update_env (prim : t) (env : unit FullEnvi.t) : unit FullEnvi.t =
-  FullEnvi.add_var [] prim.name () env
+  let (name, coq_name) = CoqName.assoc_names prim.name in
+  FullEnvi.assoc_var [] name coq_name () env
 
 (* TODO: Update to reflect that primitives are not usually pure. *)
 let update_env_with_effects (prim : t) (env : Effect.Type.t FullEnvi.t)
   : Effect.Type.t FullEnvi.t =
-  FullEnvi.add_var [] prim.name Effect.Type.Pure env
+  let (name, coq_name) = CoqName.assoc_names prim.name in
+  FullEnvi.assoc_var [] name coq_name Effect.Type.Pure env

--- a/src/reference.ml
+++ b/src/reference.ml
@@ -2,13 +2,15 @@ open Typedtree
 open SmartPrint
 
 type 'a t = {
-  name : Name.t;
+  name : CoqName.t;
+  state_name : CoqName.t;
   typ : Type.t;
   expr : 'a Exp.t }
 
 let pp (pp_a : 'a -> SmartPrint.t) (r : 'a t) : SmartPrint.t =
-  nest (!^ "Reference" ^^ OCaml.tuple
-    [Name.pp r.name; Type.pp r.typ; Exp.pp pp_a r.expr])
+  nest (!^ "Reference" ^^
+    OCaml.tuple [CoqName.pp r.name; CoqName.pp r.state_name; Type.pp r.typ;
+      Exp.pp pp_a r.expr])
 
 let is_reference (loc : Loc.t) (cases : value_binding list) : bool =
   match cases with
@@ -24,30 +26,39 @@ let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t) (cases : value_binding list)
   | [{ vb_pat = { pat_desc = Tpat_var (x, _) };
     vb_expr = { exp_type = {Types.desc = Types.Tconstr (_, [typ], _) };
                 exp_desc = Texp_apply (_, [(_, Some expr)]) }}] ->
-    { name = Name.of_ident x;
+    let name = Name.of_ident x in
+    let coq_name = (FullEnvi.resolve_var [] name env).base in
+    let state_name = name ^ "_state" in
+    let coq_state_name = (FullEnvi.resolve_descriptor [] state_name env).base in
+    { name = CoqName.of_names name coq_name;
+      state_name = CoqName.of_names state_name coq_state_name;
       typ = Type.of_type_expr env loc typ;
       expr = Exp.of_expression env Name.Map.empty expr }
   | _ -> Error.raise loc "This kind of reference definition is not handled."
 
 let update_env (update_exp : unit FullEnvi.t -> 'a Exp.t -> 'b Exp.t)
   (r : 'a t) (env : unit FullEnvi.t) : unit FullEnvi.t * 'b t =
+  let (name, coq_name) = CoqName.assoc_names r.name in
+  let (state_name, coq_state_name) = CoqName.assoc_names r.state_name in
   let env = env
-  |> FullEnvi.add_var [] r.name ()
-  |> FullEnvi.add_descriptor [] (r.name ^ "_state") in
+  |> FullEnvi.assoc_var [] name coq_name ()
+  |> FullEnvi.assoc_descriptor [] state_name coq_state_name in
   (env, {r with expr = update_exp env r.expr})
 
 let update_env_with_effects (r : (Loc.t * Type.t) t)
   (env : Effect.Type.t FullEnvi.t) (id : Effect.Descriptor.Id.t)
   : Effect.Type.t FullEnvi.t * (Loc.t * Effect.t) t =
+  let (name, coq_name) = CoqName.assoc_names r.name in
+  let (state_name, coq_state_name) = CoqName.assoc_names r.state_name in
   let env = env
-  |> FullEnvi.add_var [] r.name Effect.Type.Pure
-  |> FullEnvi.add_descriptor [] (r.name ^ "_state") in
+  |> FullEnvi.assoc_var [] name coq_name Effect.Type.Pure
+  |> FullEnvi.assoc_descriptor [] state_name coq_state_name in
   (env, {r with expr = Exp.effects env r.expr})
 
 let to_coq (r : 'a t) : SmartPrint.t =
-  nest (!^ "Definition" ^^ Name.to_coq r.name ^^
+  nest (!^ "Definition" ^^ CoqName.to_coq r.name ^^
     !^ ":" ^^ !^ "OCaml.Effect.State.t" ^^ Type.to_coq true r.typ ^^ !^ ":=" ^^
     !^ "OCaml.Effect.State.init" ^^ Exp.to_coq true r.expr ^-^ !^ ".")
   ^^ newline ^^
-  nest (!^ "Definition" ^^ Name.to_coq r.name ^-^ !^ "_state" ^^ !^ ":=" ^^
+  nest (!^ "Definition" ^^ CoqName.to_coq r.state_name ^^ !^ ":=" ^^
     !^ "nat" ^-^ !^ ".")

--- a/src/structure.ml
+++ b/src/structure.ml
@@ -29,7 +29,7 @@ module Value = struct
           braces @@ group (separate space (List.map Name.to_coq header.Exp.Header.typ_vars) ^^
           !^ ":" ^^ !^ "Type")) ^^
         group (separate space (header.Exp.Header.args |> List.map (fun (x, t) ->
-          parens @@ nest (Name.to_coq x ^^ !^ ":" ^^ Type.to_coq false t)))) ^^
+          parens @@ nest (CoqName.to_coq x ^^ !^ ":" ^^ Type.to_coq false t)))) ^^
         !^ ": " ^-^ Type.to_coq false header.Exp.Header.typ ^-^
         !^ " :=" ^^ Exp.to_coq false e))) ^-^ !^ "."
 end

--- a/src/structure.ml
+++ b/src/structure.ml
@@ -22,7 +22,7 @@ module Value = struct
             !^ "Definition"
         ) else
           !^ "with") ^^
-        Name.to_coq header.Exp.Header.name ^^
+        CoqName.to_coq header.Exp.Header.name ^^
         (match header.Exp.Header.typ_vars with
         | [] -> empty
         | _ :: _ ->

--- a/src/typeDefinition.ml
+++ b/src/typeDefinition.ml
@@ -3,29 +3,29 @@ open Typedtree
 open SmartPrint
 
 type t =
-  | Inductive of Name.t * Name.t list * (Name.t * Type.t list) list
-  | Record of Name.t * (Name.t * Type.t) list
-  | Synonym of Name.t * Name.t list * Type.t
-  | Abstract of Name.t * Name.t list
+  | Inductive of CoqName.t * Name.t list * (Name.t * Type.t list) list
+  | Record of CoqName.t * (Name.t * Type.t) list
+  | Synonym of CoqName.t * Name.t list * Type.t
+  | Abstract of CoqName.t * Name.t list
 
 let pp (def : t) : SmartPrint.t =
   match def with
   | Inductive (name, typ_args, constructors) ->
-    nest (!^ "Inductive" ^^ Name.pp name ^-^ !^ ":" ^^ newline ^^
+    nest (!^ "Inductive" ^^ CoqName.pp name ^-^ !^ ":" ^^ newline ^^
       indent (OCaml.tuple [
         OCaml.list Name.pp typ_args;
         constructors |> OCaml.list (fun (x, typs) ->
           OCaml.tuple [Name.pp x; OCaml.list Type.pp typs])]))
   | Record (name, fields) ->
-    nest (!^ "Record" ^^ Name.pp name ^-^ !^ ":" ^^ newline ^^
+    nest (!^ "Record" ^^ CoqName.pp name ^-^ !^ ":" ^^ newline ^^
       indent (fields |> OCaml.list (fun (x, typ) ->
         OCaml.tuple [Name.pp x; Type.pp typ])))
   | Synonym (name, typ_args, value) ->
     nest (!^ "Synonym" ^^ OCaml.tuple [
-      Name.pp name; OCaml.list Name.pp typ_args; Type.pp value])
+      CoqName.pp name; OCaml.list Name.pp typ_args; Type.pp value])
   | Abstract (name, typ_args) ->
     nest (!^ "Abstract" ^^ OCaml.tuple [
-      Name.pp name; OCaml.list Name.pp typ_args])
+      CoqName.pp name; OCaml.list Name.pp typ_args])
 
 let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t)
   (typs : type_declaration list) : t =
@@ -33,12 +33,14 @@ let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t)
   | [] -> Error.raise loc "Unexpected type definition with no case."
   | [{typ_id = name; typ_type = typ}] ->
     let name = Name.of_ident name in
+    let coq_name = (FullEnvi.resolve_typ [] name env).base in
+    let x = CoqName.of_names name coq_name in
     let typ_args =
       List.map (Type.of_type_expr_variable loc) typ.type_params in
     (match typ.type_kind with
     | Type_variant cases ->
       let constructors =
-        let env = FullEnvi.add_typ [] name () env in
+        let env = FullEnvi.assoc_typ [] name coq_name () env in
         cases |> List.map (fun { Types.cd_id = constr; cd_args = args } ->
           let typs =
             match args with
@@ -46,36 +48,40 @@ let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t)
             | Cstr_record _ -> Error.raise loc "Unhandled named constructor parameters." in
           (Name.of_ident constr, typs |> List.map (fun typ ->
             Type.of_type_expr env loc typ))) in
-      Inductive (name, typ_args, constructors)
+      Inductive (x, typ_args, constructors)
     | Type_record (fields, _) ->
       let fields =
         fields |> List.map (fun { Types.ld_id = x; ld_type = typ } ->
           (Name.of_ident x, Type.of_type_expr env loc typ)) in
-      Record (name, fields)
+      Record (x, fields)
     | Type_abstract ->
       (match typ.type_manifest with
-      | Some typ -> Synonym (name, typ_args, Type.of_type_expr env loc typ)
-      | None -> Abstract (name, typ_args))
+      | Some typ -> Synonym (x, typ_args, Type.of_type_expr env loc typ)
+      | None -> Abstract (x, typ_args))
       | Type_open -> Error.raise loc "Open type definition not handled.")
   | typ :: _ :: _ -> Error.raise loc "Type definition with 'and' not handled."
 
 let update_env (def : t) (v : 'a) (env : 'a FullEnvi.t) : 'a FullEnvi.t =
   match def with
   | Inductive (name, _, constructors) ->
-    let env = FullEnvi.add_typ [] name v env in
+    let (name, coq_name) = CoqName.assoc_names name in
+    let env = FullEnvi.assoc_typ [] name coq_name v env in
     List.fold_left (fun env (x, _) -> FullEnvi.add_constructor [] x env)
       env constructors
   | Record (name, fields) ->
-    let env = FullEnvi.add_typ [] name v env in
+    let (name, coq_name) = CoqName.assoc_names name in
+    let env = FullEnvi.assoc_typ [] name coq_name v env in
     List.fold_left (fun env (x, _) -> FullEnvi.add_field [] x env)
       env fields
-  | Synonym (name, _, _) | Abstract (name, _) -> FullEnvi.add_typ [] name v env
+  | Synonym (name, _, _) | Abstract (name, _) ->
+    let (name, coq_name) = CoqName.assoc_names name in
+    FullEnvi.assoc_typ [] name coq_name v env
 
 let to_coq (def : t) : SmartPrint.t =
   match def with
   | Inductive (name, typ_args, constructors) ->
     nest (
-      !^ "Inductive" ^^ Name.to_coq name ^^
+      !^ "Inductive" ^^ CoqName.to_coq name ^^
       (if typ_args = []
       then empty
       else parens @@ nest (
@@ -85,7 +91,8 @@ let to_coq (def : t) : SmartPrint.t =
       separate empty (constructors |> List.map (fun (constr, args) ->
         newline ^^ nest (
           !^ "|" ^^ Name.to_coq constr ^^ !^ ":" ^^
-          separate space (args |> List.map (fun arg -> Type.to_coq true arg ^^ !^ "->")) ^^ separate space (List.map Name.to_coq (name :: typ_args))))) ^-^ !^ "." ^^
+          separate space (args |> List.map (fun arg -> Type.to_coq true arg ^^ !^ "->")) ^^
+          separate space (CoqName.to_coq name :: List.map Name.to_coq typ_args)))) ^-^ !^ "." ^^
       separate empty (constructors |> List.map (fun (name, args) ->
         if typ_args = [] then
           empty
@@ -96,18 +103,18 @@ let to_coq (def : t) : SmartPrint.t =
             (List.map (fun _ -> !^ "_") args)) ^-^ !^ "."))))
   | Record (name, fields) ->
     nest (
-      !^ "Record" ^^ Name.to_coq name ^^ !^ ":=" ^^ !^ "{" ^^ newline ^^
+      !^ "Record" ^^ CoqName.to_coq name ^^ !^ ":=" ^^ !^ "{" ^^ newline ^^
       indent (separate (!^ ";" ^^ newline) (fields |> List.map (fun (x, typ) ->
         nest (Name.to_coq x ^^ !^ ":" ^^ Type.to_coq false typ)))) ^^
       !^ "}.")
   | Synonym (name, typ_args, value) ->
     nest (
-      !^ "Definition" ^^ Name.to_coq name ^^
+      !^ "Definition" ^^ CoqName.to_coq name ^^
       separate space (List.map Name.to_coq typ_args) ^^ !^ ":=" ^^
       Type.to_coq false value ^-^ !^ ".")
   | Abstract (name, typ_args) ->
     nest (
-      !^ "Parameter" ^^ Name.to_coq name ^^ !^ ":" ^^
+      !^ "Parameter" ^^ CoqName.to_coq name ^^ !^ ":" ^^
       (match typ_args with
       | [] -> empty
       | _ :: _ ->

--- a/tests/ex17.effects
+++ b/tests/ex17.effects
@@ -1,4 +1,4 @@
-3 Exception (Outside, ())
+3 Exception (Outside, raise_Outside, ())
 
 5
 Value
@@ -13,7 +13,7 @@ Value
     ])
 
 7 Module G:
-  8 Exception (Inside, (Type (Z/2) * Type (string/2)))
+  8 Exception (Inside, raise_Inside, (Type (Z/2) * Type (string/2)))
   
   10
   Value

--- a/tests/ex17.exp
+++ b/tests/ex17.exp
@@ -1,4 +1,4 @@
-3 Exception (Outside, ())
+3 Exception (Outside, raise_Outside, ())
 
 5
 Value
@@ -9,7 +9,7 @@ Value
     ])
 
 7 Module G:
-  8 Exception (Inside, (Type (Z/2) * Type (string/2)))
+  8 Exception (Inside, raise_Inside, (Type (Z/2) * Type (string/2)))
   
   10
   Value

--- a/tests/ex17.interface
+++ b/tests/ex17.interface
@@ -5,14 +5,14 @@
     "Ex17",
     [
       [ "Descriptor", "Outside" ],
-      [ "Var", "Outside", [ [ "Outside" ] ] ],
+      [ "Var", "raise_Outside", [ [ "Outside" ] ] ],
       [ "Var", "f", [ [ "Outside" ] ] ],
       [
         "Interface",
         "G",
         [
           [ "Descriptor", "Inside" ],
-          [ "Var", "Inside", [ [ "Inside" ] ] ],
+          [ "Var", "raise_Inside", [ [ "Inside" ] ] ],
           [ "Var", "g", [ [ "Outside", "Inside" ] ] ]
         ]
       ],

--- a/tests/ex17.monadise
+++ b/tests/ex17.monadise
@@ -1,4 +1,4 @@
-3 Exception (Outside, ())
+3 Exception (Outside, raise_Outside, ())
 
 5
 Value
@@ -9,7 +9,7 @@ Value
     ])
 
 7 Module G:
-  8 Exception (Inside, (Type (Z/2) * Type (string/2)))
+  8 Exception (Inside, raise_Inside, (Type (Z/2) * Type (string/2)))
   
   10
   Value

--- a/tests/ex18.effects
+++ b/tests/ex18.effects
@@ -1,4 +1,4 @@
-1 Reference (r, Type (Z/1), Constant ((1, Effect ([ ], .)), Int(12)))
+1 Reference (r, r_state, Type (Z/1), Constant ((1, Effect ([ ], .)), Int(12)))
 
 3
 Value
@@ -150,7 +150,9 @@ Value
             ]))
     ])
 
-6 Reference (s, Type (string/1), Constant ((6, Effect ([ ], .)), String("Hi")))
+6
+Reference
+  (s, s_state, Type (string/1), Constant ((6, Effect ([ ], .)), String("Hi")))
 
 8
 Value

--- a/tests/ex18.exp
+++ b/tests/ex18.exp
@@ -1,4 +1,4 @@
-1 Reference (r, Type (Z/1), Constant (1, Int(12)))
+1 Reference (r, r_state, Type (Z/1), Constant (1, Int(12)))
 
 3
 Value
@@ -32,7 +32,7 @@ Value
             ]))
     ])
 
-6 Reference (s, Type (string/1), Constant (6, String("Hi")))
+6 Reference (s, s_state, Type (string/1), Constant (6, String("Hi")))
 
 8
 Value

--- a/tests/ex18.interface
+++ b/tests/ex18.interface
@@ -5,10 +5,10 @@
     "Ex18",
     [
       [ "Var", "r", [] ],
-      [ "Descriptor", "r" ],
+      [ "Descriptor", "r_state" ],
       [ "Var", "plus_one", [ [ "OCaml.Effect.State.state", "OCaml.Effect.State.state" ] ] ],
       [ "Var", "s", [] ],
-      [ "Descriptor", "s" ],
+      [ "Descriptor", "s_state" ],
       [ "Var", "fail", [ [ "OCaml.Failure", "OCaml.Effect.State.state", "OCaml.Effect.State.state" ] ] ],
       [ "Var", "reset", [ [ "OCaml.Effect.State.state", "OCaml.Effect.State.state" ] ] ],
       [ "Var", "incr", [ [ "OCaml.Effect.State.state", "OCaml.Effect.State.state" ] ] ]

--- a/tests/ex18.monadise
+++ b/tests/ex18.monadise
@@ -1,4 +1,4 @@
-1 Reference (r, Type (Z/1), Constant (1, Int(12)))
+1 Reference (r, r_state, Type (Z/1), Constant (1, Int(12)))
 
 3
 Value
@@ -132,7 +132,7 @@ Value
             ]))
     ])
 
-6 Reference (s, Type (string/1), Constant (6, String("Hi")))
+6 Reference (s, s_state, Type (string/1), Constant (6, String("Hi")))
 
 8
 Value

--- a/tests/ex19.effects
+++ b/tests/ex19.effects
@@ -1,4 +1,4 @@
-3 Exception (Error, ())
+3 Exception (Error, raise_Error, ())
 
 5
 Value

--- a/tests/ex19.exp
+++ b/tests/ex19.exp
@@ -1,4 +1,4 @@
-3 Exception (Error, ())
+3 Exception (Error, raise_Error, ())
 
 5
 Value

--- a/tests/ex19.interface
+++ b/tests/ex19.interface
@@ -5,7 +5,7 @@
     "Ex19",
     [
       [ "Descriptor", "Error" ],
-      [ "Var", "Error", [ [ "Error" ] ] ],
+      [ "Var", "raise_Error", [ [ "Error" ] ] ],
       [ "Var", "x1", [] ],
       [ "Var", "x2", [ [ "OCaml.Failure" ] ] ],
       [ "Var", "x3", [ [ "OCaml.Failure" ] ] ]

--- a/tests/ex19.monadise
+++ b/tests/ex19.monadise
@@ -1,4 +1,4 @@
-3 Exception (Error, ())
+3 Exception (Error, raise_Error, ())
 
 5
 Value

--- a/tests/ex33.effects
+++ b/tests/ex33.effects
@@ -2187,10 +2187,10 @@ Value
                 Variable ((108, Effect ([ ], .)), t1/0),
                 Variable ((108, Effect ([ ], .)), t2/0)),
             [
-              (Tuple (Constructor (Empty/0), t),
-                Variable ((109, Effect ([ ], .)), t/0));
-              (Tuple (t, Constructor (Empty/0)),
-                Variable ((110, Effect ([ ], .)), t/0));
+              (Tuple (Constructor (Empty/0), t (= t_1)),
+                Variable ((109, Effect ([ ], .)), t_1/0));
+              (Tuple (t (= t_1), Constructor (Empty/0)),
+                Variable ((110, Effect ([ ], .)), t_1/0));
               (Tuple (Any, Any),
                 Match
                   ((112,
@@ -4446,10 +4446,10 @@ Value
                 Variable ((208, Effect ([ ], .)), t1/0),
                 Variable ((208, Effect ([ ], .)), t2/0)),
             [
-              (Tuple (Constructor (Empty/0), t),
-                Variable ((209, Effect ([ ], .)), t/0));
-              (Tuple (t, Constructor (Empty/0)),
-                Variable ((210, Effect ([ ], .)), t/0));
+              (Tuple (Constructor (Empty/0), t (= t_1)),
+                Variable ((209, Effect ([ ], .)), t_1/0));
+              (Tuple (t (= t_1), Constructor (Empty/0)),
+                Variable ((210, Effect ([ ], .)), t_1/0));
               (Tuple (Any, Any),
                 Match
                   ((212,

--- a/tests/ex33.exp
+++ b/tests/ex33.exp
@@ -977,8 +977,10 @@ Value
         Match
           (108, Tuple (108, Variable (108, t1/0), Variable (108, t2/0)),
             [
-              (Tuple (Constructor (Empty/0), t), Variable (109, t/0));
-              (Tuple (t, Constructor (Empty/0)), Variable (110, t/0));
+              (Tuple (Constructor (Empty/0), t (= t_1)),
+                Variable (109, t_1/0));
+              (Tuple (t (= t_1), Constructor (Empty/0)),
+                Variable (110, t_1/0));
               (Tuple (Any, Any),
                 Match
                   (112,
@@ -1951,8 +1953,10 @@ Value
         Match
           (208, Tuple (208, Variable (208, t1/0), Variable (208, t2/0)),
             [
-              (Tuple (Constructor (Empty/0), t), Variable (209, t/0));
-              (Tuple (t, Constructor (Empty/0)), Variable (210, t/0));
+              (Tuple (Constructor (Empty/0), t (= t_1)),
+                Variable (209, t_1/0));
+              (Tuple (t (= t_1), Constructor (Empty/0)),
+                Variable (210, t_1/0));
               (Tuple (Any, Any),
                 Match
                   (212,

--- a/tests/ex33.monadise
+++ b/tests/ex33.monadise
@@ -1039,10 +1039,10 @@ Value
         Match
           (108, Tuple (108, Variable (108, t1/0), Variable (108, t2/0)),
             [
-              (Tuple (Constructor (Empty/0), t),
-                Return (?, Variable (109, t/0)));
-              (Tuple (t, Constructor (Empty/0)),
-                Return (?, Variable (110, t/0)));
+              (Tuple (Constructor (Empty/0), t (= t_1)),
+                Return (?, Variable (109, t_1/0)));
+              (Tuple (t (= t_1), Constructor (Empty/0)),
+                Return (?, Variable (110, t_1/0)));
               (Tuple (Any, Any),
                 Bind
                   (?,
@@ -2158,10 +2158,10 @@ Value
         Match
           (208, Tuple (208, Variable (208, t1/0), Variable (208, t2/0)),
             [
-              (Tuple (Constructor (Empty/0), t),
-                Return (?, Variable (209, t/0)));
-              (Tuple (t, Constructor (Empty/0)),
-                Return (?, Variable (210, t/0)));
+              (Tuple (Constructor (Empty/0), t (= t_1)),
+                Return (?, Variable (209, t_1/0)));
+              (Tuple (t (= t_1), Constructor (Empty/0)),
+                Return (?, Variable (210, t_1/0)));
               (Tuple (Any, Any),
                 Bind
                   (?,

--- a/tests/ex33.v
+++ b/tests/ex33.v
@@ -170,8 +170,8 @@ Fixpoint remove_min_binding {A : Type} (x : t A)
 Definition remove_merge {A : Type} (t1 : t A) (t2 : t A)
   : M [ OCaml.Invalid_argument; OCaml.Not_found ] (t A) :=
   match (t1, t2) with
-  | (Empty, t) => ret t
-  | (t, Empty) => ret t
+  | (Empty, t_1) => ret t_1
+  | (t_1, Empty) => ret t_1
   | (_, _) =>
     let! x := lift [_;_] "01" (min_binding t2) in
     match x with
@@ -291,8 +291,8 @@ Definition join {A : Type} (l : t A) (v : key) (d : A) (r : t A)
 Definition concat {A : Type} (t1 : t A) (t2 : t A)
   : M [ Counter; NonTermination; OCaml.Invalid_argument; OCaml.Not_found ] (t A) :=
   match (t1, t2) with
-  | (Empty, t) => ret t
-  | (t, Empty) => ret t
+  | (Empty, t_1) => ret t_1
+  | (t_1, Empty) => ret t_1
   | (_, _) =>
     let! x := lift [_;_;_;_] "0001" (min_binding t2) in
     match x with

--- a/tests/ex34.effects
+++ b/tests/ex34.effects
@@ -1074,7 +1074,7 @@ Value
                           ],
                             .)),
                         Int(1))));
-              (Alias (Constructor (Node/0, l, v, r, Any), t),
+              (Alias (Constructor (Node/0, l, v, r, Any), t (= t_1)),
                 LetVar
                   (68,
                     Effect
@@ -1157,7 +1157,7 @@ Value
                           ([
                           ],
                             .)),
-                        t/0),
+                        t_1/0),
                     IfThenElse
                       ((70,
                         Effect
@@ -2436,10 +2436,10 @@ Value
                 Variable ((133, Effect ([ ], .)), t1/0),
                 Variable ((133, Effect ([ ], .)), t2/0)),
             [
-              (Tuple (Constructor (Empty/0), t),
-                Variable ((134, Effect ([ ], .)), t/0));
-              (Tuple (t, Constructor (Empty/0)),
-                Variable ((135, Effect ([ ], .)), t/0));
+              (Tuple (Constructor (Empty/0), t (= t_1)),
+                Variable ((134, Effect ([ ], .)), t_1/0));
+              (Tuple (t (= t_1), Constructor (Empty/0)),
+                Variable ((135, Effect ([ ], .)), t_1/0));
               (Tuple (Any, Any),
                 Apply
                   ((136,
@@ -2549,10 +2549,10 @@ Value
                 Variable ((143, Effect ([ ], .)), t1/0),
                 Variable ((143, Effect ([ ], .)), t2/0)),
             [
-              (Tuple (Constructor (Empty/0), t),
-                Variable ((144, Effect ([ ], .)), t/0));
-              (Tuple (t, Constructor (Empty/0)),
-                Variable ((145, Effect ([ ], .)), t/0));
+              (Tuple (Constructor (Empty/0), t (= t_1)),
+                Variable ((144, Effect ([ ], .)), t_1/0));
+              (Tuple (t (= t_1), Constructor (Empty/0)),
+                Variable ((145, Effect ([ ], .)), t_1/0));
               (Tuple (Any, Any),
                 Apply
                   ((146,

--- a/tests/ex34.exp
+++ b/tests/ex34.exp
@@ -485,7 +485,7 @@ Value
                     Constant
                       (66,
                         Int(1))));
-              (Alias (Constructor (Node/0, l, v, r, Any), t),
+              (Alias (Constructor (Node/0, l, v, r, Any), t (= t_1)),
                 LetVar 68 c =
                   Apply
                     (68,
@@ -518,7 +518,7 @@ Value
                         ]),
                     Variable
                       (69,
-                        t/0),
+                        t_1/0),
                     IfThenElse
                       (70,
                         Apply
@@ -1062,8 +1062,10 @@ Value
         Match
           (133, Tuple (133, Variable (133, t1/0), Variable (133, t2/0)),
             [
-              (Tuple (Constructor (Empty/0), t), Variable (134, t/0));
-              (Tuple (t, Constructor (Empty/0)), Variable (135, t/0));
+              (Tuple (Constructor (Empty/0), t (= t_1)),
+                Variable (134, t_1/0));
+              (Tuple (t (= t_1), Constructor (Empty/0)),
+                Variable (135, t_1/0));
               (Tuple (Any, Any),
                 Apply
                   (136,
@@ -1106,8 +1108,10 @@ Value
         Match
           (143, Tuple (143, Variable (143, t1/0), Variable (143, t2/0)),
             [
-              (Tuple (Constructor (Empty/0), t), Variable (144, t/0));
-              (Tuple (t, Constructor (Empty/0)), Variable (145, t/0));
+              (Tuple (Constructor (Empty/0), t (= t_1)),
+                Variable (144, t_1/0));
+              (Tuple (t (= t_1), Constructor (Empty/0)),
+                Variable (145, t_1/0));
               (Tuple (Any, Any),
                 Apply
                   (146,

--- a/tests/ex34.monadise
+++ b/tests/ex34.monadise
@@ -515,7 +515,7 @@ Value
                         Constant
                           (66,
                             Int(1)))));
-              (Alias (Constructor (Node/0, l, v, r, Any), t),
+              (Alias (Constructor (Node/0, l, v, r, Any), t (= t_1)),
                 LetVar ? c =
                   Apply
                     (68,
@@ -550,7 +550,7 @@ Value
                       (?,
                         Variable
                           (69,
-                            t/0)),
+                            t_1/0)),
                     IfThenElse
                       (70,
                         Apply
@@ -1220,10 +1220,10 @@ Value
         Match
           (133, Tuple (133, Variable (133, t1/0), Variable (133, t2/0)),
             [
-              (Tuple (Constructor (Empty/0), t),
-                Return (?, Variable (134, t/0)));
-              (Tuple (t, Constructor (Empty/0)),
-                Return (?, Variable (135, t/0)));
+              (Tuple (Constructor (Empty/0), t (= t_1)),
+                Return (?, Variable (134, t_1/0)));
+              (Tuple (t (= t_1), Constructor (Empty/0)),
+                Return (?, Variable (135, t_1/0)));
               (Tuple (Any, Any),
                 Bind
                   (?,
@@ -1314,10 +1314,10 @@ Value
         Match
           (143, Tuple (143, Variable (143, t1/0), Variable (143, t2/0)),
             [
-              (Tuple (Constructor (Empty/0), t),
-                Return (?, Variable (144, t/0)));
-              (Tuple (t, Constructor (Empty/0)),
-                Return (?, Variable (145, t/0)));
+              (Tuple (Constructor (Empty/0), t (= t_1)),
+                Return (?, Variable (144, t_1/0)));
+              (Tuple (t (= t_1), Constructor (Empty/0)),
+                Return (?, Variable (145, t_1/0)));
               (Tuple (Any, Any),
                 Bind
                   (?,

--- a/tests/ex34.v
+++ b/tests/ex34.v
@@ -97,10 +97,10 @@ Definition bal (l : t) (v : elt) (r : t) : M [ OCaml.Invalid_argument ] t :=
 Fixpoint add (x : elt) (x_1 : t) : M [ OCaml.Invalid_argument ] t :=
   match x_1 with
   | Empty => ret (Node Empty x Empty 1)
-  | Node l v r _ as t =>
+  | Node l v r _ as t_1 =>
     let c := Ord.compare x v in
     if equiv_decb c 0 then
-      ret t
+      ret t_1
     else
       if OCaml.Pervasives.lt c 0 then
         let! x_2 := add x l in
@@ -180,8 +180,8 @@ Fixpoint remove_min_elt (x : t) : M [ OCaml.Invalid_argument ] t :=
 Definition merge (t1 : t) (t2 : t)
   : M [ OCaml.Invalid_argument; OCaml.Not_found ] t :=
   match (t1, t2) with
-  | (Empty, t) => ret t
-  | (t, Empty) => ret t
+  | (Empty, t_1) => ret t_1
+  | (t_1, Empty) => ret t_1
   | (_, _) =>
     let! x := lift [_;_] "01" (min_elt t2) in
     let! x_1 := lift [_;_] "10" (remove_min_elt t2) in
@@ -191,8 +191,8 @@ Definition merge (t1 : t) (t2 : t)
 Definition concat (t1 : t) (t2 : t)
   : M [ Counter; NonTermination; OCaml.Invalid_argument; OCaml.Not_found ] t :=
   match (t1, t2) with
-  | (Empty, t) => ret t
-  | (t, Empty) => ret t
+  | (Empty, t_1) => ret t_1
+  | (t_1, Empty) => ret t_1
   | (_, _) =>
     let! x := lift [_;_;_;_] "0001" (min_elt t2) in
     let! x_1 := lift [_;_;_;_] "0010" (remove_min_elt t2) in

--- a/tests/ex35.effects
+++ b/tests/ex35.effects
@@ -1,4 +1,4 @@
-3 Exception (Fail, (Type (string/1)))
+3 Exception (Fail, raise_Fail, (Type (string/1)))
 
 5
 Value

--- a/tests/ex35.exp
+++ b/tests/ex35.exp
@@ -1,4 +1,4 @@
-3 Exception (Fail, (Type (string/1)))
+3 Exception (Fail, raise_Fail, (Type (string/1)))
 
 5
 Value

--- a/tests/ex35.interface
+++ b/tests/ex35.interface
@@ -3,6 +3,6 @@
   "content": [
     "Interface",
     "Ex35",
-    [ [ "Descriptor", "Fail" ], [ "Var", "Fail", [ [ "Fail" ] ] ], [ "Var", "div", [ [ "Fail" ] ] ] ]
+    [ [ "Descriptor", "Fail" ], [ "Var", "raise_Fail", [ [ "Fail" ] ] ], [ "Var", "div", [ [ "Fail" ] ] ] ]
   ]
 }

--- a/tests/ex35.monadise
+++ b/tests/ex35.monadise
@@ -1,4 +1,4 @@
-3 Exception (Fail, (Type (string/1)))
+3 Exception (Fail, raise_Fail, (Type (string/1)))
 
 5
 Value

--- a/tests/ex39.effects
+++ b/tests/ex39.effects
@@ -650,7 +650,7 @@ Value
             [ Constant ((30, Effect ([ ], .)), Int(15)) ]))
     ])
 
-32 Reference (r, Type (Z/1), Constant ((32, Effect ([ ], .)), Int(18)))
+32 Reference (r, r_state, Type (Z/1), Constant ((32, Effect ([ ], .)), Int(18)))
 
 34
 Value

--- a/tests/ex39.exp
+++ b/tests/ex39.exp
@@ -201,7 +201,7 @@ Value
             [ Constant (30, Int(15)) ]))
     ])
 
-32 Reference (r, Type (Z/1), Constant (32, Int(18)))
+32 Reference (r, r_state, Type (Z/1), Constant (32, Int(18)))
 
 34
 Value

--- a/tests/ex39.interface
+++ b/tests/ex39.interface
@@ -12,7 +12,7 @@
       [ "Var", "update_ref", [ [ "OCaml.Effect.State.state" ] ] ],
       [ "Var", "new_ref", [ [ "OCaml.Effect.State.state" ] ] ],
       [ "Var", "r", [] ],
-      [ "Descriptor", "r" ],
+      [ "Descriptor", "r_state" ],
       [ "Var", "set_r", [ [ "OCaml.Effect.State.state", "OCaml.Effect.State.state" ] ] ],
       [ "Var", "get_r", [ [ "OCaml.Effect.State.state", "OCaml.Effect.State.state" ] ] ],
       [ "Var", "r_add_15", [ [ "OCaml.Effect.State.state", "OCaml.Effect.State.state" ] ] ],

--- a/tests/ex39.monadise
+++ b/tests/ex39.monadise
@@ -269,7 +269,7 @@ Value
             [ Constant (30, Int(15)) ]))
     ])
 
-32 Reference (r, Type (Z/1), Constant (32, Int(18)))
+32 Reference (r, r_state, Type (Z/1), Constant (32, Int(18)))
 
 34
 Value


### PR DESCRIPTION
This PR
* uses a central map from names to objects for all values in `Mod`
* uses a per-sort map to manage which OCaml name (which can be re-used between sorts) maps to which Coq name (which cannot) via `Mod.Locator.t`
* automatically redirect an OCaml name to a different Coq name if the corresponding Coq name is already used for a value of another sort
* adds `CoqName.t` to carry OCaml and Coq names together, and uses it everywhere where the OCaml and Coq names might have diverged
* fixes an oversight in `Interface`, where `raise_name` and `name_state` weren't registered for Exceptions and References respectively. This lets code use Exceptions and References from external modules included via interfaces, as expected.
* updates the test output to reflect the changes