### PR TITLE
Consider where guards on match branches

### DIFF
--- a/src/loc.ml
+++ b/src/loc.ml
@@ -18,5 +18,10 @@ let to_user (l : t) : SmartPrint.t =
     let (file_name, line, _) = Location.get_pos_info start in
     !^ file_name ^-^ !^ "," ^^ !^ "line" ^^ OCaml.int line
 
+let to_tuple (l : t) : string * int * int =
+  match l with
+  | Unknown -> ("", 0, 0)
+  | Known (start, _) -> Location.get_pos_info start
+
 let of_location (l : Location.t) : t =
   Known (l.Location.loc_start, l.Location.loc_end)

--- a/tests/ex33.effects
+++ b/tests/ex33.effects
@@ -5185,6 +5185,7 @@ Value
               ([
                 Counter/3;
                 OCaml.Invalid_argument/3;
+                OCaml.Match_failure/3;
                 NonTermination/3;
                 OCaml.Not_found/3
               ], .)), Variable ((?, Effect ([ ], .)), counter/0),
@@ -5217,42 +5218,202 @@ Value
                               .)))
                     ]));
               (Constructor (S/3, counter),
+                LetVar
+                  (?,
+                    Effect
+                      ([
+                        Counter/3;
+                        OCaml.Invalid_argument/3;
+                        OCaml.Match_failure/3;
+                        NonTermination/3;
+                        OCaml.Not_found/3
+                      ],
+                        .))
+                  i =
+                  Match
+                    ((?,
+                      Effect
+                        ([
+                        ],
+                          .)),
+                      Tuple
+                        ((233,
+                          Effect
+                            ([
+                            ],
+                              .)),
+                          Variable
+                            ((233,
+                              Effect
+                                ([
+                                ],
+                                  .)),
+                              s1/0),
+                          Variable
+                            ((233,
+                              Effect
+                                ([
+                                ],
+                                  .)),
+                              s2/0)),
+                      [
+                        (Tuple
+                          (Constructor
+                            (Empty/0),
+                            Constructor
+                              (Empty/0)),
+                          Constant
+                            ((?,
+                              Effect
+                                ([
+                                ],
+                                  .)),
+                              Int(0)));
+                        (Tuple
+                          (Constructor
+                            (Node/0,
+                              l1,
+                              v1,
+                              d1,
+                              r1,
+                              h1),
+                            Any),
+                          IfThenElse
+                            ((?,
+                              Effect
+                                ([
+                                ],
+                                  .)),
+                              Apply
+                                ((235,
+                                  Effect
+                                    ([
+                                    ],
+                                      .)),
+                                  Variable
+                                    ((235,
+                                      Effect
+                                        ([
+                                        ],
+                                          .)),
+                                      OCaml.Pervasives.ge/3),
+                                  [
+                                    Variable
+                                      ((235,
+                                        Effect
+                                          ([
+                                          ],
+                                            .)),
+                                        h1/0);
+                                    Apply
+                                      ((235,
+                                        Effect
+                                          ([
+                                          ],
+                                            .)),
+                                        Variable
+                                          ((235,
+                                            Effect
+                                              ([
+                                              ],
+                                                .
+                                                  ->
+                                                  .)),
+                                            height/0),
+                                        [
+                                          Variable
+                                            ((235,
+                                              Effect
+                                                ([
+                                                ],
+                                                  .)),
+                                              s2/0)
+                                        ])
+                                  ]),
+                              Constant
+                                ((?,
+                                  Effect
+                                    ([
+                                    ],
+                                      .)),
+                                  Int(1)),
+                              Constant
+                                ((?,
+                                  Effect
+                                    ([
+                                    ],
+                                      .)),
+                                  Int(0))));
+                        (Tuple
+                          (Any,
+                            Constructor
+                              (Node/0,
+                                l2,
+                                v2,
+                                d2,
+                                r2,
+                                h2)),
+                          Constant
+                            ((?,
+                              Effect
+                                ([
+                                ],
+                                  .)),
+                              Int(0)))
+                      ])
+                  in
                 Match
                   ((233,
                     Effect
                       ([
                         Counter/3;
                         OCaml.Invalid_argument/3;
+                        OCaml.Match_failure/3;
                         NonTermination/3;
                         OCaml.Not_found/3
                       ],
                         .)),
                     Tuple
-                      ((233,
+                      ((?,
                         Effect
                           ([
                           ],
                             .)),
-                        Variable
+                        Tuple
                           ((233,
                             Effect
                               ([
                               ],
                                 .)),
-                            s1/0),
+                            Variable
+                              ((233,
+                                Effect
+                                  ([
+                                  ],
+                                    .)),
+                                s1/0),
+                            Variable
+                              ((233,
+                                Effect
+                                  ([
+                                  ],
+                                    .)),
+                                s2/0)),
                         Variable
-                          ((233,
+                          ((?,
                             Effect
                               ([
                               ],
                                 .)),
-                            s2/0)),
+                            i/0)),
                     [
                       (Tuple
-                        (Constructor
-                          (Empty/0),
-                          Constructor
-                            (Empty/0)),
+                        (Tuple
+                          (Constructor
+                            (Empty/0),
+                            Constructor
+                              (Empty/0)),
+                          Any),
                         Constructor
                           ((234,
                             Effect
@@ -5261,20 +5422,23 @@ Value
                                 .)),
                             Empty/0));
                       (Tuple
-                        (Constructor
-                          (Node/0,
-                            l1,
-                            v1,
-                            d1,
-                            r1,
-                            h1),
-                          Any),
+                        (Tuple
+                          (Constructor
+                            (Node/0,
+                              l1,
+                              v1,
+                              d1,
+                              r1,
+                              h1),
+                            Any),
+                          Int(1)),
                         Match
                           ((236,
                             Effect
                               ([
                                 Counter/3;
                                 OCaml.Invalid_argument/3;
+                                OCaml.Match_failure/3;
                                 NonTermination/3;
                                 OCaml.Not_found/3
                               ],
@@ -5330,6 +5494,7 @@ Value
                                       ([
                                         Counter/3;
                                         OCaml.Invalid_argument/3;
+                                        OCaml.Match_failure/3;
                                         NonTermination/3;
                                         OCaml.Not_found/3
                                       ],
@@ -5361,6 +5526,7 @@ Value
                                             ([
                                               Counter/3;
                                               OCaml.Invalid_argument/3;
+                                              OCaml.Match_failure/3;
                                               NonTermination/3;
                                               OCaml.Not_found/3
                                             ],
@@ -5378,6 +5544,7 @@ Value
                                                         -[
                                                           Counter/3;
                                                           OCaml.Invalid_argument/3;
+                                                          OCaml.Match_failure/3;
                                                           NonTermination/3;
                                                           OCaml.Not_found/3
                                                         ]->
@@ -5397,6 +5564,7 @@ Value
                                                               -[
                                                                 Counter/3;
                                                                 OCaml.Invalid_argument/3;
+                                                                OCaml.Match_failure/3;
                                                                 NonTermination/3;
                                                                 OCaml.Not_found/3
                                                               ]->
@@ -5490,6 +5658,7 @@ Value
                                             ([
                                               Counter/3;
                                               OCaml.Invalid_argument/3;
+                                              OCaml.Match_failure/3;
                                               NonTermination/3;
                                               OCaml.Not_found/3
                                             ],
@@ -5507,6 +5676,7 @@ Value
                                                         -[
                                                           Counter/3;
                                                           OCaml.Invalid_argument/3;
+                                                          OCaml.Match_failure/3;
                                                           NonTermination/3;
                                                           OCaml.Not_found/3
                                                         ]->
@@ -5526,6 +5696,7 @@ Value
                                                               -[
                                                                 Counter/3;
                                                                 OCaml.Invalid_argument/3;
+                                                                OCaml.Match_failure/3;
                                                                 NonTermination/3;
                                                                 OCaml.Not_found/3
                                                               ]->
@@ -5566,20 +5737,23 @@ Value
                                     ]))
                             ]));
                       (Tuple
-                        (Any,
-                          Constructor
-                            (Node/0,
-                              l2,
-                              v2,
-                              d2,
-                              r2,
-                              h2)),
+                        (Tuple
+                          (Any,
+                            Constructor
+                              (Node/0,
+                                l2,
+                                v2,
+                                d2,
+                                r2,
+                                h2)),
+                          Any),
                         Match
                           ((239,
                             Effect
                               ([
                                 Counter/3;
                                 OCaml.Invalid_argument/3;
+                                OCaml.Match_failure/3;
                                 NonTermination/3;
                                 OCaml.Not_found/3
                               ],
@@ -5635,6 +5809,7 @@ Value
                                       ([
                                         Counter/3;
                                         OCaml.Invalid_argument/3;
+                                        OCaml.Match_failure/3;
                                         NonTermination/3;
                                         OCaml.Not_found/3
                                       ],
@@ -5666,6 +5841,7 @@ Value
                                             ([
                                               Counter/3;
                                               OCaml.Invalid_argument/3;
+                                              OCaml.Match_failure/3;
                                               NonTermination/3;
                                               OCaml.Not_found/3
                                             ],
@@ -5683,6 +5859,7 @@ Value
                                                         -[
                                                           Counter/3;
                                                           OCaml.Invalid_argument/3;
+                                                          OCaml.Match_failure/3;
                                                           NonTermination/3;
                                                           OCaml.Not_found/3
                                                         ]->
@@ -5702,6 +5879,7 @@ Value
                                                               -[
                                                                 Counter/3;
                                                                 OCaml.Invalid_argument/3;
+                                                                OCaml.Match_failure/3;
                                                                 NonTermination/3;
                                                                 OCaml.Not_found/3
                                                               ]->
@@ -5795,6 +5973,7 @@ Value
                                             ([
                                               Counter/3;
                                               OCaml.Invalid_argument/3;
+                                              OCaml.Match_failure/3;
                                               NonTermination/3;
                                               OCaml.Not_found/3
                                             ],
@@ -5812,6 +5991,7 @@ Value
                                                         -[
                                                           Counter/3;
                                                           OCaml.Invalid_argument/3;
+                                                          OCaml.Match_failure/3;
                                                           NonTermination/3;
                                                           OCaml.Not_found/3
                                                         ]->
@@ -5831,6 +6011,7 @@ Value
                                                               -[
                                                                 Counter/3;
                                                                 OCaml.Invalid_argument/3;
+                                                                OCaml.Match_failure/3;
                                                                 NonTermination/3;
                                                                 OCaml.Not_found/3
                                                               ]->
@@ -5869,6 +6050,54 @@ Value
                                                 r2/0)
                                           ])
                                     ]))
+                            ]));
+                      (Any,
+                        Apply
+                          ((?,
+                            Effect
+                              ([
+                                OCaml.Match_failure/3
+                              ],
+                                .)),
+                            Variable
+                              ((?,
+                                Effect
+                                  ([
+                                  ],
+                                    .
+                                      -[
+                                        OCaml.Match_failure/3
+                                      ]->
+                                      .)),
+                                OCaml.raise_Match_failure/3),
+                            [
+                              Tuple
+                                ((?,
+                                  Effect
+                                    ([
+                                    ],
+                                      .)),
+                                  Constant
+                                    ((?,
+                                      Effect
+                                        ([
+                                        ],
+                                          .)),
+                                      String("tests/ex33.ml")),
+                                  Constant
+                                    ((?,
+                                      Effect
+                                        ([
+                                        ],
+                                          .)),
+                                      Int(233)),
+                                  Constant
+                                    ((?,
+                                      Effect
+                                        ([
+                                        ],
+                                          .)),
+                                      Int(2)))
                             ]))
                     ]))
             ]))
@@ -5894,6 +6123,7 @@ Value
               ([
                 Counter/3;
                 OCaml.Invalid_argument/3;
+                OCaml.Match_failure/3;
                 NonTermination/3;
                 OCaml.Not_found/3
               ], .)),
@@ -5908,6 +6138,7 @@ Value
                             -[
                               Counter/3;
                               OCaml.Invalid_argument/3;
+                              OCaml.Match_failure/3;
                               NonTermination/3;
                               OCaml.Not_found/3
                             ]-> .)), merge_rec/0),

--- a/tests/ex33.exp
+++ b/tests/ex33.exp
@@ -2264,34 +2264,114 @@ Value
                         (?)
                     ]));
               (Constructor (S/3, counter),
+                LetVar ? i =
+                  Match
+                    (?,
+                      Tuple
+                        (233,
+                          Variable
+                            (233,
+                              s1/0),
+                          Variable
+                            (233,
+                              s2/0)),
+                      [
+                        (Tuple
+                          (Constructor
+                            (Empty/0),
+                            Constructor
+                              (Empty/0)),
+                          Constant
+                            (?,
+                              Int(0)));
+                        (Tuple
+                          (Constructor
+                            (Node/0,
+                              l1,
+                              v1,
+                              d1,
+                              r1,
+                              h1),
+                            Any),
+                          IfThenElse
+                            (?,
+                              Apply
+                                (235,
+                                  Variable
+                                    (235,
+                                      OCaml.Pervasives.ge/3),
+                                  [
+                                    Variable
+                                      (235,
+                                        h1/0);
+                                    Apply
+                                      (235,
+                                        Variable
+                                          (235,
+                                            height/0),
+                                        [
+                                          Variable
+                                            (235,
+                                              s2/0)
+                                        ])
+                                  ]),
+                              Constant
+                                (?,
+                                  Int(1)),
+                              Constant
+                                (?,
+                                  Int(0))));
+                        (Tuple
+                          (Any,
+                            Constructor
+                              (Node/0,
+                                l2,
+                                v2,
+                                d2,
+                                r2,
+                                h2)),
+                          Constant
+                            (?,
+                              Int(0)))
+                      ])
+                  in
                 Match
                   (233,
                     Tuple
-                      (233,
-                        Variable
+                      (?,
+                        Tuple
                           (233,
-                            s1/0),
+                            Variable
+                              (233,
+                                s1/0),
+                            Variable
+                              (233,
+                                s2/0)),
                         Variable
-                          (233,
-                            s2/0)),
+                          (?,
+                            i/0)),
                     [
                       (Tuple
-                        (Constructor
-                          (Empty/0),
-                          Constructor
-                            (Empty/0)),
+                        (Tuple
+                          (Constructor
+                            (Empty/0),
+                            Constructor
+                              (Empty/0)),
+                          Any),
                         Constructor
                           (234,
                             Empty/0));
                       (Tuple
-                        (Constructor
-                          (Node/0,
-                            l1,
-                            v1,
-                            d1,
-                            r1,
-                            h1),
-                          Any),
+                        (Tuple
+                          (Constructor
+                            (Node/0,
+                              l1,
+                              v1,
+                              d1,
+                              r1,
+                              h1),
+                            Any),
+                          Int(1)),
                         Match
                           (236,
                             Apply
@@ -2389,14 +2469,16 @@ Value
                                     ]))
                             ]));
                       (Tuple
-                        (Any,
-                          Constructor
-                            (Node/0,
-                              l2,
-                              v2,
-                              d2,
-                              r2,
-                              h2)),
+                        (Tuple
+                          (Any,
+                            Constructor
+                              (Node/0,
+                                l2,
+                                v2,
+                                d2,
+                                r2,
+                                h2)),
+                          Any),
                         Match
                           (239,
                             Apply
@@ -2492,6 +2574,25 @@ Value
                                                 r2/0)
                                           ])
                                     ]))
+                            ]));
+                      (Any,
+                        Apply
+                          (?,
+                            Variable
+                              (?,
+                                OCaml.raise_Match_failure/3),
+                            [
+                              Tuple
+                                (?,
+                                  Constant
+                                    (?,
+                                      String("tests/ex33.ml")),
+                                  Constant
+                                    (?,
+                                      Int(233)),
+                                  Constant
+                                    (?,
+                                      Int(2)))
                             ]))
                     ]))
             ]))

--- a/tests/ex33.interface
+++ b/tests/ex33.interface
@@ -43,9 +43,18 @@
       [
         "Var",
         "merge_rec",
-        [ [], [], [], [ "Counter", "OCaml.Invalid_argument", "NonTermination", "OCaml.Not_found" ] ]
+        [
+          [],
+          [],
+          [],
+          [ "Counter", "OCaml.Invalid_argument", "OCaml.Match_failure", "NonTermination", "OCaml.Not_found" ]
+        ]
       ],
-      [ "Var", "merge", [ [], [], [ "Counter", "OCaml.Invalid_argument", "NonTermination", "OCaml.Not_found" ] ] ],
+      [
+        "Var",
+        "merge",
+        [ [], [], [ "Counter", "OCaml.Invalid_argument", "OCaml.Match_failure", "NonTermination", "OCaml.Not_found" ] ]
+      ],
       [ "Var", "filter", [ [], [ "Counter", "OCaml.Invalid_argument", "NonTermination", "OCaml.Not_found" ] ] ],
       [ "Var", "partition", [ [], [ "Counter", "OCaml.Invalid_argument", "NonTermination", "OCaml.Not_found" ] ] ],
       [ "Typ", "enumeration" ],

--- a/tests/ex33.monadise
+++ b/tests/ex33.monadise
@@ -2565,6 +2565,7 @@ Value
           ([
             Counter/3;
             OCaml.Invalid_argument/3;
+            OCaml.Match_failure/3;
             NonTermination/3;
             OCaml.Not_found/3
           ], Type (t/0, C))),
@@ -2580,6 +2581,7 @@ Value
                     [
                       Counter/3;
                       OCaml.Invalid_argument/3;
+                      OCaml.Match_failure/3;
                       NonTermination/3;
                       OCaml.Not_found/3
                     ],
@@ -2593,36 +2595,116 @@ Value
                             (?)
                         ])));
               (Constructor (S/3, counter),
+                LetVar ? i =
+                  Match
+                    (?,
+                      Tuple
+                        (233,
+                          Variable
+                            (233,
+                              s1/0),
+                          Variable
+                            (233,
+                              s2/0)),
+                      [
+                        (Tuple
+                          (Constructor
+                            (Empty/0),
+                            Constructor
+                              (Empty/0)),
+                          Constant
+                            (?,
+                              Int(0)));
+                        (Tuple
+                          (Constructor
+                            (Node/0,
+                              l1,
+                              v1,
+                              d1,
+                              r1,
+                              h1),
+                            Any),
+                          IfThenElse
+                            (?,
+                              Apply
+                                (235,
+                                  Variable
+                                    (235,
+                                      OCaml.Pervasives.ge/3),
+                                  [
+                                    Variable
+                                      (235,
+                                        h1/0);
+                                    Apply
+                                      (235,
+                                        Variable
+                                          (235,
+                                            height/0),
+                                        [
+                                          Variable
+                                            (235,
+                                              s2/0)
+                                        ])
+                                  ]),
+                              Constant
+                                (?,
+                                  Int(1)),
+                              Constant
+                                (?,
+                                  Int(0))));
+                        (Tuple
+                          (Any,
+                            Constructor
+                              (Node/0,
+                                l2,
+                                v2,
+                                d2,
+                                r2,
+                                h2)),
+                          Constant
+                            (?,
+                              Int(0)))
+                      ])
+                  in
                 Match
                   (233,
                     Tuple
-                      (233,
-                        Variable
+                      (?,
+                        Tuple
                           (233,
-                            s1/0),
+                            Variable
+                              (233,
+                                s1/0),
+                            Variable
+                              (233,
+                                s2/0)),
                         Variable
-                          (233,
-                            s2/0)),
+                          (?,
+                            i/0)),
                     [
                       (Tuple
-                        (Constructor
-                          (Empty/0),
-                          Constructor
-                            (Empty/0)),
+                        (Tuple
+                          (Constructor
+                            (Empty/0),
+                            Constructor
+                              (Empty/0)),
+                          Any),
                         Return
                           (?,
                             Constructor
                               (234,
                                 Empty/0)));
                       (Tuple
-                        (Constructor
-                          (Node/0,
-                            l1,
-                            v1,
-                            d1,
-                            r1,
-                            h1),
-                          Any),
+                        (Tuple
+                          (Constructor
+                            (Node/0,
+                              l1,
+                              v1,
+                              d1,
+                              r1,
+                              h1),
+                            Any),
+                          Int(1)),
                         Bind
                           (?,
                             Lift
@@ -2635,6 +2717,7 @@ Value
                                 [
                                   Counter/3;
                                   OCaml.Invalid_argument/3;
+                                  OCaml.Match_failure/3;
                                   NonTermination/3;
                                   OCaml.Not_found/3
                                 ],
@@ -2717,51 +2800,68 @@ Value
                                                 ]),
                                             Some
                                               x_1,
-                                            Apply
-                                              (237,
-                                                Variable
-                                                  (237,
-                                                    concat_or_join/0),
+                                            Lift
+                                              (?,
                                                 [
-                                                  Variable
-                                                    (?,
-                                                      x/0);
-                                                  Variable
-                                                    (237,
-                                                      v1/0);
-                                                  Apply
-                                                    (237,
+                                                  Counter/3;
+                                                  OCaml.Invalid_argument/3;
+                                                  NonTermination/3;
+                                                  OCaml.Not_found/3
+                                                ],
+                                                [
+                                                  Counter/3;
+                                                  OCaml.Invalid_argument/3;
+                                                  OCaml.Match_failure/3;
+                                                  NonTermination/3;
+                                                  OCaml.Not_found/3
+                                                ],
+                                                Apply
+                                                  (237,
+                                                    Variable
+                                                      (237,
+                                                        concat_or_join/0),
+                                                    [
+                                                      Variable
+                                                        (?,
+                                                          x/0);
                                                       Variable
                                                         (237,
-                                                          f/0),
-                                                      [
-                                                        Variable
-                                                          (237,
-                                                            v1/0);
-                                                        Constructor
-                                                          (237,
-                                                            Some/3,
+                                                          v1/0);
+                                                      Apply
+                                                        (237,
+                                                          Variable
+                                                            (237,
+                                                              f/0),
+                                                          [
                                                             Variable
                                                               (237,
-                                                                d1/0));
-                                                        Variable
-                                                          (237,
-                                                            d2/0)
-                                                      ]);
-                                                  Variable
-                                                    (?,
-                                                      x_1/0)
-                                                ]))))
+                                                                v1/0);
+                                                            Constructor
+                                                              (237,
+                                                                Some/3,
+                                                                Variable
+                                                                  (237,
+                                                                    d1/0));
+                                                            Variable
+                                                              (237,
+                                                                d2/0)
+                                                          ]);
+                                                      Variable
+                                                        (?,
+                                                          x_1/0)
+                                                    ])))))
                                 ])));
                       (Tuple
-                        (Any,
-                          Constructor
-                            (Node/0,
-                              l2,
-                              v2,
-                              d2,
-                              r2,
-                              h2)),
+                        (Tuple
+                          (Any,
+                            Constructor
+                              (Node/0,
+                                l2,
+                                v2,
+                                d2,
+                                r2,
+                                h2)),
+                          Any),
                         Bind
                           (?,
                             Lift
@@ -2774,6 +2874,7 @@ Value
                                 [
                                   Counter/3;
                                   OCaml.Invalid_argument/3;
+                                  OCaml.Match_failure/3;
                                   NonTermination/3;
                                   OCaml.Not_found/3
                                 ],
@@ -2856,41 +2957,87 @@ Value
                                                 ]),
                                             Some
                                               x_1,
-                                            Apply
-                                              (240,
-                                                Variable
-                                                  (240,
-                                                    concat_or_join/0),
+                                            Lift
+                                              (?,
                                                 [
-                                                  Variable
-                                                    (?,
-                                                      x/0);
-                                                  Variable
-                                                    (240,
-                                                      v2/0);
-                                                  Apply
-                                                    (240,
+                                                  Counter/3;
+                                                  OCaml.Invalid_argument/3;
+                                                  NonTermination/3;
+                                                  OCaml.Not_found/3
+                                                ],
+                                                [
+                                                  Counter/3;
+                                                  OCaml.Invalid_argument/3;
+                                                  OCaml.Match_failure/3;
+                                                  NonTermination/3;
+                                                  OCaml.Not_found/3
+                                                ],
+                                                Apply
+                                                  (240,
+                                                    Variable
+                                                      (240,
+                                                        concat_or_join/0),
+                                                    [
+                                                      Variable
+                                                        (?,
+                                                          x/0);
                                                       Variable
                                                         (240,
-                                                          f/0),
-                                                      [
-                                                        Variable
-                                                          (240,
-                                                            v2/0);
-                                                        Variable
-                                                          (240,
-                                                            d1/0);
-                                                        Constructor
-                                                          (240,
-                                                            Some/3,
+                                                          v2/0);
+                                                      Apply
+                                                        (240,
+                                                          Variable
+                                                            (240,
+                                                              f/0),
+                                                          [
                                                             Variable
                                                               (240,
-                                                                d2/0))
-                                                      ]);
-                                                  Variable
-                                                    (?,
-                                                      x_1/0)
-                                                ]))))
+                                                                v2/0);
+                                                            Variable
+                                                              (240,
+                                                                d1/0);
+                                                            Constructor
+                                                              (240,
+                                                                Some/3,
+                                                                Variable
+                                                                  (240,
+                                                                    d2/0))
+                                                          ]);
+                                                      Variable
+                                                        (?,
+                                                          x_1/0)
+                                                    ])))))
+                                ])));
+                      (Any,
+                        Lift
+                          (?,
+                            [
+                              OCaml.Match_failure/3
+                            ],
+                            [
+                              Counter/3;
+                              OCaml.Invalid_argument/3;
+                              OCaml.Match_failure/3;
+                              NonTermination/3;
+                              OCaml.Not_found/3
+                            ],
+                            Apply
+                              (?,
+                                Variable
+                                  (?,
+                                    OCaml.raise_Match_failure/3),
+                                [
+                                  Tuple
+                                    (?,
+                                      Constant
+                                        (?,
+                                          String("tests/ex33.ml")),
+                                      Constant
+                                        (?,
+                                          Int(233)),
+                                      Constant
+                                        (?,
+                                          Int(2)))
                                 ])))
                     ]))
             ]))
@@ -2914,6 +3061,7 @@ Value
           ([
             Counter/3;
             OCaml.Invalid_argument/3;
+            OCaml.Match_failure/3;
             NonTermination/3;
             OCaml.Not_found/3
           ], Type (t/0, C))),
@@ -2924,6 +3072,7 @@ Value
                 [
                   Counter/3;
                   OCaml.Invalid_argument/3;
+                  OCaml.Match_failure/3;
                   NonTermination/3;
                   OCaml.Not_found/3
                 ],


### PR DESCRIPTION
This adds the ability to transpile `match ... with ... when ...` statements properly. In order to keep the tests passing, it also adds a catch-all final branch to raise a `Match_failure` if none of the branches match.