### PR TITLE
Simplify FullEnvi/FullMod

### DIFF
--- a/src/exception.ml
+++ b/src/exception.ml
@@ -13,9 +13,9 @@ let pp (exn : t) : SmartPrint.t =
 let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t)
   (exn : extension_constructor) : t =
   let name = Name.of_ident exn.ext_id in
-  let coq_name = (FullEnvi.resolve_descriptor [] name env).base in
+  let coq_name = (FullEnvi.Descriptor.resolve [] name env).base in
   let raise_name = "raise_" ^ name in
-  let coq_raise_name = (FullEnvi.resolve_var [] raise_name env).base in
+  let coq_raise_name = (FullEnvi.Var.resolve [] raise_name env).base in
   let typs =
     match exn.ext_type.Types.ext_args with
     | Types.Cstr_tuple typs -> typs
@@ -29,21 +29,21 @@ let update_env (exn : t) (env : unit FullEnvi.t) : unit FullEnvi.t =
   let (name, coq_name) = CoqName.assoc_names exn.name in
   let (raise_name, coq_raise_name) = CoqName.assoc_names exn.raise_name in
   env
-  |> FullEnvi.assoc_descriptor [] name coq_name
-  |> FullEnvi.assoc_var [] raise_name coq_raise_name ()
+  |> FullEnvi.Descriptor.assoc [] name coq_name
+  |> FullEnvi.Var.assoc [] raise_name coq_raise_name ()
 
 let update_env_with_effects (exn : t) (env : Effect.Type.t FullEnvi.t)
   (id : Effect.Descriptor.Id.t) : Effect.Type.t FullEnvi.t =
   let (name, coq_name) = CoqName.assoc_names exn.name in
   let (raise_name, coq_raise_name) = CoqName.assoc_names exn.raise_name in
-  let env = FullEnvi.assoc_descriptor [] name coq_name env in
+  let env = FullEnvi.Descriptor.assoc [] name coq_name env in
   let effect_typ =
     Effect.Type.Arrow (
       Effect.Descriptor.singleton
         id
-        (FullEnvi.bound_descriptor Loc.Unknown (PathName.of_name [] name) env),
+        (FullEnvi.Descriptor.bound Loc.Unknown (PathName.of_name [] name) env),
       Effect.Type.Pure) in
-  FullEnvi.assoc_var [] raise_name coq_raise_name effect_typ env
+  FullEnvi.Var.assoc [] raise_name coq_raise_name effect_typ env
 
 let to_coq (exn : t) : SmartPrint.t =
   !^ "Definition" ^^ CoqName.to_coq exn.name ^^ !^ ":=" ^^

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -274,7 +274,7 @@ let map (f : 'a -> 'b) (env : 'a t) : 'b t =
    required_modules = env.required_modules}
 
 let include_module (loc : Loc.t) (x : 'a Mod.t) (env : 'a t) : 'a t =
-  try {env with active_module = FullMod.include_module loc x env.active_module}
+  try {env with active_module = FullMod.include_module x env.active_module}
   with Mod.NameConflict (typ1, typ2, name) ->
     let message = !^ "Could not include module: the" ^^ !^ typ1 ^^
       PathName.pp name ^^ !^ "is already declared as a" ^^ !^ (typ2 ^ ".") in

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -77,7 +77,8 @@ let find_external_module_path (x : PathName.t) (env : 'a t)
   match find_external_module_path_opt x env with
   | Some ret -> ret
   | None ->
-    failwith ("Could not find include for " ^ to_string 80 2 (PathName.pp x) ^ ".")
+    failwith @@ to_string 80 2 @@
+      !^ "Could not find include for" ^^ PathName.pp x ^-^ !^ "."
 
 let bound_name_external_opt (find : PathName.t -> 'a Mod.t -> PathName.t option)
   (x : PathName.t) (env : 'a t) : BoundName.t option =

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -181,7 +181,7 @@ let map (f : 'a -> 'b) (env : 'a t) : 'b t =
    required_modules = env.required_modules}
 
 let include_module (loc : Loc.t) (x : 'a Mod.t) (env : 'a t) : 'a t =
-  try {env with active_module = FullMod.include_module x env.active_module}
+  try update_active (Mod.include_module x) env
   with Mod.NameConflict (typ1, typ2, name) ->
     let message = !^ "Could not include module: the" ^^ !^ typ1 ^^
       PathName.pp name ^^ !^ "is already declared as a" ^^ !^ (typ2 ^ ".") in

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -274,4 +274,8 @@ let map (f : 'a -> 'b) (env : 'a t) : 'b t =
    required_modules = env.required_modules}
 
 let include_module (loc : Loc.t) (x : 'a Mod.t) (env : 'a t) : 'a t =
-  {env with active_module = FullMod.include_module loc x env.active_module}
+  try {env with active_module = FullMod.include_module loc x env.active_module}
+  with Mod.NameConflict (typ1, typ2, name) ->
+    let message = !^ "Could not include module: the" ^^ !^ typ1 ^^
+      PathName.pp name ^^ !^ "is already declared as a" ^^ !^ (typ2 ^ ".") in
+    Error.raise loc (SmartPrint.to_string 80 2 message)

--- a/src/fullMod.ml
+++ b/src/fullMod.ml
@@ -149,10 +149,7 @@ let fresh_var  (prefix : string) (v : 'a) (env : 'a t) : Name.t * 'a t =
     (name, m :: env)
   | [] -> failwith "The environment must be a non-empty list."
 
-let rec map (f : 'a -> 'b) (env : 'a t) : 'b t =
-  match env with
-  | m :: env -> Mod.map f m :: map f env
-  | [] -> []
+let rec map (f : 'a -> 'b) (env : 'a t) : 'b t = List.map (Mod.map f) env
 
 let include_module (loc : Loc.t) (x : 'a Mod.t) (env : 'a t) : 'a t =
   match env with

--- a/src/fullMod.ml
+++ b/src/fullMod.ml
@@ -73,6 +73,3 @@ let fresh_var  (prefix : string) (v : 'a) (env : 'a t) : Name.t * 'a t =
     (name, m :: env)) env
 
 let rec map (f : 'a -> 'b) (env : 'a t) : 'b t = List.map (Mod.map f) env
-
-let include_module (x : 'a Mod.t) (env : 'a t) : 'a t =
-  hd_mod_map (Mod.include_module x) env

--- a/src/fullMod.ml
+++ b/src/fullMod.ml
@@ -143,15 +143,11 @@ let find_bound_name (find : PathName.t -> 'a Mod.t -> 'b) (x : BoundName.t)
   iterate_open_lift v x.BoundName.depth
 
 let fresh_var  (prefix : string) (v : 'a) (env : 'a t) : Name.t * 'a t =
-  match env with
-  | m :: env ->
+  hd_map (fun m env ->
     let (name, m) = Mod.Vars.fresh prefix v m in
-    (name, m :: env)
-  | [] -> failwith "The environment must be a non-empty list."
+    (name, m :: env)) env
 
 let rec map (f : 'a -> 'b) (env : 'a t) : 'b t = List.map (Mod.map f) env
 
-let include_module (loc : Loc.t) (x : 'a Mod.t) (env : 'a t) : 'a t =
-  match env with
-  | m :: env -> Mod.include_module x m :: env
-  | [] -> failwith "The environment must be a non-empty list."
+let include_module (x : 'a Mod.t) (env : 'a t) : 'a t =
+  hd_mod_map (Mod.include_module x) env

--- a/src/fullMod.ml
+++ b/src/fullMod.ml
@@ -16,10 +16,6 @@ let hd_map (f : 'a Mod.t -> 'a t -> 'b) (env : 'a t) : 'b =
 let hd_mod_map (f : 'a Mod.t -> 'a Mod.t) : 'a t -> 'a t =
   hd_map (fun m env -> f m :: env)
 
-let add_module (path : Name.t list) (base : Name.t) (v : 'a Mod.t) (env : 'a t)
-  : 'a t =
-  hd_mod_map (Mod.Modules.add (PathName.of_name path base) v) env
-
 let enter_module (env : 'a t) : 'a t = Mod.empty :: env
 
 let open_module (module_name : Name.t list) (env : 'a t) : 'a t =
@@ -54,14 +50,6 @@ let rec bound_name_opt (find : PathName.t -> 'a Mod.t -> PathName.t option)
           { name with BoundName.depth = name.BoundName.depth + 1 }))
     end
   | [] -> None
-
-let bound_name (find : PathName.t -> 'a Mod.t -> PathName.t option)
-  (loc : Loc.t) (x : PathName.t) (env : 'a t) : BoundName.t =
-  match bound_name_opt find x env with
-  | Some name -> name
-  | None ->
-    let message = PathName.pp x ^^ !^ "not found." in
-    Error.raise loc (SmartPrint.to_string 80 2 message)
 
 let bound_module_opt (x : PathName.t) (env : 'a t) : BoundName.t option =
   bound_name_opt Mod.Modules.resolve_opt x env

--- a/src/fullMod.ml
+++ b/src/fullMod.ml
@@ -18,12 +18,6 @@ let hd_mod_map (f : 'a Mod.t -> 'a Mod.t) : 'a t -> 'a t =
 
 let enter_module (env : 'a t) : 'a t = Mod.empty :: env
 
-let open_module (module_name : Name.t list) (env : 'a t) : 'a t =
-  hd_mod_map (Mod.open_module module_name) env
-
-let open_external_module (module_name : Name.t list) (env : 'a t) : 'a t =
-  hd_mod_map (Mod.open_external_module module_name) env
-
 let rec external_opens (env : 'a t) : Name.t list list =
   match env with
   | m :: env -> m.external_opens @ external_opens env

--- a/src/fullMod.ml
+++ b/src/fullMod.ml
@@ -147,23 +147,6 @@ let bound_module_opt (x : PathName.t) (env : 'a t) : BoundName.t option =
 let bound_module (loc : Loc.t) (x : PathName.t) (env : 'a t) : BoundName.t =
   bound_name Mod.Modules.resolve_opt loc x env
 
-let add_exception (path : Name.t list) (base : Name.t) (env : unit t) : unit t =
-  env
-  |> add_descriptor path base
-  |> add_var path ("raise_" ^ base) ()
-
-let add_exception_with_effects (path : Name.t list) (base : Name.t)
-  (id : Effect.Descriptor.Id.t) (env : Effect.Type.t t)
-  : Effect.Type.t t =
-  let env = add_descriptor path base env in
-  let effect_typ =
-    Effect.Type.Arrow (
-      Effect.Descriptor.singleton
-        id
-        (bound_descriptor Loc.Unknown (PathName.of_name path base) env),
-      Effect.Type.Pure) in
-  add_var path ("raise_" ^ base) effect_typ env
-
 let find_bound_name (find : PathName.t -> 'a Mod.t -> 'b) (x : BoundName.t)
   (env : 'a t) (open_lift : 'b -> 'b) : 'b =
   let m =

--- a/src/fullMod.ml
+++ b/src/fullMod.ml
@@ -126,26 +126,8 @@ let bound_name (find : PathName.t -> 'a Mod.t -> PathName.t option)
     let message = PathName.pp x ^^ !^ "not found." in
     Error.raise loc (SmartPrint.to_string 80 2 message)
 
-let bound_var (loc : Loc.t) (x : PathName.t) (env : 'a t) : BoundName.t =
-  bound_name Mod.Vars.resolve_opt loc x env
-
-let bound_typ (loc : Loc.t) (x : PathName.t) (env : 'a t) : BoundName.t =
-  bound_name Mod.Typs.resolve_opt loc x env
-
-let bound_descriptor (loc : Loc.t) (x : PathName.t) (env : 'a t) : BoundName.t =
-  bound_name Mod.Descriptors.resolve_opt loc x env
-
-let bound_constructor (loc : Loc.t) (x : PathName.t) (env : 'a t) : BoundName.t =
-  bound_name Mod.Constructors.resolve_opt loc x env
-
-let bound_field (loc : Loc.t) (x : PathName.t) (env : 'a t) : BoundName.t =
-  bound_name Mod.Fields.resolve_opt loc x env
-
 let bound_module_opt (x : PathName.t) (env : 'a t) : BoundName.t option =
   bound_name_opt Mod.Modules.resolve_opt x env
-
-let bound_module (loc : Loc.t) (x : PathName.t) (env : 'a t) : BoundName.t =
-  bound_name Mod.Modules.resolve_opt loc x env
 
 let find_bound_name (find : PathName.t -> 'a Mod.t -> 'b) (x : BoundName.t)
   (env : 'a t) (open_lift : 'b -> 'b) : 'b =

--- a/src/fullMod.ml
+++ b/src/fullMod.ml
@@ -16,72 +16,9 @@ let hd_map (f : 'a Mod.t -> 'a t -> 'b) (env : 'a t) : 'b =
 let hd_mod_map (f : 'a Mod.t -> 'a Mod.t) : 'a t -> 'a t =
   hd_map (fun m env -> f m :: env)
 
-let add_var (path : Name.t list) (base : Name.t) (v : 'a) (env : 'a t)
-  : 'a t =
-  hd_mod_map (Mod.Vars.add (PathName.of_name path base) v) env
-
-let add_typ (path : Name.t list) (base : Name.t) (v : 'a) (env : 'a t)
-  : 'a t =
-  hd_mod_map (Mod.Typs.add (PathName.of_name path base) v) env
-
-let add_descriptor (path : Name.t list) (base : Name.t) (env : 'a t)
-  : 'a t =
-  hd_mod_map (Mod.Descriptors.add (PathName.of_name path base)) env
-
-let add_constructor (path : Name.t list) (base : Name.t) (env : 'a t)
-  : 'a t =
-  hd_mod_map (Mod.Constructors.add (PathName.of_name path base)) env
-
-let add_field (path : Name.t list) (base : Name.t) (env : 'a t)
-  : 'a t =
-  hd_mod_map (Mod.Fields.add (PathName.of_name path base)) env
-
 let add_module (path : Name.t list) (base : Name.t) (v : 'a Mod.t) (env : 'a t)
   : 'a t =
   hd_mod_map (Mod.Modules.add (PathName.of_name path base) v) env
-
-let assoc_var (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
-  (v : 'a) (env : 'a t) : 'a t =
-   hd_mod_map (Mod.Vars.assoc (PathName.of_name path base)
-      (PathName.of_name path assoc_base) v) env
-
-let assoc_typ (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
-  (v : 'a) (env : 'a t) : 'a t =
-   hd_mod_map (Mod.Typs.assoc (PathName.of_name path base)
-      (PathName.of_name path assoc_base) v) env
-
-let assoc_descriptor (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
-  (env : 'a t) : 'a t =
-   hd_mod_map (Mod.Descriptors.assoc (PathName.of_name path base)
-      (PathName.of_name path assoc_base)) env
-
-let assoc_constructor (path : Name.t list) (base : Name.t)
-  (assoc_base : Name.t) (env : 'a t) : 'a t =
-   hd_mod_map (Mod.Constructors.assoc (PathName.of_name path base)
-      (PathName.of_name path assoc_base)) env
-
-let assoc_field (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
-  (env : 'a t) : 'a t =
-   hd_mod_map (Mod.Fields.assoc (PathName.of_name path base)
-      (PathName.of_name path assoc_base)) env
-
-let resolve_var (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
-  hd_map (fun m _ -> Mod.Vars.resolve (PathName.of_name path base) m) env
-
-let resolve_typ (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
-  hd_map (fun m _ -> Mod.Typs.resolve (PathName.of_name path base) m) env
-
-let resolve_descriptor (path : Name.t list) (base : Name.t) (env : 'a t)
-  : PathName.t =
-  hd_map (fun m _ -> Mod.Descriptors.resolve (PathName.of_name path base) m) env
-
-let resolve_constructor (path : Name.t list) (base : Name.t) (env : 'a t)
-  : PathName.t =
-  hd_map (fun m _ -> Mod.Constructors.resolve (PathName.of_name path base) m) env
-
-let resolve_field (path : Name.t list) (base : Name.t) (env : 'a t)
-  : PathName.t =
-  hd_map (fun m _ -> Mod.Fields.resolve (PathName.of_name path base) m) env
 
 let enter_module (env : 'a t) : 'a t = Mod.empty :: env
 

--- a/src/fullMod.ml
+++ b/src/fullMod.ml
@@ -142,16 +142,6 @@ let find_bound_name (find : PathName.t -> 'a Mod.t -> 'b) (x : BoundName.t)
   let v = find x.BoundName.path_name m in
   iterate_open_lift v x.BoundName.depth
 
-let find_var (x : BoundName.t) (env : 'a t) (open_lift : 'a -> 'a) : 'a =
-  find_bound_name Mod.Vars.find x env open_lift
-
-let find_typ (x : BoundName.t) (env : 'a t) (open_lift : 'a -> 'a) : 'a =
-  find_bound_name Mod.Typs.find x env open_lift
-
-let find_module (x : BoundName.t) (env : 'a t)
-  (open_lift : 'a Mod.t -> 'a Mod.t) : 'a Mod.t =
-  find_bound_name Mod.Modules.find x env open_lift
-
 let fresh_var  (prefix : string) (v : 'a) (env : 'a t) : Name.t * 'a t =
   match env with
   | m :: env ->

--- a/src/fullMod.ml
+++ b/src/fullMod.ml
@@ -8,121 +8,88 @@ let pp (env : 'a t) : SmartPrint.t =
 
 let empty : 'a t = [Mod.empty]
 
+let hd_map (f : 'a Mod.t -> 'a t -> 'b) (env : 'a t) : 'b =
+  match env with
+  | m :: env -> f m env
+  | [] -> failwith "The environment must be a non-empty list."
+
+let hd_mod_map (f : 'a Mod.t -> 'a Mod.t) : 'a t -> 'a t =
+  hd_map (fun m env -> f m :: env)
+
 let add_var (path : Name.t list) (base : Name.t) (v : 'a) (env : 'a t)
   : 'a t =
-  match env with
-  | m :: env -> Mod.Vars.add (PathName.of_name path base) v m :: env
-  | [] -> failwith "The environment must be a non-empty list."
+  hd_mod_map (Mod.Vars.add (PathName.of_name path base) v) env
 
 let add_typ (path : Name.t list) (base : Name.t) (v : 'a) (env : 'a t)
   : 'a t =
-  match env with
-  | m :: env -> Mod.Typs.add (PathName.of_name path base) v m :: env
-  | [] -> failwith "The environment must be a non-empty list."
+  hd_mod_map (Mod.Typs.add (PathName.of_name path base) v) env
 
 let add_descriptor (path : Name.t list) (base : Name.t) (env : 'a t)
   : 'a t =
-  match env with
-  | m :: env -> Mod.Descriptors.add (PathName.of_name path base) m :: env
-  | [] -> failwith "The environment must be a non-empty list."
+  hd_mod_map (Mod.Descriptors.add (PathName.of_name path base)) env
 
 let add_constructor (path : Name.t list) (base : Name.t) (env : 'a t)
   : 'a t =
-  match env with
-  | m :: env -> Mod.Constructors.add (PathName.of_name path base) m :: env
-  | [] -> failwith "The environment must be a non-empty list."
+  hd_mod_map (Mod.Constructors.add (PathName.of_name path base)) env
 
 let add_field (path : Name.t list) (base : Name.t) (env : 'a t)
   : 'a t =
-  match env with
-  | m :: env -> Mod.Fields.add (PathName.of_name path base) m :: env
-  | [] -> failwith "The environment must be a non-empty list."
+  hd_mod_map (Mod.Fields.add (PathName.of_name path base)) env
 
 let add_module (path : Name.t list) (base : Name.t) (v : 'a Mod.t) (env : 'a t)
   : 'a t =
-  match env with
-  | m :: env -> Mod.Modules.add (PathName.of_name path base) v m :: env
-  | [] -> failwith "The environment must be a non-empty list."
+  hd_mod_map (Mod.Modules.add (PathName.of_name path base) v) env
 
 let assoc_var (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
   (v : 'a) (env : 'a t) : 'a t =
-  match env with
-  | m :: env ->
-    Mod.Vars.assoc (PathName.of_name path base)
-      (PathName.of_name path assoc_base) v m :: env
-  | [] -> failwith "The environment must be a non-empty list."
+   hd_mod_map (Mod.Vars.assoc (PathName.of_name path base)
+      (PathName.of_name path assoc_base) v) env
 
 let assoc_typ (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
   (v : 'a) (env : 'a t) : 'a t =
-  match env with
-  | m :: env ->
-    Mod.Typs.assoc (PathName.of_name path base)
-      (PathName.of_name path assoc_base) v m :: env
-  | [] -> failwith "The environment must be a non-empty list."
+   hd_mod_map (Mod.Typs.assoc (PathName.of_name path base)
+      (PathName.of_name path assoc_base) v) env
 
 let assoc_descriptor (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
   (env : 'a t) : 'a t =
-  match env with
-  | m :: env ->
-    Mod.Descriptors.assoc (PathName.of_name path base)
-      (PathName.of_name path assoc_base) m :: env
-  | [] -> failwith "The environment must be a non-empty list."
+   hd_mod_map (Mod.Descriptors.assoc (PathName.of_name path base)
+      (PathName.of_name path assoc_base)) env
 
 let assoc_constructor (path : Name.t list) (base : Name.t)
   (assoc_base : Name.t) (env : 'a t) : 'a t =
-  match env with
-  | m :: env ->
-    Mod.Constructors.assoc (PathName.of_name path base)
-      (PathName.of_name path assoc_base) m :: env
-  | [] -> failwith "The environment must be a non-empty list."
+   hd_mod_map (Mod.Constructors.assoc (PathName.of_name path base)
+      (PathName.of_name path assoc_base)) env
 
 let assoc_field (path : Name.t list) (base : Name.t) (assoc_base : Name.t)
   (env : 'a t) : 'a t =
-  match env with
-  | m :: env ->
-    Mod.Fields.assoc (PathName.of_name path base)
-      (PathName.of_name path assoc_base) m :: env
-  | [] -> failwith "The environment must be a non-empty list."
+   hd_mod_map (Mod.Fields.assoc (PathName.of_name path base)
+      (PathName.of_name path assoc_base)) env
 
 let resolve_var (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
-  match env with
-  | m :: env -> Mod.Vars.resolve (PathName.of_name path base) m
-  | [] -> failwith "The environment must be a non-empty list."
+  hd_map (fun m _ -> Mod.Vars.resolve (PathName.of_name path base) m) env
 
 let resolve_typ (path : Name.t list) (base : Name.t) (env : 'a t) : PathName.t =
-  match env with
-  | m :: env -> Mod.Typs.resolve (PathName.of_name path base) m
-  | [] -> failwith "The environment must be a non-empty list."
+  hd_map (fun m _ -> Mod.Typs.resolve (PathName.of_name path base) m) env
 
 let resolve_descriptor (path : Name.t list) (base : Name.t) (env : 'a t)
   : PathName.t =
-  match env with
-  | m :: env -> Mod.Descriptors.resolve (PathName.of_name path base) m
-  | [] -> failwith "The environment must be a non-empty list."
+  hd_map (fun m _ -> Mod.Descriptors.resolve (PathName.of_name path base) m) env
 
 let resolve_constructor (path : Name.t list) (base : Name.t) (env : 'a t)
   : PathName.t =
-  match env with
-  | m :: env -> Mod.Constructors.resolve (PathName.of_name path base) m
-  | [] -> failwith "The environment must be a non-empty list."
+  hd_map (fun m _ -> Mod.Constructors.resolve (PathName.of_name path base) m) env
 
 let resolve_field (path : Name.t list) (base : Name.t) (env : 'a t)
   : PathName.t =
-  match env with
-  | m :: env -> Mod.Fields.resolve (PathName.of_name path base) m
-  | [] -> failwith "The environment must be a non-empty list."
+  hd_map (fun m _ -> Mod.Fields.resolve (PathName.of_name path base) m) env
 
 let enter_module (env : 'a t) : 'a t = Mod.empty :: env
 
 let open_module (module_name : Name.t list) (env : 'a t) : 'a t =
-  match env with
-  | m :: env -> Mod.open_module m module_name :: env
-  | _ -> failwith "You should have entered in at least one module."
+  hd_mod_map (Mod.open_module module_name) env
 
 let open_external_module (module_name : Name.t list) (env : 'a t) : 'a t =
-  match env with
-  | m :: env -> Mod.open_external_module m module_name :: env
-  | _ -> failwith "You should have entered in at least one module."
+  hd_mod_map (Mod.open_external_module module_name) env
 
 let rec external_opens (env : 'a t) : Name.t list list =
   match env with

--- a/src/fullMod.ml
+++ b/src/fullMod.ml
@@ -153,10 +153,5 @@ let rec map (f : 'a -> 'b) (env : 'a t) : 'b t = List.map (Mod.map f) env
 
 let include_module (loc : Loc.t) (x : 'a Mod.t) (env : 'a t) : 'a t =
   match env with
-  | m :: env ->
-      (try Mod.include_module x m :: env with
-      | Mod.NameConflict (typ1, typ2, name) ->
-        let message = !^ "Could not include module: the" ^^ !^ typ1 ^^
-          PathName.pp name ^^ !^ "is already declared as a" ^^ !^ (typ2 ^ ".") in
-        Error.raise loc (SmartPrint.to_string 80 2 message))
+  | m :: env -> Mod.include_module x m :: env
   | [] -> failwith "The environment must be a non-empty list."

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -19,7 +19,7 @@ module Shape = struct
     let descriptor ds : Effect.Descriptor.t =
       let ds = ds |> List.map (fun d ->
         Effect.Descriptor.singleton (Effect.Descriptor.Id.Ether d)
-          (FullEnvi.bound_descriptor Loc.Unknown d env)) in
+          (FullEnvi.Descriptor.bound Loc.Unknown d env)) in
       Effect.Descriptor.union ds in
     List.fold_right (fun ds typ -> Effect.Type.Arrow (descriptor ds, typ))
       shape Effect.Type.Pure
@@ -99,11 +99,11 @@ and of_structure (def : ('a * Effect.t) Structure.t) : t list =
 let rec to_full_envi (interface : t) (env : Effect.Type.t FullEnvi.t)
   : Effect.Type.t FullEnvi.t =
   match interface with
-  | Var (x, shape) -> FullEnvi.add_var [] x (Shape.to_effect_typ shape env) env
-  | Typ x -> FullEnvi.add_typ [] x Effect.Type.Pure env
-  | Descriptor x -> FullEnvi.add_descriptor [] x env
-  | Constructor x -> FullEnvi.add_constructor [] x env
-  | Field x -> FullEnvi.add_field [] x env
+  | Var (x, shape) -> FullEnvi.Var.add [] x (Shape.to_effect_typ shape env) env
+  | Typ x -> FullEnvi.Typ.add [] x Effect.Type.Pure env
+  | Descriptor x -> FullEnvi.Descriptor.add [] x env
+  | Constructor x -> FullEnvi.Constructor.add [] x env
+  | Field x -> FullEnvi.Field.add [] x env
   | Include x -> Include.of_interface x env
   | Interface (x, defs) ->
     let env = FullEnvi.enter_module env in

--- a/src/mod.ml
+++ b/src/mod.ml
@@ -121,6 +121,23 @@ let rec map (f : 'a -> 'b) (m : 'a t) : 'b t =
     values = m.values |> PathName.Map.map (Value.map f);
     modules = PathName.Map.map (map f) m.modules }
 
+module type ValueCarrier = sig
+  val resolve_opt : PathName.t -> 'a t -> PathName.t option
+  val resolve : PathName.t -> 'a t -> PathName.t
+  val assoc : PathName.t -> PathName.t -> 'a -> 'a t -> 'a t
+  val add : PathName.t -> 'a -> 'a t -> 'a t
+  val mem : PathName.t -> 'a t -> bool
+  val find : PathName.t -> 'a t -> 'a
+end
+
+module type EmptyCarrier = sig
+  val resolve_opt : PathName.t -> 'a t -> PathName.t option
+  val resolve : PathName.t -> 'a t -> PathName.t
+  val assoc : PathName.t -> PathName.t -> 'a t -> 'a t
+  val add : PathName.t -> 'a t -> 'a t
+  val mem : PathName.t -> 'a t -> bool
+end
+
 module Vars = struct
   let resolve_opt (x : PathName.t) (m : 'a t) : PathName.t option =
     option_map (fun name -> { x with base = name }) @@

--- a/src/mod.ml
+++ b/src/mod.ml
@@ -94,10 +94,10 @@ let pp (m : 'a t) : SmartPrint.t =
     !^ "modules:" ^^ nest (OCaml.list (fun (x, _) -> PathName.pp x) @@
       PathName.Map.bindings m.modules))
 
-let open_module (m : 'a t) (module_name : Name.t list) : 'a t =
+let open_module (module_name : Name.t list) (m : 'a t) : 'a t =
   { m with opens = module_name :: m.opens }
 
-let open_external_module (m : 'a t) (module_name : Name.t list) : 'a t =
+let open_external_module (module_name : Name.t list) (m : 'a t) : 'a t =
   { m with external_opens = module_name :: m.external_opens }
 
 let find_free_name (base_name : string) (env : 'a t) : Name.t =

--- a/src/pattern.ml
+++ b/src/pattern.ml
@@ -33,20 +33,20 @@ let rec of_pattern (env : 'a FullEnvi.t) (p : pattern) : t =
   | Tpat_any -> Any
   | Tpat_var (x, _) ->
       let x = Name.of_ident x in
-      let x = CoqName.of_names x (FullEnvi.resolve_var [] x env).base in
+      let x = CoqName.of_names x (FullEnvi.Var.resolve [] x env).base in
       Variable x
   | Tpat_tuple ps -> Tuple (List.map (of_pattern env) ps)
   | Tpat_construct (x, _, ps) ->
-    let x = FullEnvi.bound_constructor l (PathName.of_loc x) env in
+    let x = FullEnvi.Constructor.bound l (PathName.of_loc x) env in
     Constructor (x, List.map (of_pattern env) ps)
   | Tpat_alias (p, x, _) ->
     let x = Name.of_ident x in
-    let x = CoqName.of_names x (FullEnvi.resolve_var [] x env).base in
+    let x = CoqName.of_names x (FullEnvi.Var.resolve [] x env).base in
     Alias (of_pattern env p, x)
   | Tpat_constant c -> Constant (Constant.of_constant l c)
   | Tpat_record (fields, _) ->
     Record (fields |> List.map (fun (x, _, p) ->
-      let x = FullEnvi.bound_field l (PathName.of_loc x) env in
+      let x = FullEnvi.Field.bound l (PathName.of_loc x) env in
       (x, of_pattern env p)))
   | Tpat_or (p1, p2, _) -> Or (of_pattern env p1, of_pattern env p2)
   | _ -> Error.raise l "Unhandled pattern."
@@ -67,7 +67,7 @@ let rec free_variables (p : t) : Name.Set.t =
   | Or (p1, p2) -> Name.Set.inter (free_variables p1) (free_variables p2)
 
 let add_to_env (p : t) (env : unit FullEnvi.t) : unit FullEnvi.t =
-  Name.Set.fold (fun x env -> FullEnvi.add_var [] x () env)
+  Name.Set.fold (fun x env -> FullEnvi.Var.add [] x () env)
     (free_variables p) env
 
 (** Pretty-print a pattern to Coq (inside parenthesis if the [paren] flag is set). *)

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -21,37 +21,37 @@ let env_with_effects : Effect.Type.t FullEnvi.t =
       (Effect.Descriptor.Id.Ether (PathName.of_name path base)) in
   FullEnvi.empty (fun _ -> failwith "No modules loaded")
   (* Values specific to the translation to Coq *)
-  |> add_typ [] "nat" Pure
-  |> add_constructor [] "O"
-  |> add_constructor [] "S"
-  |> add_typ [] "sum" Pure
-  |> add_constructor [] "inl"
-  |> add_constructor [] "inr"
-  |> add_descriptor [] "IO"
-  |> add_descriptor [] "Counter"
-  |> add_var [] "read_counter" (Arrow (d [[], "Counter"], Pure))
-  |> add_descriptor [] "NonTermination"
-  |> add_var [] "not_terminated" (Arrow (d [[], "NonTermination"], Pure))
-  |> add_var ["OCaml"] "assert" (Arrow (d [["OCaml"], "Assert_failure"], Pure))
+  |> Typ.add [] "nat" Pure
+  |> Constructor.add [] "O"
+  |> Constructor.add [] "S"
+  |> Typ.add [] "sum" Pure
+  |> Constructor.add [] "inl"
+  |> Constructor.add [] "inr"
+  |> Descriptor.add [] "IO"
+  |> Descriptor.add [] "Counter"
+  |> Var.add [] "read_counter" (Arrow (d [[], "Counter"], Pure))
+  |> Descriptor.add [] "NonTermination"
+  |> Var.add [] "not_terminated" (Arrow (d [[], "NonTermination"], Pure))
+  |> Var.add ["OCaml"] "assert" (Arrow (d [["OCaml"], "Assert_failure"], Pure))
 
   (* The core library *)
   (* Built-in types *)
-  |> add_typ [] "Z" Pure
-  |> add_typ [] "ascii" Pure
-  |> add_typ [] "string" Pure
-  |> add_typ [] "bool" Pure
-  |> add_constructor [] "false"
-  |> add_constructor [] "true"
-  |> add_typ [] "unit" Pure
-  |> add_constructor [] "tt"
-  |> add_typ [] "list" Pure
-  |> add_constructor [] "[]"
-  |> add_constructor [] "cons"
-  |> add_typ [] "option" Pure
-  |> add_constructor [] "None"
-  |> add_constructor [] "Some"
+  |> Typ.add [] "Z" Pure
+  |> Typ.add [] "ascii" Pure
+  |> Typ.add [] "string" Pure
+  |> Typ.add [] "bool" Pure
+  |> Constructor.add [] "false"
+  |> Constructor.add [] "true"
+  |> Typ.add [] "unit" Pure
+  |> Constructor.add [] "tt"
+  |> Typ.add [] "list" Pure
+  |> Constructor.add [] "[]"
+  |> Constructor.add [] "cons"
+  |> Typ.add [] "option" Pure
+  |> Constructor.add [] "None"
+  |> Constructor.add [] "Some"
   (* Predefined exceptions *)
-  |> add_typ ["OCaml"] "exn" Pure
+  |> Typ.add ["OCaml"] "exn" Pure
   |> add_exn ["OCaml"] "Match_failure"
   |> add_exn ["OCaml"] "Assert_failure"
   |> add_exn ["OCaml"] "Invalid_argument"
@@ -65,91 +65,91 @@ let env_with_effects : Effect.Type.t FullEnvi.t =
   |> add_exn ["OCaml"] "Sys_blocked_io"
   |> add_exn ["OCaml"] "Undefined_recursive_module"
   (* State *)
-  |> add_descriptor ["OCaml"; "Effect"; "State"] "state"
-  |> add_typ ["OCaml"; "Effect"; "State"] "t" (Arrow (d [["OCaml"; "Effect"; "State"], "state"], Pure))
-  |> add_var ["OCaml"; "Effect"; "State"] "peekstate" Pure
-  |> add_var ["OCaml"; "Effect"; "State"] "global" Pure
-  |> add_var ["OCaml"; "Effect"; "State"] "read" (Arrow (typ_d 0, Pure))
-  |> add_var ["OCaml"; "Effect"; "State"] "write" (Arrow (d [], Arrow (typ_d 0, Pure)))
+  |> Descriptor.add ["OCaml"; "Effect"; "State"] "state"
+  |> Typ.add ["OCaml"; "Effect"; "State"] "t" (Arrow (d [["OCaml"; "Effect"; "State"], "state"], Pure))
+  |> Var.add ["OCaml"; "Effect"; "State"] "peekstate" Pure
+  |> Var.add ["OCaml"; "Effect"; "State"] "global" Pure
+  |> Var.add ["OCaml"; "Effect"; "State"] "read" (Arrow (typ_d 0, Pure))
+  |> Var.add ["OCaml"; "Effect"; "State"] "write" (Arrow (d [], Arrow (typ_d 0, Pure)))
 
   (* Pervasives *)
   (* Exceptions *)
-  |> add_var ["OCaml"; "Pervasives"] "invalid_arg" (Arrow (d [["OCaml"], "Invalid_argument"], Pure))
-  |> add_var ["OCaml"; "Pervasives"] "failwith" (Arrow (d [["OCaml"], "Failure"], Pure))
+  |> Var.add ["OCaml"; "Pervasives"] "invalid_arg" (Arrow (d [["OCaml"], "Invalid_argument"], Pure))
+  |> Var.add ["OCaml"; "Pervasives"] "failwith" (Arrow (d [["OCaml"], "Failure"], Pure))
   |> add_exn ["OCaml"; "Pervasives"] "Exit"
   (* Comparisons *)
-  |> add_var [] "equiv_decb" Pure
-  |> add_var [] "nequiv_decb" Pure
-  |> add_var ["OCaml"; "Pervasives"] "lt" Pure
-  |> add_var ["OCaml"; "Pervasives"] "gt" Pure
-  |> add_var ["OCaml"; "Pervasives"] "le" Pure
-  |> add_var ["OCaml"; "Pervasives"] "ge" Pure
-  |> add_var ["OCaml"; "Pervasives"] "compare" Pure
-  |> add_var ["OCaml"; "Pervasives"] "min" Pure
-  |> add_var ["OCaml"; "Pervasives"] "max" Pure
+  |> Var.add [] "equiv_decb" Pure
+  |> Var.add [] "nequiv_decb" Pure
+  |> Var.add ["OCaml"; "Pervasives"] "lt" Pure
+  |> Var.add ["OCaml"; "Pervasives"] "gt" Pure
+  |> Var.add ["OCaml"; "Pervasives"] "le" Pure
+  |> Var.add ["OCaml"; "Pervasives"] "ge" Pure
+  |> Var.add ["OCaml"; "Pervasives"] "compare" Pure
+  |> Var.add ["OCaml"; "Pervasives"] "min" Pure
+  |> Var.add ["OCaml"; "Pervasives"] "max" Pure
   (* Boolean operations *)
-  |> add_var [] "negb" Pure
-  |> add_var [] "andb" Pure
-  |> add_var [] "orb" Pure
+  |> Var.add [] "negb" Pure
+  |> Var.add [] "andb" Pure
+  |> Var.add [] "orb" Pure
   (* Composition operators *)
-  |> add_var ["OCaml"; "Pervasives"] "reverse_apply" Pure
-  |> add_var [] "apply" Pure
+  |> Var.add ["OCaml"; "Pervasives"] "reverse_apply" Pure
+  |> Var.add [] "apply" Pure
   (* Integer arithmetic *)
-  |> add_var ["Z"] "opp" Pure
-  |> add_var [] "" Pure
-  |> add_var ["Z"] "succ" Pure
-  |> add_var ["Z"] "pred" Pure
-  |> add_var ["Z"] "add" Pure
-  |> add_var ["Z"] "sub" Pure
-  |> add_var ["Z"] "mul" Pure
-  |> add_var ["Z"] "div" Pure
-  |> add_var ["Z"] "modulo" Pure
-  |> add_var ["Z"] "abs" Pure
+  |> Var.add ["Z"] "opp" Pure
+  |> Var.add [] "" Pure
+  |> Var.add ["Z"] "succ" Pure
+  |> Var.add ["Z"] "pred" Pure
+  |> Var.add ["Z"] "add" Pure
+  |> Var.add ["Z"] "sub" Pure
+  |> Var.add ["Z"] "mul" Pure
+  |> Var.add ["Z"] "div" Pure
+  |> Var.add ["Z"] "modulo" Pure
+  |> Var.add ["Z"] "abs" Pure
   (* Bitwise operations *)
-  |> add_var ["Z"] "land" Pure
-  |> add_var ["Z"] "lor" Pure
-  |> add_var ["Z"] "lxor" Pure
-  |> add_var ["Z"] "shiftl" Pure
-  |> add_var ["Z"] "shiftr" Pure
+  |> Var.add ["Z"] "land" Pure
+  |> Var.add ["Z"] "lor" Pure
+  |> Var.add ["Z"] "lxor" Pure
+  |> Var.add ["Z"] "shiftl" Pure
+  |> Var.add ["Z"] "shiftr" Pure
   (* Floating-point arithmetic *)
   (* String operations *)
-  |> add_var ["String"] "append" Pure
+  |> Var.add ["String"] "append" Pure
   (* Character operations *)
-  |> add_var ["OCaml"; "Pervasives"] "int_of_char" Pure
-  |> add_var ["OCaml"; "Pervasives"] "char_of_int" (Arrow (d [["OCaml"], "Invalid_argument"], Pure))
+  |> Var.add ["OCaml"; "Pervasives"] "int_of_char" Pure
+  |> Var.add ["OCaml"; "Pervasives"] "char_of_int" (Arrow (d [["OCaml"], "Invalid_argument"], Pure))
   (* Unit operations *)
-  |> add_var ["OCaml"; "Pervasives"] "ignore" Pure
+  |> Var.add ["OCaml"; "Pervasives"] "ignore" Pure
   (* String conversion functions *)
-  |> add_var ["OCaml"; "Pervasives"] "string_of_bool" Pure
-  |> add_var ["OCaml"; "Pervasives"] "bool_of_string" Pure
-  |> add_var ["OCaml"; "Pervasives"] "string_of_int" Pure
-  |> add_var ["OCaml"; "Pervasives"] "int_of_string" Pure
+  |> Var.add ["OCaml"; "Pervasives"] "string_of_bool" Pure
+  |> Var.add ["OCaml"; "Pervasives"] "bool_of_string" Pure
+  |> Var.add ["OCaml"; "Pervasives"] "string_of_int" Pure
+  |> Var.add ["OCaml"; "Pervasives"] "int_of_string" Pure
   (* Pair operations *)
-  |> add_var [] "fst" Pure
-  |> add_var [] "snd" Pure
+  |> Var.add [] "fst" Pure
+  |> Var.add [] "snd" Pure
   (* List operations *)
-  |> add_var ["OCaml"; "Pervasives"] "app" Pure
+  |> Var.add ["OCaml"; "Pervasives"] "app" Pure
   (* Input/output *)
   (* Output functions on standard output *)
-  |> add_var ["OCaml"; "Pervasives"] "print_char" (Arrow (d [[], "IO"], Pure))
-  |> add_var ["OCaml"; "Pervasives"] "print_string" (Arrow (d [[], "IO"], Pure))
-  |> add_var ["OCaml"; "Pervasives"] "print_int" (Arrow (d [[], "IO"], Pure))
-  |> add_var ["OCaml"; "Pervasives"] "print_endline" (Arrow (d [[], "IO"], Pure))
-  |> add_var ["OCaml"; "Pervasives"] "print_newline" (Arrow (d [[], "IO"], Pure))
+  |> Var.add ["OCaml"; "Pervasives"] "print_char" (Arrow (d [[], "IO"], Pure))
+  |> Var.add ["OCaml"; "Pervasives"] "print_string" (Arrow (d [[], "IO"], Pure))
+  |> Var.add ["OCaml"; "Pervasives"] "print_int" (Arrow (d [[], "IO"], Pure))
+  |> Var.add ["OCaml"; "Pervasives"] "print_endline" (Arrow (d [[], "IO"], Pure))
+  |> Var.add ["OCaml"; "Pervasives"] "print_newline" (Arrow (d [[], "IO"], Pure))
   (* Output functions on standard error *)
-  |> add_var ["OCaml"; "Pervasives"] "prerr_char" (Arrow (d [[], "IO"], Pure))
-  |> add_var ["OCaml"; "Pervasives"] "prerr_string" (Arrow (d [[], "IO"], Pure))
-  |> add_var ["OCaml"; "Pervasives"] "prerr_int" (Arrow (d [[], "IO"], Pure))
-  |> add_var ["OCaml"; "Pervasives"] "prerr_endline" (Arrow (d [[], "IO"], Pure))
-  |> add_var ["OCaml"; "Pervasives"] "prerr_newline" (Arrow (d [[], "IO"], Pure))
+  |> Var.add ["OCaml"; "Pervasives"] "prerr_char" (Arrow (d [[], "IO"], Pure))
+  |> Var.add ["OCaml"; "Pervasives"] "prerr_string" (Arrow (d [[], "IO"], Pure))
+  |> Var.add ["OCaml"; "Pervasives"] "prerr_int" (Arrow (d [[], "IO"], Pure))
+  |> Var.add ["OCaml"; "Pervasives"] "prerr_endline" (Arrow (d [[], "IO"], Pure))
+  |> Var.add ["OCaml"; "Pervasives"] "prerr_newline" (Arrow (d [[], "IO"], Pure))
   (* Input functions on standard input *)
-  |> add_var ["OCaml"; "Pervasives"] "read_line" (Arrow (d [[], "IO"], Pure))
-  |> add_var ["OCaml"; "Pervasives"] "read_int" (Arrow (d [[], "IO"], Pure))
+  |> Var.add ["OCaml"; "Pervasives"] "read_line" (Arrow (d [[], "IO"], Pure))
+  |> Var.add ["OCaml"; "Pervasives"] "read_int" (Arrow (d [[], "IO"], Pure))
   (* General output functions *)
   (* General input functions *)
   (* Operations on large files *)
   (* References *)
-  |> add_var ["OCaml"; "Pervasives"] "ref" Pure
+  |> Var.add ["OCaml"; "Pervasives"] "ref" Pure
   (* Operations on format strings *)
   (* Program termination *)
 

--- a/src/primitiveDeclaration.ml
+++ b/src/primitiveDeclaration.ml
@@ -29,17 +29,17 @@ let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t) (desc : value_description)
     let (typ, _, new_typ_vars) =
       Type.of_type_expr_new_typ_vars env loc Name.Map.empty type_expr in
     let name = Name.of_ident desc.val_id in
-    let coq_name = (FullEnvi.resolve_var [] name env).base in
+    let coq_name = (FullEnvi.Var.resolve [] name env).base in
     { name = CoqName.of_names name coq_name;
       typ_args = Name.Set.elements new_typ_vars;
       typ }
 
 let update_env (prim : t) (env : unit FullEnvi.t) : unit FullEnvi.t =
   let (name, coq_name) = CoqName.assoc_names prim.name in
-  FullEnvi.assoc_var [] name coq_name () env
+  FullEnvi.Var.assoc [] name coq_name () env
 
 (* TODO: Update to reflect that primitives are not usually pure. *)
 let update_env_with_effects (prim : t) (env : Effect.Type.t FullEnvi.t)
   : Effect.Type.t FullEnvi.t =
   let (name, coq_name) = CoqName.assoc_names prim.name in
-  FullEnvi.assoc_var [] name coq_name Effect.Type.Pure env
+  FullEnvi.Var.assoc [] name coq_name Effect.Type.Pure env

--- a/src/reference.ml
+++ b/src/reference.ml
@@ -27,9 +27,9 @@ let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t) (cases : value_binding list)
     vb_expr = { exp_type = {Types.desc = Types.Tconstr (_, [typ], _) };
                 exp_desc = Texp_apply (_, [(_, Some expr)]) }}] ->
     let name = Name.of_ident x in
-    let coq_name = (FullEnvi.resolve_var [] name env).base in
+    let coq_name = (FullEnvi.Var.resolve [] name env).base in
     let state_name = name ^ "_state" in
-    let coq_state_name = (FullEnvi.resolve_descriptor [] state_name env).base in
+    let coq_state_name = (FullEnvi.Descriptor.resolve [] state_name env).base in
     { name = CoqName.of_names name coq_name;
       state_name = CoqName.of_names state_name coq_state_name;
       typ = Type.of_type_expr env loc typ;
@@ -41,8 +41,8 @@ let update_env (update_exp : unit FullEnvi.t -> 'a Exp.t -> 'b Exp.t)
   let (name, coq_name) = CoqName.assoc_names r.name in
   let (state_name, coq_state_name) = CoqName.assoc_names r.state_name in
   let env = env
-  |> FullEnvi.assoc_var [] name coq_name ()
-  |> FullEnvi.assoc_descriptor [] state_name coq_state_name in
+  |> FullEnvi.Var.assoc [] name coq_name ()
+  |> FullEnvi.Descriptor.assoc [] state_name coq_state_name in
   (env, {r with expr = update_exp env r.expr})
 
 let update_env_with_effects (r : (Loc.t * Type.t) t)
@@ -51,8 +51,8 @@ let update_env_with_effects (r : (Loc.t * Type.t) t)
   let (name, coq_name) = CoqName.assoc_names r.name in
   let (state_name, coq_state_name) = CoqName.assoc_names r.state_name in
   let env = env
-  |> FullEnvi.assoc_var [] name coq_name Effect.Type.Pure
-  |> FullEnvi.assoc_descriptor [] state_name coq_state_name in
+  |> FullEnvi.Var.assoc [] name coq_name Effect.Type.Pure
+  |> FullEnvi.Descriptor.assoc [] state_name coq_state_name in
   (env, {r with expr = Exp.effects env r.expr})
 
 let to_coq (r : 'a t) : SmartPrint.t =

--- a/src/type.ml
+++ b/src/type.ml
@@ -50,7 +50,7 @@ let rec of_type_expr_new_typ_vars (env : 'a FullEnvi.t) (loc : Loc.t)
     (Tuple typs, typ_vars, new_typ_vars)
   | Tconstr (path, typs, _) ->
     let (typs, typ_vars, new_typ_vars) = of_typs_exprs_new_free_vars env loc typ_vars typs in
-    let x = FullEnvi.bound_typ loc (PathName.of_type_path loc path) env in
+    let x = FullEnvi.Typ.bound loc (PathName.of_type_path loc path) env in
     (Apply (x, typs), typ_vars, new_typ_vars)
   | Tlink typ -> of_type_expr_new_typ_vars env loc typ_vars typ
   | Tpoly (typ, []) -> of_type_expr_new_typ_vars env loc typ_vars typ
@@ -78,7 +78,7 @@ let rec of_type_expr ?allow_anon:(anon_var=false) (env : 'a FullEnvi.t)
   | Ttuple typs ->
     Tuple (List.map (of_type_expr ~allow_anon:anon_var env loc) typs)
   | Tconstr (path, typs, _) ->
-    let x = FullEnvi.bound_typ loc (PathName.of_type_path loc path) env in
+    let x = FullEnvi.Typ.bound loc (PathName.of_type_path loc path) env in
     Apply (x, List.map (of_type_expr ~allow_anon:anon_var env loc) typs)
   | Tlink typ -> of_type_expr ~allow_anon:anon_var env loc typ
   | Tpoly (typ, []) -> of_type_expr ~allow_anon:anon_var env loc typ
@@ -102,7 +102,7 @@ let rec type_effects (env : Effect.Type.t FullEnvi.t) (typ : t)
     Effect.Type.union (List.map (type_effects env) [typ1; typ2])
   | Tuple typs -> Effect.Type.union (List.map (type_effects env) typs)
   | Apply (x, typs) ->
-    Effect.Type.union (FullEnvi.find_typ x env Effect.Type.depth_lift ::
+    Effect.Type.union (FullEnvi.Typ.find x env Effect.Type.depth_lift ::
       List.map (type_effects env) typs)
   | Monad (x, typ) -> type_effects env typ
 


### PR DESCRIPTION
This PR makes various changes to reduce the size and complexity of the `FullEnvi` and `FullMod` modules. The biggest changes are:
* moving from `FullEnvi.resolve_descriptor`/`assoc_typ`/`bound_var`/... to `FullEnvi.Descriptor.resolve`/`Typ.assoc`/`Var.bound`/..., while completely bypassing the `FullMod` intermediaries
* Adding `FullMod.hd_mod_map` and using it via `FullEnvi.update_active` to remove several trivial `FullMod` functions

This is a no-op.