### PR TITLE
Type Unification for Effects

### DIFF
--- a/OCaml/Effect.v
+++ b/OCaml/Effect.v
@@ -82,6 +82,38 @@ Module Effect.
         + exact (fst s2, expand_state ebs s1 (snd s2)).
     Defined.
   End Ebs.
+
+  Module Lens.
+    Fixpoint get_state (n : nat) (es : list t) {struct es}
+      : state es -> S (List.nth n es Effect.nil).
+      destruct es as [ | e es];
+        destruct n as [ | n].
+      - exact (fun _ => tt).
+      - exact (fun _ => tt).
+      - destruct 1 as [s ss].
+        exact s.
+      - destruct 1 as [s ss].
+        exact (get_state n es ss).
+    Defined.
+
+    Fixpoint set_state (n : nat) (es : list t) {struct es}
+      : S (List.nth n es Effect.nil) -> state es -> state es.
+      destruct es as [ | e es].
+      - exact (fun _ ss => ss).
+      - destruct n as [ | n].
+        * exact (fun s ss => (s, snd ss)).
+        * exact (fun s ss => (fst ss, set_state n es s (snd ss))).
+    Defined.
+
+    Fixpoint set_error (n : nat) (es : list t) {struct es}
+      : E (List.nth n es Effect.nil) -> error es.
+      destruct es as [ | e es].
+      - destruct n; destruct 1.
+      - destruct n as [ | n].
+        * exact (fun e => inl e).
+        * exact (fun e => inr (set_error n es e)).
+    Defined.
+  End Lens.
 End Effect.
 
 Module Raw.
@@ -305,6 +337,324 @@ Module Run.
       | inr err => False_rect _ (error_is_empty err)
       end.
 End Run.
+
+Module Union.
+  Open Scope nat.
+
+  Definition INPUT (es_in es_out : list Effect.t) : Type :=
+    forall (n : nat), Effect.S (List.nth n es_out Effect.nil) ->
+      Effect.state es_in -> Effect.state es_in.
+
+  Definition OUTPUT (es_in es_out : list Effect.t) : Type :=
+    forall (n : nat), Effect.state es_in ->
+      Effect.S (List.nth n es_out Effect.nil).
+
+  Definition ERROR (es_in es_out : list Effect.t) : Type :=
+    forall (n : nat), Effect.E (List.nth n es_out Effect.nil) ->
+      Effect.error es_in.
+
+  Definition CORRECT (es_in es_out : list Effect.t)
+    (index_map : list nat) :=
+    List.map (fun n => List.nth n es_in Effect.nil) index_map = es_out.
+
+  Definition IN_RANGE (es_in es_out : list Effect.t)
+    (index_map : list nat) :=
+    let l := length es_in in
+    List.map (fun x => S x - l) index_map =
+    List.map (fun _ => 0) index_map.
+
+  (** Describes a union of effects.
+      [index_map] describes how to get each effect in [es_out] from an
+      effect in [es_in]. This allows aliases for the same effects to
+      appear multiple times in [es_out], backed by a single effect in
+      [es_in], so that effects containing type variables can resolve to
+      the same effect as necessary.
+
+      This has a few quirks:
+      - The input and output effect lists need to be parameters to
+        make typechecking work correctly. This means that code using
+        it must provide a parameter for [es_in], which will be inferred
+        at the callsite.
+      - There are two proofs to make typechecking work: [index_correct]
+        and [index_in_range]. To keep these both as unintrusive as
+        possible, they are both equality proofs, so passing [eq_refl]
+        should be enough.
+      - The [input], [output], and [error] functions only discharge a
+        single effect from the union. This means that all low-level
+        functions *MUST* only use a single unionable effect or manually
+        perform the discharges as necessary.
+   *)
+  Record t (es_in es_out : list Effect.t) := {
+    index_map : list nat;
+    index_correct : CORRECT es_in es_out index_map;
+    index_in_range : IN_RANGE es_in es_out index_map;
+    input : INPUT es_in es_out;
+    output : OUTPUT es_in es_out;
+    error : ERROR es_in es_out
+  }.
+
+  (** Caution: All code using this assumes that it is the first effect
+      in the effects list. *)
+  Definition union (es_in es_out : list Effect.t) : Effect.t :=
+    Effect.add
+      (Effect.make (t es_in es_out) Empty_set)
+      (Effect.of_list es_in).
+
+  Fixpoint length_compare {A : Type} (n : nat) (l : list A) {struct l} :
+    {n < length l} + {length l <= n}.
+    destruct l as [ | x l], n as [ | n].
+    - now right.
+    - right.
+      rewrite (plus_n_O (S n)); now apply le_plus_r.
+    - left.
+      apply (lt_plus_trans 0 1 (length l)); now repeat constructor.
+    - destruct (length_compare _ n l) as [Sn_lt | Sn_ge].
+      * left; now apply lt_n_S.
+      * right; now apply le_n_S.
+  Defined.
+
+  Definition base_input (es_in es_out : list Effect.t)
+    : forall (index_map : list nat),
+        CORRECT es_in es_out index_map -> INPUT es_in es_out.
+    unfold CORRECT, INPUT.
+    intros index_map index_correct n s.
+    destruct (length_compare n es_out) as [lt_len | ge_len].
+    - apply (Effect.Lens.set_state (List.nth n index_map 0)).
+      rewrite <- (List.map_nth (fun n => nth n es_in Effect.nil)).
+      rewrite index_correct.
+      now rewrite (nth_indep _ _ Effect.nil).
+    - exact (fun state => state).
+  Defined.
+
+  Definition base_output (es_in es_out : list Effect.t)
+    : forall (index_map : list nat),
+        CORRECT es_in es_out index_map -> OUTPUT es_in es_out.
+    unfold CORRECT, INPUT.
+    intros index_map index_correct n ss.
+    destruct (length_compare n es_out) as [lt_len | ge_len].
+    - erewrite (List.nth_indep _ _ _); [ | assumption ].
+      rewrite <- index_correct.
+      erewrite (List.map_nth (fun n => nth n es_in Effect.nil) index_map _ n).
+      now apply (Effect.Lens.get_state (List.nth n index_map 0)).
+    - now rewrite List.nth_overflow.
+  Defined.
+
+  Definition base_error (es_in es_out : list Effect.t)
+    : forall (index_map : list nat),
+        CORRECT es_in es_out index_map -> ERROR es_in es_out.
+    unfold CORRECT, ERROR.
+    intros index_map index_correct n.
+    destruct (length_compare n es_out) as [lt_len | ge_len].
+    - erewrite List.nth_indep; [ | assumption ].
+      rewrite <- index_correct.
+      erewrite (List.map_nth (fun n => nth n es_in Effect.nil) index_map _ n).
+      now apply (Effect.Lens.set_error (List.nth n index_map 0)).
+    - now rewrite List.nth_overflow.
+  Defined.
+
+  Definition create (es_in es_out : list Effect.t) (index_map : list nat)
+    (correct : CORRECT es_in es_out index_map)
+    (in_range : IN_RANGE es_in es_out index_map) : t es_in es_out := {|
+    index_map := index_map;
+    index_correct := correct;
+    index_in_range := in_range;
+    input := base_input correct;
+    output := base_output correct;
+    error := base_error correct
+  |}.
+
+  Definition compose_input (es_in es_mid es_out : list Effect.t)
+    : forall (index_map : list nat),
+        CORRECT es_mid es_out index_map ->
+        INPUT es_in es_mid -> INPUT es_in es_out.
+    unfold CORRECT, INPUT.
+    intros index_map index_correct input1 n s.
+    destruct (length_compare n es_out) as [lt_len | ge_len].
+    - apply (input1 (List.nth n index_map 0)).
+      rewrite <- (List.map_nth (fun n => nth n es_mid Effect.nil)).
+      rewrite index_correct.
+      now rewrite (nth_indep _ _ Effect.nil).
+    - exact (fun state => state).
+  Defined.
+
+  Definition compose_output (es_in es_mid es_out : list Effect.t)
+    : forall (index_map : list nat),
+        CORRECT es_mid es_out index_map ->
+        OUTPUT es_in es_mid -> OUTPUT es_in es_out.
+    unfold CORRECT, OUTPUT.
+    intros index_map index_correct output1 n.
+    destruct (length_compare n es_out) as [lt_len | ge_len].
+    - erewrite (List.nth_indep _ _ _); [ | assumption ].
+      rewrite <- index_correct.
+      erewrite (List.map_nth (fun n => nth n es_mid Effect.nil) index_map _ n).
+      now apply (output1 (List.nth n index_map 0)).
+    - now rewrite List.nth_overflow.
+  Defined.
+
+  Definition compose_error (es_in es_mid es_out : list Effect.t)
+    : forall (index_map : list nat),
+        CORRECT es_mid es_out index_map ->
+        ERROR es_in es_mid -> ERROR es_in es_out.
+    unfold CORRECT, ERROR.
+    intros index_map index_correct error1 n.
+    destruct (length_compare n es_out) as [lt_len | ge_len].
+    - erewrite List.nth_indep; [ | assumption ].
+      rewrite <- index_correct.
+      erewrite (List.map_nth (fun n => nth n es_mid Effect.nil) index_map _ n).
+      now apply (error1 (List.nth n index_map 0)).
+    - now rewrite List.nth_overflow.
+  Defined.
+
+  Lemma in_range_equiv
+    : forall (index_map : list nat) (es_in es_out : list Effect.t),
+        IN_RANGE es_in es_out index_map <->
+        List.Forall (fun n => n < length es_in) index_map.
+  Proof.
+    unfold IN_RANGE.
+    intros index_map es_in _.
+    induction index_map as [ | x index_map IH].
+    - easy.
+    - destruct es_in as [ | e es_in].
+        split; now inversion 1.
+      split; simpl.
+      * inversion 1 as [[x_sub_eq_0 tl_range]].
+        rewrite x_sub_eq_0 in tl_range.
+        now firstorder.
+      * inversion 1 as [ | n l x_le_len tl_forall].
+        apply IH in tl_forall.
+        f_equal; [ | now firstorder ].
+        revert x_le_len; clear.
+        generalize (List.length es_in) as m; clear.
+        induction x as [ | x IH];
+        [ | intros [ | m] Sx_le ].
+        + easy.
+        + inversion Sx_le as [ | n SSx_le_O].
+          now inversion SSx_le_O.
+        + now apply IH, le_S_n.
+  Qed.
+
+  Lemma compose_correct (es_in es_mid es_out : list Effect.t)
+    : forall (index_map1 index_map2 : list nat),
+        CORRECT es_mid es_out index_map1 ->
+        CORRECT es_in es_mid index_map2 ->
+        IN_RANGE es_mid es_out index_map1 ->
+        IN_RANGE es_in es_mid index_map2 ->
+        CORRECT es_in es_out
+          (List.map (fun n => List.nth n index_map2 0) index_map1).
+  Proof.
+    unfold CORRECT, IN_RANGE.
+    intros index_map1.
+    revert es_out.
+    induction index_map1 as [ | i index_map1 IH];
+      intros es_out index_map2 correct1 correct2 range1 range2.
+    - now rewrite <- correct1.
+    - rewrite <- correct1, <- correct2.
+      simpl; f_equal.
+      * erewrite (List.nth_indep (map _ _)).
+        + now rewrite map_nth.
+        + apply (in_range_equiv _ _ es_out) in range1.
+          inversion range1.
+          now rewrite correct2.
+      * destruct es_out as [ | e es_out];
+          inversion correct1 as [[e_eq es_out_eq]].
+        specialize (IH es_out index_map2 es_out_eq correct2).
+        rewrite correct2, es_out_eq.
+        apply IH.
+        + now inversion range1.
+        + now inversion range2.
+  Qed.
+
+  Lemma compose_in_range (es_in es_mid es_out : list Effect.t)
+    : forall (index_map1 index_map2 : list nat),
+        CORRECT es_mid es_out index_map1 ->
+        CORRECT es_in es_mid index_map2 ->
+        IN_RANGE es_mid es_out index_map1 ->
+        IN_RANGE es_in es_mid index_map2 ->
+        IN_RANGE es_in es_out
+          (List.map (fun n => List.nth n index_map2 0) index_map1).
+  Proof.
+    unfold CORRECT, IN_RANGE.
+    intros index_map1.
+    revert es_out.
+    induction index_map1 as [ | i index_map1 IH];
+      intros es_out index_map2 correct1 correct2 range1 range2.
+      easy.
+    destruct es_in as [ | ei es_in];
+    [ | destruct es_out as [ | eo es_out] ].
+    - destruct index_map2 as [ | i2 index_map2].
+        simpl in *; rewrite <- correct2 in range1; now inversion range1.
+        now inversion range2.
+    - now inversion correct1.
+    - simpl; f_equal.
+      * apply (in_range_equiv _ _ es_out) in range1.
+        inversion range1 as [ | i' index_map1' i_lt_len _].
+        cut (In (nth i index_map2 0) index_map2).
+        + intros in_index_map2.
+          apply (List.in_map (fun x => S x - List.length (ei :: es_in)))
+            in in_index_map2.
+          rewrite range2 in in_index_map2.
+          apply List.in_map_iff in in_index_map2.
+          now destruct in_index_map2 as [_ [eq_0 _]].
+        + apply List.nth_In.
+          replace (List.length index_map2) with (List.length es_mid).
+            assumption.
+          rewrite <- correct2.
+          now apply List.map_length.
+      * now apply (IH es_out);
+        [ inversion correct1 | | inversion range1 | ].
+  Qed.
+
+  Definition compose {es_in es_mid es_out : list Effect.t}
+    (map1 : t es_in es_mid) (map2 : t es_mid es_out)
+    : t es_in es_out :=
+    {|
+      index_map := List.map (fun n => List.nth n (index_map map1) 0)
+        (index_map map2);
+      index_correct := compose_correct
+        (index_correct map2) (index_correct map1)
+        (index_in_range map2) (index_in_range map1);
+      index_in_range := compose_in_range
+        (index_correct map2) (index_correct map1)
+        (index_in_range map2) (index_in_range map1);
+      input := compose_input (index_correct map2) (input map1);
+      output := compose_output (index_correct map2) (output map1);
+      error := compose_error (index_correct map2) (error map1)
+    |}.
+
+  Definition mix {es_in es_mid es_out es : list Effect.t}
+    {A : Type} (map : t es_mid es_out)
+    (x : M (union es_in es_out :: es) A)
+    : M (union es_in es_mid :: es) A :=
+    fun s =>
+      let (union_state, s) := s in
+      let (map', s_inner) := union_state in
+      let s := ((compose map' map, s_inner), s) in
+      let (x, s) := x s in
+      let (union_state, s) := s in
+      let s := ((map', snd union_state), s) in
+      (x, s).
+
+  Definition lift {es_in es_out es : list Effect.t} {A : Type}
+    (n : nat) (x : M (nth n es_out Effect.nil :: es) A)
+    : M (union es_in es_out :: es) A :=
+    fun s =>
+      let (union_state, s) := s in
+      let (map, s_inner) := union_state in
+      let s' := output map n s_inner in
+      let s := (s', s) in
+      let (x, s) := x s in
+      let (s', s) := s in
+      let s_inner := input map n s' s_inner in
+      let s := ((map, s_inner), s) in
+      let x := match x with
+        | inl x => inl x
+        | inr (inl e) => inr (inl (inr (error map n e)))
+        | inr (inr e) => inr (inr e)
+        end in
+      (x, s).
+
+  Close Scope nat.
+End Union.
 
 Module State.
   Unset Implicit Arguments.

--- a/src/boundName.ml
+++ b/src/boundName.ml
@@ -32,5 +32,10 @@ let resolve_open (name_list : Name.t list) (x : t) : t =
   else
     x
 
+(* Compare on the base name first, for better stability across modules. *)
+let stable_compare (x : t) (y : t) : int =
+  let cmp = compare x.path_name.base y.path_name.base in
+  if cmp == 0 then compare x y else cmp
+
 let to_coq (x : t) : SmartPrint.t =
   PathName.to_coq x.path_name

--- a/src/effect.ml
+++ b/src/effect.ml
@@ -270,6 +270,20 @@ module Type = struct
     match typ with
     | Pure -> false
     | Arrow (d, typ) -> Descriptor.has_type_vars d || has_type_vars typ
+
+  let rec split_calls (typ : t) (e_xs : 'a list)
+    : ('a list * Descriptor.t) list =
+    match e_xs with
+    | [] -> []
+    | e_x :: e_xs ->
+      let e_xs = split_calls (return_type typ 1) e_xs in
+      let d = return_descriptor typ 1 in
+      if Descriptor.is_pure d then
+        match e_xs with
+        | [] -> [([e_x], Descriptor.pure)]
+        | (e_xs', d') :: e_xs -> ((e_x :: e_xs'), d') :: e_xs
+      else
+        ([e_x], d) :: e_xs
 end
 
 type t = { descriptor : Descriptor.t; typ : Type.t }

--- a/src/effect.ml
+++ b/src/effect.ml
@@ -42,7 +42,7 @@ end
 module Descriptor = struct
   module Id = struct
     type t =
-      | Ether of PathName.t
+      | Ether of BoundName.t
       | Type of PureType.t
   end
   module Map = Map.Make (struct type t = Id.t let compare = compare end)

--- a/src/effect.ml
+++ b/src/effect.ml
@@ -14,8 +14,8 @@ let rec pp (typ : t) : SmartPrint.t =
   | Arrow (typ1, typ2) -> nest @@ parens (pp typ1 ^^ !^ "->" ^^ pp typ2)
   | Tuple typs -> nest @@ parens (separate (space ^^ !^ "*" ^^ space) (List.map pp typs))
   | Apply (x, typs) ->
-    nest (!^ "Type" ^^ nest (parens (
-      separate (!^ "," ^^ space) (BoundName.pp x :: List.map pp typs))))
+    nest @@ parens @@
+      separate (!^ "," ^^ space) (BoundName.pp x :: List.map pp typs)
 
 let first_param (typ : t) : t =
   match typ with
@@ -86,7 +86,7 @@ module Descriptor = struct
   let pp (d : t) : SmartPrint.t =
     Set.elements d |> OCaml.list (fun id ->
       match id with
-      | Id.Type pt -> !^ "TypeEffect" ^^ OCaml.tuple [PureType.pp pt]
+      | Id.Type pt -> PureType.pp pt
       | Id.Ether x -> BoundName.pp x)
 
   let pure : t = Set.empty

--- a/src/effect.ml
+++ b/src/effect.ml
@@ -77,13 +77,11 @@ module Descriptor = struct
   module Set = Set.Make (struct
       type t = Id.t
 
-      (* Compare on the base name first, for better stability across modules. *)
       let compare x y =
         match x, y with
-        | Id.Type ({path_name={base=a}}, _),
-          Id.Type ({path_name={base=b}}, _) ->
-          let cmp = compare a b in
-          if cmp == 0 then compare x y else cmp
+        | Id.Type (a, ta), Id.Type (b, tb) ->
+          let cmp = BoundName.stable_compare a b in
+          if cmp == 0 then compare ta tb else cmp
 
     end)
   type t = Set.t

--- a/src/effect.ml
+++ b/src/effect.ml
@@ -43,7 +43,6 @@ module Descriptor = struct
   module Id = struct
     type t =
       | Ether of PathName.t
-      | Loc of Loc.t
       | Type of PureType.t
   end
   module Map = Map.Make (struct type t = Id.t let compare = compare end)

--- a/src/effect.ml
+++ b/src/effect.ml
@@ -51,8 +51,6 @@ module Descriptor = struct
     type t =
       | Type of BoundName.t * PureType.t list (* Mirrors PureType.Apply *)
 
-    let ether (x : BoundName.t) : t = Type (x, [])
-
     let map (f : BoundName.t -> BoundName.t) (x : t) =
       match x with
       | Type (x, typs) -> Type (f x, List.map (PureType.map f) typs)
@@ -86,7 +84,8 @@ module Descriptor = struct
 
   let eq (d1 : t) (d2 : t) : bool = Set.equal d1 d2
 
-  let singleton (id : Id.t) : t = Set.singleton id
+  let singleton (x : BoundName.t) (typs : PureType.t list) : t =
+    Set.singleton (Id.Type (x, typs))
 
   let union (ds : t list) : t =
     List.fold_left (fun d1 d2 -> Set.fold Set.add d1 d2) pure ds

--- a/src/exception.ml
+++ b/src/exception.ml
@@ -41,7 +41,7 @@ let update_env_with_effects (exn : t) (env : Effect.Type.t FullEnvi.t)
     (PathName.of_name [] name) env in
   let effect_typ =
     Effect.Type.Arrow (
-      Effect.Descriptor.singleton (Effect.Descriptor.Id.Ether bound_effect),
+      Effect.Descriptor.singleton (Effect.Descriptor.Id.ether bound_effect),
       Effect.Type.Pure) in
   FullEnvi.Var.assoc [] raise_name coq_raise_name effect_typ env
 

--- a/src/exception.ml
+++ b/src/exception.ml
@@ -37,11 +37,12 @@ let update_env_with_effects (exn : t) (env : Effect.Type.t FullEnvi.t)
   let (name, coq_name) = CoqName.assoc_names exn.name in
   let (raise_name, coq_raise_name) = CoqName.assoc_names exn.raise_name in
   let env = FullEnvi.Descriptor.assoc [] name coq_name env in
+  let bound_effect = FullEnvi.Descriptor.bound Loc.Unknown
+    (PathName.of_name [] name) env in
   let effect_typ =
     Effect.Type.Arrow (
-      Effect.Descriptor.singleton
-        (Effect.Descriptor.Id.Ether (PathName.of_name [] coq_name))
-        (FullEnvi.Descriptor.bound Loc.Unknown (PathName.of_name [] name) env),
+      Effect.Descriptor.singleton (Effect.Descriptor.Id.Ether bound_effect)
+        bound_effect,
       Effect.Type.Pure) in
   FullEnvi.Var.assoc [] raise_name coq_raise_name effect_typ env
 

--- a/src/exception.ml
+++ b/src/exception.ml
@@ -41,7 +41,7 @@ let update_env_with_effects (exn : t) (env : Effect.Type.t FullEnvi.t)
     (PathName.of_name [] name) env in
   let effect_typ =
     Effect.Type.Arrow (
-      Effect.Descriptor.singleton (Effect.Descriptor.Id.ether bound_effect),
+      Effect.Descriptor.singleton bound_effect [],
       Effect.Type.Pure) in
   FullEnvi.Var.assoc [] raise_name coq_raise_name effect_typ env
 

--- a/src/exception.ml
+++ b/src/exception.ml
@@ -33,14 +33,14 @@ let update_env (exn : t) (env : unit FullEnvi.t) : unit FullEnvi.t =
   |> FullEnvi.Var.assoc [] raise_name coq_raise_name ()
 
 let update_env_with_effects (exn : t) (env : Effect.Type.t FullEnvi.t)
-  (id : Effect.Descriptor.Id.t) : Effect.Type.t FullEnvi.t =
+  : Effect.Type.t FullEnvi.t =
   let (name, coq_name) = CoqName.assoc_names exn.name in
   let (raise_name, coq_raise_name) = CoqName.assoc_names exn.raise_name in
   let env = FullEnvi.Descriptor.assoc [] name coq_name env in
   let effect_typ =
     Effect.Type.Arrow (
       Effect.Descriptor.singleton
-        id
+        (Effect.Descriptor.Id.Ether (PathName.of_name [] coq_name))
         (FullEnvi.Descriptor.bound Loc.Unknown (PathName.of_name [] name) env),
       Effect.Type.Pure) in
   FullEnvi.Var.assoc [] raise_name coq_raise_name effect_typ env

--- a/src/exception.ml
+++ b/src/exception.ml
@@ -41,8 +41,7 @@ let update_env_with_effects (exn : t) (env : Effect.Type.t FullEnvi.t)
     (PathName.of_name [] name) env in
   let effect_typ =
     Effect.Type.Arrow (
-      Effect.Descriptor.singleton (Effect.Descriptor.Id.Ether bound_effect)
-        bound_effect,
+      Effect.Descriptor.singleton (Effect.Descriptor.Id.Ether bound_effect),
       Effect.Type.Pure) in
   FullEnvi.Var.assoc [] raise_name coq_raise_name effect_typ env
 

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -671,9 +671,9 @@ and monadise_let_rec_definition (env : unit FullEnvi.t)
 let rec effects (env : Effect.Type.t FullEnvi.t) (e : (Loc.t * Type.t) t)
   : (Loc.t * Effect.t) t =
   let type_effect typ = let open Effect.Descriptor in
-    singleton (Id.Type
-      (FullEnvi.Descriptor.bound Loc.Unknown
-        (PathName.of_name ["OCaml"; "Effect"; "State"] "state") env, [typ])) in
+    singleton (FullEnvi.Descriptor.bound Loc.Unknown
+        (PathName.of_name ["OCaml"; "Effect"; "State"] "state") env)
+      [typ] in
   let type_effect_of_exp e =
     if Type.is_function @@ snd @@ annotation e ||
         Effect.Type.is_pure @@ Type.type_effects env @@ snd @@ annotation e

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -772,20 +772,8 @@ let rec effects (env : Effect.Type.t FullEnvi.t) (e : (Loc.t * Type.t) t)
     let e_xs = List.map (effects env) e_xs in
     let effects_e_xs = List.map (fun e_x -> snd (annotation e_x)) e_xs in
     if effects_e_xs |> List.for_all (fun effect_e_x ->
-      Effect.Type.is_pure effect_e_x.Effect.typ) then
-      let rec e_xss typ e_xs : ('b t list * Effect.Descriptor.t) list =
-        match e_xs with
-        | [] -> []
-        | e_x :: e_xs ->
-          let e_xss = e_xss (Effect.Type.return_type typ 1) e_xs in
-          let d = Effect.Type.return_descriptor typ 1 in
-          if Effect.Descriptor.is_pure d then
-            match e_xss with
-            | [] -> [([e_x], Effect.Descriptor.pure)]
-            | (e_xs', d') :: e_xss -> ((e_x :: e_xs'), d') :: e_xss
-          else
-            ([e_x], d) :: e_xss in
-      let e_xss = e_xss effect_e_f.Effect.typ e_xs in
+        Effect.Type.is_pure effect_e_x.Effect.typ) then
+      let e_xss = Effect.Type.split_calls effect_e_f.Effect.typ e_xs in
       List.fold_left (fun e (e_xs, d) ->
         let effect_e = snd (annotation e) in
         let effects_e_xs = List.map (fun e_x -> snd (annotation e_x)) e_xs in

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -731,8 +731,7 @@ let rec effects (env : Effect.Type.t FullEnvi.t) (e : (Loc.t * Type.t) t)
         let get_var p b =
           FullEnvi.Var.bound Loc.Unknown (PathName.of_name p b) env in
         let var a path base = Variable (a, get_var path base) in
-        let state_dsc_eff = type_effect
-          (Effect.PureType.Apply (state_dsc', [])) in
+        let state_dsc_eff = Effect.Descriptor.singleton state_dsc' [] in
         let open Effect.Type in let open Effect.Descriptor in
         let mk desc ty = { Effect.descriptor = desc; Effect.typ = ty } in
         Apply ((u, mk (union [typ_eff; state_dsc_eff]) Pure),

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -671,9 +671,9 @@ and monadise_let_rec_definition (env : unit FullEnvi.t)
 let rec effects (env : Effect.Type.t FullEnvi.t) (e : (Loc.t * Type.t) t)
   : (Loc.t * Effect.t) t =
   let type_effect typ = let open Effect.Descriptor in
-    singleton (Id.Type (Effect.PureType.Apply
+    singleton (Id.Type
       (FullEnvi.Descriptor.bound Loc.Unknown
-        (PathName.of_name ["OCaml"; "Effect"; "State"] "state") env, [typ]))) in
+        (PathName.of_name ["OCaml"; "Effect"; "State"] "state") env, [typ])) in
   let type_effect_of_exp e =
     if Type.is_function @@ snd @@ annotation e ||
         Effect.Type.is_pure @@ Type.type_effects env @@ snd @@ annotation e
@@ -756,9 +756,9 @@ let rec effects (env : Effect.Type.t FullEnvi.t) (e : (Loc.t * Type.t) t)
       (l, { eff with Effect.typ = Effect.Type.map (fun i desc ->
         Effect.Descriptor.Set.map (fun key ->
           match key with
-          | Effect.Descriptor.Id.Type (Effect.PureType.Apply
-            (ty, [Effect.PureType.Variable key])) ->
-            Effect.Descriptor.Id.Type (Effect.PureType.Apply
+          | Effect.Descriptor.Id.Type
+            (ty, [Effect.PureType.Variable key]) ->
+            Effect.Descriptor.Id.Type
               (ty, [ match int_of_string_opt key with
                 | Some i ->
                   begin match List.nth_opt e_xs i with
@@ -769,7 +769,7 @@ let rec effects (env : Effect.Type.t FullEnvi.t) (e : (Loc.t * Type.t) t)
                     Effect.PureType.Variable
                       (string_of_int (i - List.length e_xs))
                   end
-                | None -> Effect.PureType.Variable key]))
+                | None -> Effect.PureType.Variable key])
           | _ -> key) desc)
         eff.Effect.typ })) e_f in
     (* Add an effect for the type, if there is one *)

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -768,24 +768,6 @@ let rec effects (env : Effect.Type.t FullEnvi.t) (e : (Loc.t * Type.t) t)
         let vars_map = Type.unify ptyp_f typ_f in
         (l, Effect.map_type_vars vars_map eff)
       | None -> (l, eff)) in
-    (* Add an effect for the type, if there is one *)
-    let e_f = match type_effect_of_exp e with
-      | None -> e_f
-      | Some e_e -> update_annotation (fun (l, eff) ->
-          let rec change_last_eff typ eff =
-            match typ with
-            | Type.Arrow (_, (Arrow _ as typ)) ->
-              begin match eff with
-              | Effect.Type.Arrow (desc, eff) ->
-                Effect.Type.Arrow (desc, change_last_eff typ eff)
-              | Effect.Type.Pure ->
-                Effect.Type.Arrow (Effect.Descriptor.pure,
-                  change_last_eff typ Effect.Type.Pure)
-              end
-            | Type.Arrow (_, typ) -> Effect.Type.union [eff; e_e]
-            | _ -> eff in
-          (l, {eff with
-            Effect.typ = change_last_eff typ_f eff.Effect.typ})) e_f in
     let effect_e_f = snd (annotation e_f) in
     let e_xs = List.map (effects env) e_xs in
     let effects_e_xs = List.map (fun e_x -> snd (annotation e_x)) e_xs in

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -668,6 +668,13 @@ and monadise_let_rec_definition (env : unit FullEnvi.t)
     let env = Definition.env_after_def def env in
     (env, [def])
 
+let rec function_type (env : Effect.Type.t FullEnvi.t) (e : (Loc.t * Type.t) t)
+  : Effect.PureType.t option =
+  match e with
+  | Variable ((l, typ), x) ->
+    FullEnvi.Function.find x env (Effect.PureType.map BoundName.depth_lift)
+  | _ -> None
+
 let rec effects (env : Effect.Type.t FullEnvi.t) (e : (Loc.t * Type.t) t)
   : (Loc.t * Effect.t) t =
   let type_effect typ = let open Effect.Descriptor in
@@ -748,28 +755,15 @@ let rec effects (env : Effect.Type.t FullEnvi.t) (e : (Loc.t * Type.t) t)
     Constructor ((l, effect), x, es)
   | Apply ((l, typ), e_f, e_xs) ->
     let typ_f = snd @@ annotation e_f in
+    let ptyp_f = function_type env e_f in
     let e_f = effects env e_f in
     (* Resolve effects with type variables *)
     let e_f = e_f |> update_annotation (fun (l, eff) ->
-      let type_effect_bound = FullEnvi.Descriptor.bound Loc.Unknown
-        (PathName.of_name [] "__type__") env in
-      let descriptor = Effect.Type.return_descriptor eff.Effect.typ 1 in
-      let (type_effect_descriptors, descriptor) =
-        Effect.Descriptor.partition type_effect_bound descriptor in
-      match Effect.Descriptor.choose type_effect_descriptors with
-      | Some (Effect.Descriptor.Id.Type (_, [ptyp_f])) ->
-        let eff = { eff with Effect.typ =
-          Effect.Type.Arrow (descriptor,
-            Effect.Type.return_type eff.Effect.typ 1) } in
+      match ptyp_f with
+      | Some ptyp_f ->
         let vars_map = Type.unify ptyp_f typ_f in
-        let new_eff = Effect.map_type_vars vars_map eff in
-        if Effect.has_type_vars new_eff then
-          (l, new_eff)
-        else
-          (l, { new_eff with Effect.descriptor =
-            Effect.Descriptor.remove type_effect_bound new_eff.descriptor })
-      | _ -> (l, eff)
-        ) in
+        (l, Effect.map_type_vars vars_map eff)
+      | None -> (l, eff)) in
     (* Add an effect for the type, if there is one *)
     let e_f = match type_effect_of_exp e with
       | None -> e_f

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -207,13 +207,13 @@ let add_exception (path : Name.t list) (base : Name.t) (env : unit t) : unit t =
   |> Var.add path ("raise_" ^ base) ()
 
 let add_exception_with_effects (path : Name.t list) (base : Name.t)
-  (id : Effect.Descriptor.Id.t) (env : Effect.Type.t t)
-  : Effect.Type.t t =
+  (env : Effect.Type.t t) : Effect.Type.t t =
   let env = Descriptor.add path base env in
+  let descriptor = PathName.of_name path base in
+  let bound_descriptor = Descriptor.bound Loc.Unknown descriptor env in
   let effect_typ =
     Effect.Type.Arrow (
-      Effect.Descriptor.singleton
-        id
-        (Descriptor.bound Loc.Unknown (PathName.of_name path base) env),
+      Effect.Descriptor.singleton (Effect.Descriptor.Id.Ether bound_descriptor)
+        bound_descriptor,
       Effect.Type.Pure) in
   Var.add path ("raise_" ^ base) effect_typ env

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -213,7 +213,6 @@ let add_exception_with_effects (path : Name.t list) (base : Name.t)
   let bound_descriptor = Descriptor.bound Loc.Unknown descriptor env in
   let effect_typ =
     Effect.Type.Arrow (
-      Effect.Descriptor.singleton (Effect.Descriptor.Id.Ether bound_descriptor)
-        bound_descriptor,
+      Effect.Descriptor.singleton (Effect.Descriptor.Id.Ether bound_descriptor),
       Effect.Type.Pure) in
   Var.add path ("raise_" ^ base) effect_typ env

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -213,6 +213,6 @@ let add_exception_with_effects (path : Name.t list) (base : Name.t)
   let bound_descriptor = Descriptor.bound Loc.Unknown descriptor env in
   let effect_typ =
     Effect.Type.Arrow (
-      Effect.Descriptor.singleton (Effect.Descriptor.Id.ether bound_descriptor),
+      Effect.Descriptor.singleton bound_descriptor [],
       Effect.Type.Pure) in
   Var.add path ("raise_" ^ base) effect_typ env

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -186,6 +186,24 @@ end
 module Var = ValueCarrier(Mod.Vars)
 module Typ = ValueCarrier(Mod.Typs)
 
+module Function = struct
+  include Carrier(Mod.Vars)
+
+  let add (path : Name.t list) (base : Name.t) (v : 'a)
+    (typ : Effect.PureType.t) (env : 'a t) : 'a t =
+    update_active (Mod.Function.add (PathName.of_name path base) v typ) env
+
+  let assoc (path : Name.t list) (base : Name.t) (assoc_base : Name.t) (v : 'a)
+    (typ : Effect.PureType.t) (env : 'a t) : 'a t =
+    update_active (Mod.Function.assoc (PathName.of_name path base)
+      (PathName.of_name path assoc_base) v typ) env
+
+  let find (x : BoundName.t) (env : 'a t)
+    (open_lift : Effect.PureType.t -> Effect.PureType.t)
+    : Effect.PureType.t option =
+    find_bound_name Mod.Function.find x env (option_map open_lift)
+end
+
 module EmptyCarrier (M : Mod.EmptyCarrier) = struct
   include Carrier(M)
   let add (path : Name.t list) (base : Name.t) (env : 'a t) : 'a t =

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -213,6 +213,6 @@ let add_exception_with_effects (path : Name.t list) (base : Name.t)
   let bound_descriptor = Descriptor.bound Loc.Unknown descriptor env in
   let effect_typ =
     Effect.Type.Arrow (
-      Effect.Descriptor.singleton (Effect.Descriptor.Id.Ether bound_descriptor),
+      Effect.Descriptor.singleton (Effect.Descriptor.Id.ether bound_descriptor),
       Effect.Type.Pure) in
   Var.add path ("raise_" ^ base) effect_typ env

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -19,8 +19,7 @@ module Shape = struct
     let descriptor ds : Effect.Descriptor.t =
       let ds = ds |> List.map (fun d ->
         let bound_descriptor = FullEnvi.Descriptor.bound Loc.Unknown d env in
-        Effect.Descriptor.singleton
-          (Effect.Descriptor.Id.ether bound_descriptor)) in
+        Effect.Descriptor.singleton bound_descriptor []) in
       Effect.Descriptor.union ds in
     List.fold_right (fun ds typ -> Effect.Type.Arrow (descriptor ds, typ))
       shape Effect.Type.Pure

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -20,7 +20,7 @@ module Shape = struct
       let ds = ds |> List.map (fun d ->
         let bound_descriptor = FullEnvi.Descriptor.bound Loc.Unknown d env in
         Effect.Descriptor.singleton
-          (Effect.Descriptor.Id.Ether bound_descriptor) bound_descriptor) in
+          (Effect.Descriptor.Id.Ether bound_descriptor)) in
       Effect.Descriptor.union ds in
     List.fold_right (fun ds typ -> Effect.Type.Arrow (descriptor ds, typ))
       shape Effect.Type.Pure

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -18,8 +18,9 @@ module Shape = struct
   let to_effect_typ (shape : t) (env : 'a FullEnvi.t) : Effect.Type.t =
     let descriptor ds : Effect.Descriptor.t =
       let ds = ds |> List.map (fun d ->
-        Effect.Descriptor.singleton (Effect.Descriptor.Id.Ether d)
-          (FullEnvi.Descriptor.bound Loc.Unknown d env)) in
+        let bound_descriptor = FullEnvi.Descriptor.bound Loc.Unknown d env in
+        Effect.Descriptor.singleton
+          (Effect.Descriptor.Id.Ether bound_descriptor) bound_descriptor) in
       Effect.Descriptor.union ds in
     List.fold_right (fun ds typ -> Effect.Type.Arrow (descriptor ds, typ))
       shape Effect.Type.Pure

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -20,7 +20,7 @@ module Shape = struct
       let ds = ds |> List.map (fun d ->
         let bound_descriptor = FullEnvi.Descriptor.bound Loc.Unknown d env in
         Effect.Descriptor.singleton
-          (Effect.Descriptor.Id.Ether bound_descriptor)) in
+          (Effect.Descriptor.Id.ether bound_descriptor)) in
       Effect.Descriptor.union ds in
     List.fold_right (fun ds typ -> Effect.Type.Arrow (descriptor ds, typ))
       shape Effect.Type.Pure

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -6,15 +6,16 @@ open SmartPrint
 let env_with_effects : Effect.Type.t FullEnvi.t =
   let descriptor depth (path, base) =
     let x = { BoundName.path_name = PathName.of_name path base; depth } in
-    Effect.Descriptor.singleton (Effect.Descriptor.Id.Ether x) x in
+    Effect.Descriptor.singleton (Effect.Descriptor.Id.Ether x) in
   let d depth xs : Effect.Descriptor.t =
     Effect.Descriptor.union (List.map (descriptor depth) xs) in
   let typ_d (x : int) : Effect.Descriptor.t =
     let i = string_of_int x in
     Effect.Descriptor.singleton
-      (Effect.Descriptor.Id.Type (Effect.PureType.Variable i))
-      { BoundName.depth = 0; BoundName.path_name =
-        (PathName.of_name ["Effect"; "State"] "state") } in
+      (Effect.Descriptor.Id.Type (Effect.PureType.Apply
+        ({ BoundName.depth = 0; BoundName.path_name =
+            (PathName.of_name ["Effect"; "State"] "state") },
+          [Effect.PureType.Variable i]))) in
   let add_exn path base = add_exception_with_effects path base in
   FullEnvi.empty None (fun _ -> failwith "No modules loaded")
   (* Values specific to the translation to Coq *)

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -29,7 +29,6 @@ let env_with_effects : Effect.Type.t FullEnvi.t =
   |> Var.add [] "read_counter" (Arrow (d 0 [[], "Counter"], Pure))
   |> Descriptor.add [] "NonTermination"
   |> Var.add [] "not_terminated" (Arrow (d 0 [[], "NonTermination"], Pure))
-  |> Descriptor.add [] "__type__"
 
   (* The core library *)
   (* Built-in types *)
@@ -101,36 +100,27 @@ let env_with_effects : Effect.Type.t FullEnvi.t =
   |> Typ.add ["Effect"; "State"] "t" (Arrow (d 0 [["Effect"; "State"], "state"], Pure))
   |> Var.add ["Effect"; "State"] "peekstate" Pure
   |> Var.add ["Effect"; "State"] "global" Pure
-  |> Var.add ["Effect"; "State"] "read"
-    (Arrow (Effect.Descriptor.union [typ_d 0;
-      Effect.Descriptor.singleton
-        { BoundName.depth = 1;
-          path_name = PathName.of_name [] "__type__" }
-        [Effect.PureType.Arrow
-          (Effect.PureType.Apply
-            ({ BoundName.depth = 0;
-                path_name = PathName.of_name ["Effect"; "State"] "state" },
-              [Effect.PureType.Variable "0"]),
-            Effect.PureType.Variable "0")
-    ]], Pure))
-  |> Var.add ["Effect"; "State"] "write"
-    (Arrow (
-      Effect.Descriptor.singleton
-        { BoundName.depth = 1;
-          path_name = PathName.of_name [] "__type__" }
-        [Effect.PureType.Arrow
-          (Effect.PureType.Apply
-            ({ BoundName.depth = 0;
-                path_name = PathName.of_name ["Effect"; "State"] "state" },
-              [Effect.PureType.Variable "0"]),
-            Effect.PureType.Arrow
-              (Effect.PureType.Variable "0",
-              Effect.PureType.Apply
-                ({ BoundName.depth = 1;
-                    path_name = PathName.of_name [] "unit" },
-                [])))
-        ],
-    Arrow (typ_d 0, Pure)))
+  |> Function.add ["Effect"; "State"] "read"
+    (Arrow (typ_d 0, Pure))
+    (Effect.PureType.Arrow
+      (Effect.PureType.Apply
+        ({ BoundName.depth = 0;
+            path_name = PathName.of_name ["Effect"; "State"] "state" },
+          [Effect.PureType.Variable "0"]),
+        Effect.PureType.Variable "0"))
+  |> Function.add ["Effect"; "State"] "write"
+    (Arrow (d 0 [], Arrow (typ_d 0, Pure)))
+    (Effect.PureType.Arrow
+      (Effect.PureType.Apply
+        ({ BoundName.depth = 0;
+            path_name = PathName.of_name ["Effect"; "State"] "state" },
+          [Effect.PureType.Variable "0"]),
+        Effect.PureType.Arrow
+          (Effect.PureType.Variable "0",
+          Effect.PureType.Apply
+            ({ BoundName.depth = 1;
+                path_name = PathName.of_name [] "unit" },
+            []))))
 
   (* Pervasives *)
   (* Exceptions *)

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -170,7 +170,14 @@ let env_with_effects : Effect.Type.t FullEnvi.t =
   (* General input functions *)
   (* Operations on large files *)
   (* References *)
-  |> Var.add ["Pervasives"] "ref" Pure
+  |> Function.add ["Pervasives"] "ref"
+    (Arrow (typ_d 0, Pure))
+    (Effect.PureType.Arrow
+      (Effect.PureType.Variable "0",
+        Effect.PureType.Apply
+          ({ BoundName.depth = 0;
+              path_name = PathName.of_name ["Effect"; "State"] "state" },
+            [Effect.PureType.Variable "0"])))
   (* Operations on format strings *)
   (* Program termination *)
   |> leave_module Effect.Type.leave_prefix Effect.Type.resolve_open

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -29,6 +29,7 @@ let env_with_effects : Effect.Type.t FullEnvi.t =
   |> Var.add [] "read_counter" (Arrow (d 0 [[], "Counter"], Pure))
   |> Descriptor.add [] "NonTermination"
   |> Var.add [] "not_terminated" (Arrow (d 0 [[], "NonTermination"], Pure))
+  |> Descriptor.add [] "__type__"
 
   (* The core library *)
   (* Built-in types *)
@@ -100,8 +101,36 @@ let env_with_effects : Effect.Type.t FullEnvi.t =
   |> Typ.add ["Effect"; "State"] "t" (Arrow (d 0 [["Effect"; "State"], "state"], Pure))
   |> Var.add ["Effect"; "State"] "peekstate" Pure
   |> Var.add ["Effect"; "State"] "global" Pure
-  |> Var.add ["Effect"; "State"] "read" (Arrow (typ_d 0, Pure))
-  |> Var.add ["Effect"; "State"] "write" (Arrow (d 0 [], Arrow (typ_d 0, Pure)))
+  |> Var.add ["Effect"; "State"] "read"
+    (Arrow (Effect.Descriptor.union [typ_d 0;
+      Effect.Descriptor.singleton
+        { BoundName.depth = 1;
+          path_name = PathName.of_name [] "__type__" }
+        [Effect.PureType.Arrow
+          (Effect.PureType.Apply
+            ({ BoundName.depth = 0;
+                path_name = PathName.of_name ["Effect"; "State"] "state" },
+              [Effect.PureType.Variable "0"]),
+            Effect.PureType.Variable "0")
+    ]], Pure))
+  |> Var.add ["Effect"; "State"] "write"
+    (Arrow (
+      Effect.Descriptor.singleton
+        { BoundName.depth = 1;
+          path_name = PathName.of_name [] "__type__" }
+        [Effect.PureType.Arrow
+          (Effect.PureType.Apply
+            ({ BoundName.depth = 0;
+                path_name = PathName.of_name ["Effect"; "State"] "state" },
+              [Effect.PureType.Variable "0"]),
+            Effect.PureType.Arrow
+              (Effect.PureType.Variable "0",
+              Effect.PureType.Apply
+                ({ BoundName.depth = 1;
+                    path_name = PathName.of_name [] "unit" },
+                [])))
+        ],
+    Arrow (typ_d 0, Pure)))
 
   (* Pervasives *)
   (* Exceptions *)

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -6,16 +6,15 @@ open SmartPrint
 let env_with_effects : Effect.Type.t FullEnvi.t =
   let descriptor depth (path, base) =
     let x = { BoundName.path_name = PathName.of_name path base; depth } in
-    Effect.Descriptor.singleton (Effect.Descriptor.Id.ether x) in
+    Effect.Descriptor.singleton x [] in
   let d depth xs : Effect.Descriptor.t =
     Effect.Descriptor.union (List.map (descriptor depth) xs) in
   let typ_d (x : int) : Effect.Descriptor.t =
     let i = string_of_int x in
     Effect.Descriptor.singleton
-      (Effect.Descriptor.Id.Type
-        ({ BoundName.depth = 0; BoundName.path_name =
-            (PathName.of_name ["Effect"; "State"] "state") },
-          [Effect.PureType.Variable i])) in
+      { BoundName.depth = 0; BoundName.path_name =
+        (PathName.of_name ["Effect"; "State"] "state") }
+      [Effect.PureType.Variable i] in
   let add_exn path base = add_exception_with_effects path base in
   FullEnvi.empty None (fun _ -> failwith "No modules loaded")
   (* Values specific to the translation to Coq *)

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -5,9 +5,8 @@ open SmartPrint
 
 let env_with_effects : Effect.Type.t FullEnvi.t =
   let descriptor depth (path, base) =
-    let x = PathName.of_name path base in
-    Effect.Descriptor.singleton (Effect.Descriptor.Id.Ether x)
-      { BoundName.path_name = x; depth } in
+    let x = { BoundName.path_name = PathName.of_name path base; depth } in
+    Effect.Descriptor.singleton (Effect.Descriptor.Id.Ether x) x in
   let d depth xs : Effect.Descriptor.t =
     Effect.Descriptor.union (List.map (descriptor depth) xs) in
   let typ_d (x : int) : Effect.Descriptor.t =
@@ -16,9 +15,7 @@ let env_with_effects : Effect.Type.t FullEnvi.t =
       (Effect.Descriptor.Id.Type (Effect.PureType.Variable i))
       { BoundName.depth = 0; BoundName.path_name =
         (PathName.of_name ["Effect"; "State"] "state") } in
-  let add_exn path base =
-    add_exception_with_effects path base
-      (Effect.Descriptor.Id.Ether (PathName.of_name path base)) in
+  let add_exn path base = add_exception_with_effects path base in
   FullEnvi.empty None (fun _ -> failwith "No modules loaded")
   (* Values specific to the translation to Coq *)
   |> Typ.add [] "nat" Pure

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -12,10 +12,10 @@ let env_with_effects : Effect.Type.t FullEnvi.t =
   let typ_d (x : int) : Effect.Descriptor.t =
     let i = string_of_int x in
     Effect.Descriptor.singleton
-      (Effect.Descriptor.Id.Type (Effect.PureType.Apply
+      (Effect.Descriptor.Id.Type
         ({ BoundName.depth = 0; BoundName.path_name =
             (PathName.of_name ["Effect"; "State"] "state") },
-          [Effect.PureType.Variable i]))) in
+          [Effect.PureType.Variable i])) in
   let add_exn path base = add_exception_with_effects path base in
   FullEnvi.empty None (fun _ -> failwith "No modules loaded")
   (* Values specific to the translation to Coq *)

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -6,7 +6,7 @@ open SmartPrint
 let env_with_effects : Effect.Type.t FullEnvi.t =
   let descriptor depth (path, base) =
     let x = { BoundName.path_name = PathName.of_name path base; depth } in
-    Effect.Descriptor.singleton (Effect.Descriptor.Id.Ether x) in
+    Effect.Descriptor.singleton (Effect.Descriptor.Id.ether x) in
   let d depth xs : Effect.Descriptor.t =
     Effect.Descriptor.union (List.map (descriptor depth) xs) in
   let typ_d (x : int) : Effect.Descriptor.t =

--- a/src/reference.ml
+++ b/src/reference.ml
@@ -46,7 +46,7 @@ let update_env (update_exp : unit FullEnvi.t -> 'a Exp.t -> 'b Exp.t)
   (env, {r with expr = update_exp env r.expr})
 
 let update_env_with_effects (r : (Loc.t * Type.t) t)
-  (env : Effect.Type.t FullEnvi.t) (id : Effect.Descriptor.Id.t)
+  (env : Effect.Type.t FullEnvi.t)
   : Effect.Type.t FullEnvi.t * (Loc.t * Effect.t) t =
   let (name, coq_name) = CoqName.assoc_names r.name in
   let (state_name, coq_state_name) = CoqName.assoc_names r.state_name in

--- a/src/reference.ml
+++ b/src/reference.ml
@@ -61,4 +61,4 @@ let to_coq (r : 'a t) : SmartPrint.t =
     !^ "OCaml.Effect.State.init" ^^ Exp.to_coq true r.expr ^-^ !^ ".")
   ^^ newline ^^
   nest (!^ "Definition" ^^ CoqName.to_coq r.state_name ^^ !^ ":=" ^^
-    !^ "nat" ^-^ !^ ".")
+    !^ "OCaml.Effect.State.state nat" ^-^ !^ ".")

--- a/src/structure.ml
+++ b/src/structure.ml
@@ -225,7 +225,9 @@ let rec monadise (env : unit FullEnvi.t) (defs : (Loc.t * Effect.t) t list)
         Exp.Definition.cases =
           def.Exp.Definition.cases |> List.map (fun (header, e) ->
             let typ = Type.monadise header.Exp.Header.typ (snd (Exp.annotation e)) in
-        let header = { header with Exp.Header.typ = typ } in
+        let (implicit_args, typ) = Type.allocate_implicits_for_monad
+          header.Exp.Header.implicit_args header.Exp.Header.args typ in
+        let header = { header with Exp.Header.typ = typ; implicit_args } in
         let env = Exp.Header.env_in_header header env_in_def () in
         let e = Exp.monadise env e in
         (header, e)) } in

--- a/src/structure.ml
+++ b/src/structure.ml
@@ -189,11 +189,9 @@ let rec effects (env : Effect.Type.t FullEnvi.t) (defs : ('a * Type.t) t list)
       (TypeDefinition.update_env typ_def Effect.Type.Pure env,
        TypeDefinition (loc, typ_def))
     | Exception (loc, exn) ->
-      let id = Effect.Descriptor.Id.Loc loc in
-      (Exception.update_env_with_effects exn env id, Exception (loc, exn))
+      (Exception.update_env_with_effects exn env, Exception (loc, exn))
     | Reference (loc, r) ->
-      let id = Effect.Descriptor.Id.Loc loc in
-      let (env, r) = Reference.update_env_with_effects r env id in
+      let (env, r) = Reference.update_env_with_effects r env in
       (env, Reference (loc, r))
     | Open (loc, o) -> (Open.update_env loc o env, Open (loc, o))
     | Include (loc, name) ->

--- a/src/structure.ml
+++ b/src/structure.ml
@@ -28,6 +28,9 @@ module Value = struct
         | _ :: _ ->
           braces @@ group (separate space (List.map Name.to_coq header.Exp.Header.typ_vars) ^^
           !^ ":" ^^ !^ "Type")) ^^
+        group (separate space (header.Exp.Header.implicit_args
+          |> List.map (fun (x, x_typ) ->
+            braces (CoqName.to_coq x ^^ !^ ":" ^^ Type.to_coq false x_typ)))) ^^
         group (separate space (header.Exp.Header.args |> List.map (fun (x, t) ->
           parens @@ nest (CoqName.to_coq x ^^ !^ ":" ^^ Type.to_coq false t)))) ^^
         !^ ": " ^-^ Type.to_coq false header.Exp.Header.typ ^-^

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -39,3 +39,14 @@ let rec mix_map2 (f : 'a -> bool) (g : 'a -> 'c) (h : 'a -> 'b -> 'c)
       | b :: l2' -> h a b :: mix_map2 f g h l1' l2'
     else
       g a :: mix_map2 f g h l1' l2
+
+let find_index (f : 'a -> bool) (l : 'a list) : int =
+  let rec aux l c =
+    match l with
+    | [] -> failwith "Not found."
+    | x :: l -> if f x then c else aux l (c+1) in
+  aux l 0
+
+let to_coq_list (l : SmartPrint.t list) : SmartPrint.t =
+  let open SmartPrint in
+  brakets @@ separate (!^ ";") l

--- a/tests/ex17.effects
+++ b/tests/ex17.effects
@@ -21,7 +21,7 @@ Value
       [
         ((g, [ A ], [ (b, Type (bool/4)) ], A),
           IfThenElse
-            ((11, Effect ([ Outside/1; Inside/0 ], .)),
+            ((11, Effect ([ Inside/0; Outside/1 ], .)),
               Variable ((11, Effect ([ ], .)), b/0),
               Apply
                 ((12, Effect ([ Inside/0 ], .)),
@@ -72,7 +72,7 @@ Value
     [
       ((h_rec, [ A; B ], [ (counter, Type (nat/3)); (l, Type (list/3, A)) ], B),
         Match
-          ((?, Effect ([ IO/3; NonTermination/3; Outside/0; G.Inside/0 ], .)),
+          ((?, Effect ([ IO/3; G.Inside/0; NonTermination/3; Outside/0 ], .)),
             Variable ((?, Effect ([ ], .)), counter/0),
             [
               (Constructor (O/3),
@@ -108,9 +108,9 @@ Value
                     Effect
                       ([
                         IO/3;
+                        G.Inside/0;
                         NonTermination/3;
-                        Outside/0;
-                        G.Inside/0
+                        Outside/0
                       ],
                         .)),
                     Variable
@@ -128,8 +128,8 @@ Value
                             Effect
                               ([
                                 IO/3;
-                                Outside/0;
-                                G.Inside/0
+                                G.Inside/0;
+                                Outside/0
                               ],
                                 .)),
                             Apply
@@ -163,8 +163,8 @@ Value
                               ((19,
                                 Effect
                                   ([
-                                    Outside/0;
-                                    G.Inside/0
+                                    G.Inside/0;
+                                    Outside/0
                                   ],
                                     .)),
                                 Variable
@@ -174,8 +174,8 @@ Value
                                       ],
                                         .
                                           -[
-                                            Outside/0;
-                                            G.Inside/0
+                                            G.Inside/0;
+                                            Outside/0
                                           ]->
                                           .)),
                                     G.g/0),
@@ -242,9 +242,9 @@ Value
                             Effect
                               ([
                                 IO/3;
+                                G.Inside/0;
                                 NonTermination/3;
-                                Outside/0;
-                                G.Inside/0
+                                Outside/0
                               ],
                                 .)),
                             Apply
@@ -255,9 +255,9 @@ Value
                                     .
                                       -[
                                         IO/3;
+                                        G.Inside/0;
                                         NonTermination/3;
-                                        Outside/0;
-                                        G.Inside/0
+                                        Outside/0
                                       ]->
                                       .)),
                                 Variable
@@ -270,9 +270,9 @@ Value
                                           .
                                             -[
                                               IO/3;
+                                              G.Inside/0;
                                               NonTermination/3;
-                                              Outside/0;
-                                              G.Inside/0
+                                              Outside/0
                                             ]->
                                             .)),
                                     h_rec/0),
@@ -309,9 +309,9 @@ Value
               ([
                 Counter/3;
                 IO/3;
+                G.Inside/0;
                 NonTermination/3;
-                Outside/0;
-                G.Inside/0
+                Outside/0
               ], .)),
             Variable
               ((?,
@@ -321,9 +321,9 @@ Value
                       .
                         -[
                           IO/3;
+                          G.Inside/0;
                           NonTermination/3;
-                          Outside/0;
-                          G.Inside/0
+                          Outside/0
                         ]-> .)), h_rec/0),
             [
               Apply

--- a/tests/ex17.interface
+++ b/tests/ex17.interface
@@ -13,11 +13,11 @@
         [
           [ "Descriptor", "Inside" ],
           [ "Var", "raise_Inside", [ [ "Inside" ] ] ],
-          [ "Var", "g", [ [ "Outside", "Inside" ] ] ]
+          [ "Var", "g", [ [ "Inside", "Outside" ] ] ]
         ]
       ],
-      [ "Var", "h_rec", [ [], [ "IO", "NonTermination", "Outside", "G.Inside" ] ] ],
-      [ "Var", "h", [ [ "Counter", "IO", "NonTermination", "Outside", "G.Inside" ] ] ]
+      [ "Var", "h_rec", [ [], [ "IO", "G.Inside", "NonTermination", "Outside" ] ] ],
+      [ "Var", "h", [ [ "Counter", "IO", "G.Inside", "NonTermination", "Outside" ] ] ]
     ]
   ]
 }

--- a/tests/ex17.monadise
+++ b/tests/ex17.monadise
@@ -15,11 +15,11 @@ Value
   Value
     (non_rec, @.,
       [
-        ((g, [ A ], [ (b, Type (bool/4)) ], Monad ([ Outside/1; Inside/0 ], A)),
+        ((g, [ A ], [ (b, Type (bool/4)) ], Monad ([ Inside/0; Outside/1 ], A)),
           IfThenElse
             (11, Variable (11, b/0),
               Lift
-                (?, [ Inside/0 ], [ Outside/1; Inside/0 ],
+                (?, [ Inside/0 ], [ Inside/0; Outside/1 ],
                   Apply
                     (12, Variable (12, raise_Inside/0),
                       [
@@ -33,7 +33,7 @@ Value
                                 String("no")))
                       ])),
               Lift
-                (?, [ Outside/1 ], [ Outside/1; Inside/0 ],
+                (?, [ Outside/1 ], [ Inside/0; Outside/1 ],
                   Apply
                     (14, Variable (14, raise_Outside/1),
                       [ Tuple (?) ]))))
@@ -44,7 +44,7 @@ Value
   (rec, @.,
     [
       ((h_rec, [ A; B ], [ (counter, Type (nat/3)); (l, Type (list/3, A)) ],
-        Monad ([ IO/3; NonTermination/3; Outside/0; G.Inside/0 ], B)),
+        Monad ([ IO/3; G.Inside/0; NonTermination/3; Outside/0 ], B)),
         Match
           (?, Variable (?, counter/0),
             [
@@ -56,9 +56,9 @@ Value
                     ],
                     [
                       IO/3;
+                      G.Inside/0;
                       NonTermination/3;
-                      Outside/0;
-                      G.Inside/0
+                      Outside/0
                     ],
                     Apply
                       (?,
@@ -82,14 +82,14 @@ Value
                           (?,
                             [
                               IO/3;
-                              Outside/0;
-                              G.Inside/0
+                              G.Inside/0;
+                              Outside/0
                             ],
                             [
                               IO/3;
+                              G.Inside/0;
                               NonTermination/3;
-                              Outside/0;
-                              G.Inside/0
+                              Outside/0
                             ],
                             Bind
                               (?,
@@ -100,8 +100,8 @@ Value
                                     ],
                                     [
                                       IO/3;
-                                      Outside/0;
-                                      G.Inside/0
+                                      G.Inside/0;
+                                      Outside/0
                                     ],
                                     Apply
                                       (19,
@@ -117,13 +117,13 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      Outside/0;
-                                      G.Inside/0
+                                      G.Inside/0;
+                                      Outside/0
                                     ],
                                     [
                                       IO/3;
-                                      Outside/0;
-                                      G.Inside/0
+                                      G.Inside/0;
+                                      Outside/0
                                     ],
                                     Apply
                                       (19,
@@ -147,9 +147,9 @@ Value
                             ],
                             [
                               IO/3;
+                              G.Inside/0;
                               NonTermination/3;
-                              Outside/0;
-                              G.Inside/0
+                              Outside/0
                             ],
                             Apply
                               (20,
@@ -197,7 +197,7 @@ Value
     [
       ((h, [ A; B ], [ (l, Type (list/3, A)) ],
         Monad
-          ([ Counter/3; IO/3; NonTermination/3; Outside/0; G.Inside/0 ], B)),
+          ([ Counter/3; IO/3; G.Inside/0; NonTermination/3; Outside/0 ], B)),
         Bind
           (?,
             Lift
@@ -205,20 +205,20 @@ Value
                 [
                   Counter/3;
                   IO/3;
+                  G.Inside/0;
                   NonTermination/3;
-                  Outside/0;
-                  G.Inside/0
+                  Outside/0
                 ],
                 Apply (?, Variable (?, read_counter/3), [ Tuple (?) ])),
             Some x,
             Lift
-              (?, [ IO/3; NonTermination/3; Outside/0; G.Inside/0 ],
+              (?, [ IO/3; G.Inside/0; NonTermination/3; Outside/0 ],
                 [
                   Counter/3;
                   IO/3;
+                  G.Inside/0;
                   NonTermination/3;
-                  Outside/0;
-                  G.Inside/0
+                  Outside/0
                 ],
                 Apply
                   (?, Variable (?, h_rec/0),

--- a/tests/ex17.v
+++ b/tests/ex17.v
@@ -17,31 +17,31 @@ Module G.
   Definition raise_Inside {A : Type} (x : Z * string) : M [ Inside ] A :=
     fun s => (inr (inl x), s).
   
-  Definition g {A : Type} (b : bool) : M [ Outside; Inside ] A :=
+  Definition g {A : Type} (b : bool) : M [ Inside; Outside ] A :=
     if b then
-      lift [_;_] "01" (raise_Inside (12, "no" % string))
+      lift [_;_] "10" (raise_Inside (12, "no" % string))
     else
-      lift [_;_] "10" (raise_Outside tt).
+      lift [_;_] "01" (raise_Outside tt).
 End G.
 
 Fixpoint h_rec {A B : Type} (counter : nat) (l : list A)
-  : M [ IO; NonTermination; Outside; G.Inside ] B :=
+  : M [ IO; G.Inside; NonTermination; Outside ] B :=
   match counter with
-  | O => lift [_;_;_;_] "0100" (not_terminated tt)
+  | O => lift [_;_;_;_] "0010" (not_terminated tt)
   | S counter =>
     match l with
     | [] =>
-      lift [_;_;_;_] "1011"
+      lift [_;_;_;_] "1101"
         (let! _ :=
           lift [_;_;_] "100" (OCaml.Pervasives.print_string "no tail" % string)
           in
         lift [_;_;_] "011" (G.g false))
-    | cons x [] => lift [_;_;_;_] "0001" (G.raise_Inside (0, "gg" % string))
+    | cons x [] => lift [_;_;_;_] "0100" (G.raise_Inside (0, "gg" % string))
     | cons _ xs => (h_rec counter) xs
     end
   end.
 
 Definition h {A B : Type} (l : list A)
-  : M [ Counter; IO; NonTermination; Outside; G.Inside ] B :=
+  : M [ Counter; IO; G.Inside; NonTermination; Outside ] B :=
   let! x := lift [_;_;_;_;_] "10000" (read_counter tt) in
   lift [_;_;_;_;_] "01111" (h_rec x l).

--- a/tests/ex18.effects
+++ b/tests/ex18.effects
@@ -6,12 +6,8 @@ Value
     [
       ((plus_one, [ A ], [ (x, A) ], Type (Z/3)),
         Match
-          ((?,
-            Effect
-              ([
-                (OCaml.Effect.State.state/3, Z/3);
-                (OCaml.Effect.State.state/3, r_state/0)
-              ], .)), Variable ((?, Effect ([ ], .)), x/0),
+          ((?, Effect ([ (OCaml.Effect.State.state/3, Z/3); r_state/0 ], .)),
+            Variable ((?, Effect ([ ], .)), x/0),
             [
               (Any,
                 Apply
@@ -20,8 +16,7 @@ Value
                       ([
                         (OCaml.Effect.State.state/3,
                           Z/3);
-                        (OCaml.Effect.State.state/3,
-                          r_state/0)
+                        r_state/0
                       ],
                         .)),
                     Variable
@@ -38,8 +33,7 @@ Value
                             ([
                               (OCaml.Effect.State.state/3,
                                 Z/3);
-                              (OCaml.Effect.State.state/3,
-                                r_state/0)
+                              r_state/0
                             ],
                               .)),
                           Variable
@@ -61,8 +55,7 @@ Value
                                   ([
                                     (OCaml.Effect.State.state/3,
                                       Z/3);
-                                    (OCaml.Effect.State.state/3,
-                                      r_state/0)
+                                    r_state/0
                                   ],
                                     .)),
                                 Variable
@@ -74,8 +67,7 @@ Value
                                           ->
                                           .
                                             -[
-                                              (OCaml.Effect.State.state/3,
-                                                r_state/0)
+                                              r_state/0
                                             ]->
                                             .)),
                                     OCaml.Effect.State.global/3),
@@ -141,9 +133,9 @@ Value
           ((?,
             Effect
               ([
+                (OCaml.Effect.State.state/3, string/3);
                 OCaml.Failure/3;
-                (OCaml.Effect.State.state/3, s_state/0);
-                (OCaml.Effect.State.state/3, string/3)
+                s_state/0
               ], .)), Variable ((?, Effect ([ ], .)), x/0),
             [
               (Any,
@@ -151,11 +143,10 @@ Value
                   ((8,
                     Effect
                       ([
+                        (OCaml.Effect.State.state/3,
+                          string/3);
                         OCaml.Failure/3;
-                        (OCaml.Effect.State.state/3,
-                          s_state/0);
-                        (OCaml.Effect.State.state/3,
-                          string/3)
+                        s_state/0
                       ],
                         .)),
                     Variable
@@ -175,9 +166,8 @@ Value
                           Effect
                             ([
                               (OCaml.Effect.State.state/3,
-                                s_state/0);
-                              (OCaml.Effect.State.state/3,
-                                string/3)
+                                string/3);
+                              s_state/0
                             ],
                               .)),
                           Variable
@@ -198,9 +188,8 @@ Value
                                 Effect
                                   ([
                                     (OCaml.Effect.State.state/3,
-                                      s_state/0);
-                                    (OCaml.Effect.State.state/3,
-                                      string/3)
+                                      string/3);
+                                    s_state/0
                                   ],
                                     .)),
                                 Variable
@@ -212,8 +201,7 @@ Value
                                           ->
                                           .
                                             -[
-                                              (OCaml.Effect.State.state/3,
-                                                s_state/0)
+                                              s_state/0
                                             ]->
                                             .)),
                                     OCaml.Effect.State.global/3),
@@ -265,12 +253,8 @@ Value
     [
       ((reset, [ A ], [ (x, A) ], Type (unit/3)),
         Match
-          ((?,
-            Effect
-              ([
-                (OCaml.Effect.State.state/3, Z/3);
-                (OCaml.Effect.State.state/3, r_state/0)
-              ], .)), Variable ((?, Effect ([ ], .)), x/0),
+          ((?, Effect ([ (OCaml.Effect.State.state/3, Z/3); r_state/0 ], .)),
+            Variable ((?, Effect ([ ], .)), x/0),
             [
               (Any,
                 Apply
@@ -279,8 +263,7 @@ Value
                       ([
                         (OCaml.Effect.State.state/3,
                           Z/3);
-                        (OCaml.Effect.State.state/3,
-                          r_state/0)
+                        r_state/0
                       ],
                         .)),
                     Variable
@@ -304,8 +287,7 @@ Value
                             ([
                               (OCaml.Effect.State.state/3,
                                 Z/3);
-                              (OCaml.Effect.State.state/3,
-                                r_state/0)
+                              r_state/0
                             ],
                               .)),
                           Variable
@@ -317,8 +299,7 @@ Value
                                     ->
                                     .
                                       -[
-                                        (OCaml.Effect.State.state/3,
-                                          r_state/0)
+                                        r_state/0
                                       ]->
                                       .)),
                               OCaml.Effect.State.global/3),
@@ -376,12 +357,8 @@ Value
     [
       ((incr, [ A ], [ (x, A) ], Type (unit/3)),
         Match
-          ((?,
-            Effect
-              ([
-                (OCaml.Effect.State.state/3, Z/3);
-                (OCaml.Effect.State.state/3, r_state/0)
-              ], .)), Variable ((?, Effect ([ ], .)), x/0),
+          ((?, Effect ([ (OCaml.Effect.State.state/3, Z/3); r_state/0 ], .)),
+            Variable ((?, Effect ([ ], .)), x/0),
             [
               (Any,
                 Apply
@@ -390,8 +367,7 @@ Value
                       ([
                         (OCaml.Effect.State.state/3,
                           Z/3);
-                        (OCaml.Effect.State.state/3,
-                          r_state/0)
+                        r_state/0
                       ],
                         .)),
                     Variable
@@ -415,8 +391,7 @@ Value
                             ([
                               (OCaml.Effect.State.state/3,
                                 Z/3);
-                              (OCaml.Effect.State.state/3,
-                                r_state/0)
+                              r_state/0
                             ],
                               .)),
                           Variable
@@ -428,8 +403,7 @@ Value
                                     ->
                                     .
                                       -[
-                                        (OCaml.Effect.State.state/3,
-                                          r_state/0)
+                                        r_state/0
                                       ]->
                                       .)),
                               OCaml.Effect.State.global/3),
@@ -476,8 +450,7 @@ Value
                             ([
                               (OCaml.Effect.State.state/3,
                                 Z/3);
-                              (OCaml.Effect.State.state/3,
-                                r_state/0)
+                              r_state/0
                             ],
                               .)),
                           Variable
@@ -494,8 +467,7 @@ Value
                                   ([
                                     (OCaml.Effect.State.state/3,
                                       Z/3);
-                                    (OCaml.Effect.State.state/3,
-                                      r_state/0)
+                                    r_state/0
                                   ],
                                     .)),
                                 Variable
@@ -517,8 +489,7 @@ Value
                                         ([
                                           (OCaml.Effect.State.state/3,
                                             Z/3);
-                                          (OCaml.Effect.State.state/3,
-                                            r_state/0)
+                                          r_state/0
                                         ],
                                           .)),
                                       Variable
@@ -530,8 +501,7 @@ Value
                                                 ->
                                                 .
                                                   -[
-                                                    (OCaml.Effect.State.state/3,
-                                                      r_state/0)
+                                                    r_state/0
                                                   ]->
                                                   .)),
                                           OCaml.Effect.State.global/3),

--- a/tests/ex18.effects
+++ b/tests/ex18.effects
@@ -9,10 +9,8 @@ Value
           ((?,
             Effect
               ([
-                TypeEffect
-                (Type (Z/3), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (r_state/0), OCaml.Effect.State.state/3)
+                (OCaml.Effect.State.state/3, Z/3);
+                (OCaml.Effect.State.state/3, r_state/0)
               ], .)), Variable ((?, Effect ([ ], .)), x/0),
             [
               (Any,
@@ -20,14 +18,10 @@ Value
                   ((4,
                     Effect
                       ([
-                        TypeEffect
-                        (Type
-                          (Z/3),
-                          OCaml.Effect.State.state/3);
-                        TypeEffect
-                        (Type
-                          (r_state/0),
-                          OCaml.Effect.State.state/3)
+                        (OCaml.Effect.State.state/3,
+                          Z/3);
+                        (OCaml.Effect.State.state/3,
+                          r_state/0)
                       ],
                         .)),
                     Variable
@@ -42,14 +36,10 @@ Value
                         ((4,
                           Effect
                             ([
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3);
-                              TypeEffect
-                              (Type
-                                (r_state/0),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3);
+                              (OCaml.Effect.State.state/3,
+                                r_state/0)
                             ],
                               .)),
                           Variable
@@ -59,10 +49,8 @@ Value
                                 ],
                                   .
                                     -[
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3)
                                     ]->
                                     .)),
                               OCaml.Effect.State.read/3),
@@ -71,14 +59,10 @@ Value
                               ((?,
                                 Effect
                                   ([
-                                    TypeEffect
-                                    (Type
-                                      (Z/3),
-                                      OCaml.Effect.State.state/3);
-                                    TypeEffect
-                                    (Type
-                                      (r_state/0),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      Z/3);
+                                    (OCaml.Effect.State.state/3,
+                                      r_state/0)
                                   ],
                                     .)),
                                 Variable
@@ -90,10 +74,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              TypeEffect
-                                              (Type
-                                                (r_state/0),
-                                                OCaml.Effect.State.state/3)
+                                              (OCaml.Effect.State.state/3,
+                                                r_state/0)
                                             ]->
                                             .)),
                                     OCaml.Effect.State.global/3),
@@ -109,10 +91,8 @@ Value
                                     ((?,
                                       Effect
                                         ([
-                                          TypeEffect
-                                          (Type
-                                            (Z/3),
-                                            OCaml.Effect.State.state/3)
+                                          (OCaml.Effect.State.state/3,
+                                            Z/3)
                                         ],
                                           .)),
                                       Variable
@@ -122,10 +102,8 @@ Value
                                             ],
                                               .
                                                 -[
-                                                  TypeEffect
-                                                  (Type
-                                                    (Z/3),
-                                                    OCaml.Effect.State.state/3)
+                                                  (OCaml.Effect.State.state/3,
+                                                    Z/3)
                                                 ]->
                                                 .)),
                                           OCaml.Effect.State.peekstate/3),
@@ -164,10 +142,8 @@ Value
             Effect
               ([
                 OCaml.Failure/3;
-                TypeEffect
-                (Type (s_state/0), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (string/3), OCaml.Effect.State.state/3)
+                (OCaml.Effect.State.state/3, s_state/0);
+                (OCaml.Effect.State.state/3, string/3)
               ], .)), Variable ((?, Effect ([ ], .)), x/0),
             [
               (Any,
@@ -176,14 +152,10 @@ Value
                     Effect
                       ([
                         OCaml.Failure/3;
-                        TypeEffect
-                        (Type
-                          (s_state/0),
-                          OCaml.Effect.State.state/3);
-                        TypeEffect
-                        (Type
-                          (string/3),
-                          OCaml.Effect.State.state/3)
+                        (OCaml.Effect.State.state/3,
+                          s_state/0);
+                        (OCaml.Effect.State.state/3,
+                          string/3)
                       ],
                         .)),
                     Variable
@@ -202,14 +174,10 @@ Value
                         ((8,
                           Effect
                             ([
-                              TypeEffect
-                              (Type
-                                (s_state/0),
-                                OCaml.Effect.State.state/3);
-                              TypeEffect
-                              (Type
-                                (string/3),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                s_state/0);
+                              (OCaml.Effect.State.state/3,
+                                string/3)
                             ],
                               .)),
                           Variable
@@ -219,10 +187,8 @@ Value
                                 ],
                                   .
                                     -[
-                                      TypeEffect
-                                      (Type
-                                        (string/3),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        string/3)
                                     ]->
                                     .)),
                               OCaml.Effect.State.read/3),
@@ -231,14 +197,10 @@ Value
                               ((?,
                                 Effect
                                   ([
-                                    TypeEffect
-                                    (Type
-                                      (s_state/0),
-                                      OCaml.Effect.State.state/3);
-                                    TypeEffect
-                                    (Type
-                                      (string/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      s_state/0);
+                                    (OCaml.Effect.State.state/3,
+                                      string/3)
                                   ],
                                     .)),
                                 Variable
@@ -250,10 +212,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              TypeEffect
-                                              (Type
-                                                (s_state/0),
-                                                OCaml.Effect.State.state/3)
+                                              (OCaml.Effect.State.state/3,
+                                                s_state/0)
                                             ]->
                                             .)),
                                     OCaml.Effect.State.global/3),
@@ -269,10 +229,8 @@ Value
                                     ((?,
                                       Effect
                                         ([
-                                          TypeEffect
-                                          (Type
-                                            (string/3),
-                                            OCaml.Effect.State.state/3)
+                                          (OCaml.Effect.State.state/3,
+                                            string/3)
                                         ],
                                           .)),
                                       Variable
@@ -282,10 +240,8 @@ Value
                                             ],
                                               .
                                                 -[
-                                                  TypeEffect
-                                                  (Type
-                                                    (string/3),
-                                                    OCaml.Effect.State.state/3)
+                                                  (OCaml.Effect.State.state/3,
+                                                    string/3)
                                                 ]->
                                                 .)),
                                           OCaml.Effect.State.peekstate/3),
@@ -312,10 +268,8 @@ Value
           ((?,
             Effect
               ([
-                TypeEffect
-                (Type (Z/3), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (r_state/0), OCaml.Effect.State.state/3)
+                (OCaml.Effect.State.state/3, Z/3);
+                (OCaml.Effect.State.state/3, r_state/0)
               ], .)), Variable ((?, Effect ([ ], .)), x/0),
             [
               (Any,
@@ -323,14 +277,10 @@ Value
                   ((11,
                     Effect
                       ([
-                        TypeEffect
-                        (Type
-                          (Z/3),
-                          OCaml.Effect.State.state/3);
-                        TypeEffect
-                        (Type
-                          (r_state/0),
-                          OCaml.Effect.State.state/3)
+                        (OCaml.Effect.State.state/3,
+                          Z/3);
+                        (OCaml.Effect.State.state/3,
+                          r_state/0)
                       ],
                         .)),
                     Variable
@@ -342,10 +292,8 @@ Value
                               ->
                               .
                                 -[
-                                  TypeEffect
-                                  (Type
-                                    (Z/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3)
                                 ]->
                                 .)),
                         OCaml.Effect.State.write/3),
@@ -354,14 +302,10 @@ Value
                         ((?,
                           Effect
                             ([
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3);
-                              TypeEffect
-                              (Type
-                                (r_state/0),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3);
+                              (OCaml.Effect.State.state/3,
+                                r_state/0)
                             ],
                               .)),
                           Variable
@@ -373,10 +317,8 @@ Value
                                     ->
                                     .
                                       -[
-                                        TypeEffect
-                                        (Type
-                                          (r_state/0),
-                                          OCaml.Effect.State.state/3)
+                                        (OCaml.Effect.State.state/3,
+                                          r_state/0)
                                       ]->
                                       .)),
                               OCaml.Effect.State.global/3),
@@ -392,10 +334,8 @@ Value
                               ((?,
                                 Effect
                                   ([
-                                    TypeEffect
-                                    (Type
-                                      (Z/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      Z/3)
                                   ],
                                     .)),
                                 Variable
@@ -405,10 +345,8 @@ Value
                                       ],
                                         .
                                           -[
-                                            TypeEffect
-                                            (Type
-                                              (Z/3),
-                                              OCaml.Effect.State.state/3)
+                                            (OCaml.Effect.State.state/3,
+                                              Z/3)
                                           ]->
                                           .)),
                                     OCaml.Effect.State.peekstate/3),
@@ -441,10 +379,8 @@ Value
           ((?,
             Effect
               ([
-                TypeEffect
-                (Type (Z/3), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (r_state/0), OCaml.Effect.State.state/3)
+                (OCaml.Effect.State.state/3, Z/3);
+                (OCaml.Effect.State.state/3, r_state/0)
               ], .)), Variable ((?, Effect ([ ], .)), x/0),
             [
               (Any,
@@ -452,14 +388,10 @@ Value
                   ((14,
                     Effect
                       ([
-                        TypeEffect
-                        (Type
-                          (Z/3),
-                          OCaml.Effect.State.state/3);
-                        TypeEffect
-                        (Type
-                          (r_state/0),
-                          OCaml.Effect.State.state/3)
+                        (OCaml.Effect.State.state/3,
+                          Z/3);
+                        (OCaml.Effect.State.state/3,
+                          r_state/0)
                       ],
                         .)),
                     Variable
@@ -471,10 +403,8 @@ Value
                               ->
                               .
                                 -[
-                                  TypeEffect
-                                  (Type
-                                    (Z/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3)
                                 ]->
                                 .)),
                         OCaml.Effect.State.write/3),
@@ -483,14 +413,10 @@ Value
                         ((?,
                           Effect
                             ([
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3);
-                              TypeEffect
-                              (Type
-                                (r_state/0),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3);
+                              (OCaml.Effect.State.state/3,
+                                r_state/0)
                             ],
                               .)),
                           Variable
@@ -502,10 +428,8 @@ Value
                                     ->
                                     .
                                       -[
-                                        TypeEffect
-                                        (Type
-                                          (r_state/0),
-                                          OCaml.Effect.State.state/3)
+                                        (OCaml.Effect.State.state/3,
+                                          r_state/0)
                                       ]->
                                       .)),
                               OCaml.Effect.State.global/3),
@@ -521,10 +445,8 @@ Value
                               ((?,
                                 Effect
                                   ([
-                                    TypeEffect
-                                    (Type
-                                      (Z/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      Z/3)
                                   ],
                                     .)),
                                 Variable
@@ -534,10 +456,8 @@ Value
                                       ],
                                         .
                                           -[
-                                            TypeEffect
-                                            (Type
-                                              (Z/3),
-                                              OCaml.Effect.State.state/3)
+                                            (OCaml.Effect.State.state/3,
+                                              Z/3)
                                           ]->
                                           .)),
                                     OCaml.Effect.State.peekstate/3),
@@ -554,14 +474,10 @@ Value
                         ((14,
                           Effect
                             ([
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3);
-                              TypeEffect
-                              (Type
-                                (r_state/0),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3);
+                              (OCaml.Effect.State.state/3,
+                                r_state/0)
                             ],
                               .)),
                           Variable
@@ -576,14 +492,10 @@ Value
                               ((14,
                                 Effect
                                   ([
-                                    TypeEffect
-                                    (Type
-                                      (Z/3),
-                                      OCaml.Effect.State.state/3);
-                                    TypeEffect
-                                    (Type
-                                      (r_state/0),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      Z/3);
+                                    (OCaml.Effect.State.state/3,
+                                      r_state/0)
                                   ],
                                     .)),
                                 Variable
@@ -593,10 +505,8 @@ Value
                                       ],
                                         .
                                           -[
-                                            TypeEffect
-                                            (Type
-                                              (Z/3),
-                                              OCaml.Effect.State.state/3)
+                                            (OCaml.Effect.State.state/3,
+                                              Z/3)
                                           ]->
                                           .)),
                                     OCaml.Effect.State.read/3),
@@ -605,14 +515,10 @@ Value
                                     ((?,
                                       Effect
                                         ([
-                                          TypeEffect
-                                          (Type
-                                            (Z/3),
-                                            OCaml.Effect.State.state/3);
-                                          TypeEffect
-                                          (Type
-                                            (r_state/0),
-                                            OCaml.Effect.State.state/3)
+                                          (OCaml.Effect.State.state/3,
+                                            Z/3);
+                                          (OCaml.Effect.State.state/3,
+                                            r_state/0)
                                         ],
                                           .)),
                                       Variable
@@ -624,10 +530,8 @@ Value
                                                 ->
                                                 .
                                                   -[
-                                                    TypeEffect
-                                                    (Type
-                                                      (r_state/0),
-                                                      OCaml.Effect.State.state/3)
+                                                    (OCaml.Effect.State.state/3,
+                                                      r_state/0)
                                                   ]->
                                                   .)),
                                           OCaml.Effect.State.global/3),
@@ -643,10 +547,8 @@ Value
                                           ((?,
                                             Effect
                                               ([
-                                                TypeEffect
-                                                (Type
-                                                  (Z/3),
-                                                  OCaml.Effect.State.state/3)
+                                                (OCaml.Effect.State.state/3,
+                                                  Z/3)
                                               ],
                                                 .)),
                                             Variable
@@ -656,10 +558,8 @@ Value
                                                   ],
                                                     .
                                                       -[
-                                                        TypeEffect
-                                                        (Type
-                                                          (Z/3),
-                                                          OCaml.Effect.State.state/3)
+                                                        (OCaml.Effect.State.state/3,
+                                                          Z/3)
                                                       ]->
                                                       .)),
                                                 OCaml.Effect.State.peekstate/3),

--- a/tests/ex18.interface
+++ b/tests/ex18.interface
@@ -6,12 +6,12 @@
     [
       [ "Var", "r", [] ],
       [ "Descriptor", "r_state" ],
-      [ "Var", "plus_one", [ [ "OCaml.Effect.State.state", "OCaml.Effect.State.state" ] ] ],
+      [ "Var", "plus_one", [ [ "r_state" ] ] ],
       [ "Var", "s", [] ],
       [ "Descriptor", "s_state" ],
-      [ "Var", "fail", [ [ "OCaml.Failure", "OCaml.Effect.State.state", "OCaml.Effect.State.state" ] ] ],
-      [ "Var", "reset", [ [ "OCaml.Effect.State.state", "OCaml.Effect.State.state" ] ] ],
-      [ "Var", "incr", [ [ "OCaml.Effect.State.state", "OCaml.Effect.State.state" ] ] ]
+      [ "Var", "fail", [ [ "OCaml.Failure", "s_state" ] ] ],
+      [ "Var", "reset", [ [ "r_state" ] ] ],
+      [ "Var", "incr", [ [ "r_state" ] ] ]
     ]
   ]
 }

--- a/tests/ex18.monadise
+++ b/tests/ex18.monadise
@@ -5,11 +5,7 @@ Value
   (non_rec, @.,
     [
       ((plus_one, [ A ], [ (x, A) ],
-        Monad
-          ([
-            (OCaml.Effect.State.state/3, Z/3);
-            (OCaml.Effect.State.state/3, r_state/0)
-          ], Type (Z/3))),
+        Monad ([ (OCaml.Effect.State.state/3, Z/3); r_state/0 ], Type (Z/3))),
         Match
           (?, Variable (?, x/0),
             [
@@ -29,8 +25,7 @@ Value
                                 [
                                   (OCaml.Effect.State.state/3,
                                     Z/3);
-                                  (OCaml.Effect.State.state/3,
-                                    r_state/0)
+                                  r_state/0
                                 ],
                                 Apply
                                   (?,
@@ -46,14 +41,12 @@ Value
                             Lift
                               (?,
                                 [
-                                  (OCaml.Effect.State.state/3,
-                                    r_state/0)
+                                  r_state/0
                                 ],
                                 [
                                   (OCaml.Effect.State.state/3,
                                     Z/3);
-                                  (OCaml.Effect.State.state/3,
-                                    r_state/0)
+                                  r_state/0
                                 ],
                                 Apply
                                   (?,
@@ -79,8 +72,7 @@ Value
                             [
                               (OCaml.Effect.State.state/3,
                                 Z/3);
-                              (OCaml.Effect.State.state/3,
-                                r_state/0)
+                              r_state/0
                             ],
                             Apply
                               (4,
@@ -121,9 +113,9 @@ Value
       ((fail, [ A; B ], [ (x, A) ],
         Monad
           ([
+            (OCaml.Effect.State.state/3, string/3);
             OCaml.Failure/3;
-            (OCaml.Effect.State.state/3, s_state/0);
-            (OCaml.Effect.State.state/3, string/3)
+            s_state/0
           ], B)),
         Match
           (?, Variable (?, x/0),
@@ -135,16 +127,14 @@ Value
                       (?,
                         [
                           (OCaml.Effect.State.state/3,
-                            s_state/0);
-                          (OCaml.Effect.State.state/3,
-                            string/3)
+                            string/3);
+                          s_state/0
                         ],
                         [
+                          (OCaml.Effect.State.state/3,
+                            string/3);
                           OCaml.Failure/3;
-                          (OCaml.Effect.State.state/3,
-                            s_state/0);
-                          (OCaml.Effect.State.state/3,
-                            string/3)
+                          s_state/0
                         ],
                         Bind
                           (?,
@@ -158,9 +148,8 @@ Value
                                     ],
                                     [
                                       (OCaml.Effect.State.state/3,
-                                        s_state/0);
-                                      (OCaml.Effect.State.state/3,
-                                        string/3)
+                                        string/3);
+                                      s_state/0
                                     ],
                                     Apply
                                       (?,
@@ -176,14 +165,12 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      (OCaml.Effect.State.state/3,
-                                        s_state/0)
+                                      s_state/0
                                     ],
                                     [
                                       (OCaml.Effect.State.state/3,
-                                        s_state/0);
-                                      (OCaml.Effect.State.state/3,
-                                        string/3)
+                                        string/3);
+                                      s_state/0
                                     ],
                                     Apply
                                       (?,
@@ -208,9 +195,8 @@ Value
                                 ],
                                 [
                                   (OCaml.Effect.State.state/3,
-                                    s_state/0);
-                                  (OCaml.Effect.State.state/3,
-                                    string/3)
+                                    string/3);
+                                  s_state/0
                                 ],
                                 Apply
                                   (8,
@@ -230,11 +216,10 @@ Value
                           OCaml.Failure/3
                         ],
                         [
+                          (OCaml.Effect.State.state/3,
+                            string/3);
                           OCaml.Failure/3;
-                          (OCaml.Effect.State.state/3,
-                            s_state/0);
-                          (OCaml.Effect.State.state/3,
-                            string/3)
+                          s_state/0
                         ],
                         Apply
                           (8,
@@ -255,10 +240,7 @@ Value
     [
       ((reset, [ A ], [ (x, A) ],
         Monad
-          ([
-            (OCaml.Effect.State.state/3, Z/3);
-            (OCaml.Effect.State.state/3, r_state/0)
-          ], Type (unit/3))),
+          ([ (OCaml.Effect.State.state/3, Z/3); r_state/0 ], Type (unit/3))),
         Match
           (?, Variable (?, x/0),
             [
@@ -276,8 +258,7 @@ Value
                             [
                               (OCaml.Effect.State.state/3,
                                 Z/3);
-                              (OCaml.Effect.State.state/3,
-                                r_state/0)
+                              r_state/0
                             ],
                             Apply
                               (?,
@@ -293,14 +274,12 @@ Value
                         Lift
                           (?,
                             [
-                              (OCaml.Effect.State.state/3,
-                                r_state/0)
+                              r_state/0
                             ],
                             [
                               (OCaml.Effect.State.state/3,
                                 Z/3);
-                              (OCaml.Effect.State.state/3,
-                                r_state/0)
+                              r_state/0
                             ],
                             Apply
                               (?,
@@ -326,8 +305,7 @@ Value
                         [
                           (OCaml.Effect.State.state/3,
                             Z/3);
-                          (OCaml.Effect.State.state/3,
-                            r_state/0)
+                          r_state/0
                         ],
                         Apply
                           (11,
@@ -351,10 +329,7 @@ Value
     [
       ((incr, [ A ], [ (x, A) ],
         Monad
-          ([
-            (OCaml.Effect.State.state/3, Z/3);
-            (OCaml.Effect.State.state/3, r_state/0)
-          ], Type (unit/3))),
+          ([ (OCaml.Effect.State.state/3, Z/3); r_state/0 ], Type (unit/3))),
         Match
           (?, Variable (?, x/0),
             [
@@ -372,8 +347,7 @@ Value
                             [
                               (OCaml.Effect.State.state/3,
                                 Z/3);
-                              (OCaml.Effect.State.state/3,
-                                r_state/0)
+                              r_state/0
                             ],
                             Apply
                               (?,
@@ -389,14 +363,12 @@ Value
                         Lift
                           (?,
                             [
-                              (OCaml.Effect.State.state/3,
-                                r_state/0)
+                              r_state/0
                             ],
                             [
                               (OCaml.Effect.State.state/3,
                                 Z/3);
-                              (OCaml.Effect.State.state/3,
-                                r_state/0)
+                              r_state/0
                             ],
                             Apply
                               (?,
@@ -430,8 +402,7 @@ Value
                                         [
                                           (OCaml.Effect.State.state/3,
                                             Z/3);
-                                          (OCaml.Effect.State.state/3,
-                                            r_state/0)
+                                          r_state/0
                                         ],
                                         Apply
                                           (?,
@@ -447,14 +418,12 @@ Value
                                     Lift
                                       (?,
                                         [
-                                          (OCaml.Effect.State.state/3,
-                                            r_state/0)
+                                          r_state/0
                                         ],
                                         [
                                           (OCaml.Effect.State.state/3,
                                             Z/3);
-                                          (OCaml.Effect.State.state/3,
-                                            r_state/0)
+                                          r_state/0
                                         ],
                                         Apply
                                           (?,
@@ -480,8 +449,7 @@ Value
                                     [
                                       (OCaml.Effect.State.state/3,
                                         Z/3);
-                                      (OCaml.Effect.State.state/3,
-                                        r_state/0)
+                                      r_state/0
                                     ],
                                     Apply
                                       (14,
@@ -521,8 +489,7 @@ Value
                             [
                               (OCaml.Effect.State.state/3,
                                 Z/3);
-                              (OCaml.Effect.State.state/3,
-                                r_state/0)
+                              r_state/0
                             ],
                             Apply
                               (14,

--- a/tests/ex18.monadise
+++ b/tests/ex18.monadise
@@ -7,10 +7,8 @@ Value
       ((plus_one, [ A ], [ (x, A) ],
         Monad
           ([
-            TypeEffect
-            (Type (Z/3), OCaml.Effect.State.state/3);
-            TypeEffect
-            (Type (r_state/0), OCaml.Effect.State.state/3)
+            (OCaml.Effect.State.state/3, Z/3);
+            (OCaml.Effect.State.state/3, r_state/0)
           ], Type (Z/3))),
         Match
           (?, Variable (?, x/0),
@@ -25,20 +23,14 @@ Value
                             Lift
                               (?,
                                 [
-                                  TypeEffect
-                                  (Type
-                                    (Z/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3)
                                 ],
                                 [
-                                  TypeEffect
-                                  (Type
-                                    (Z/3),
-                                    OCaml.Effect.State.state/3);
-                                  TypeEffect
-                                  (Type
-                                    (r_state/0),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3);
+                                  (OCaml.Effect.State.state/3,
+                                    r_state/0)
                                 ],
                                 Apply
                                   (?,
@@ -54,20 +46,14 @@ Value
                             Lift
                               (?,
                                 [
-                                  TypeEffect
-                                  (Type
-                                    (r_state/0),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    r_state/0)
                                 ],
                                 [
-                                  TypeEffect
-                                  (Type
-                                    (Z/3),
-                                    OCaml.Effect.State.state/3);
-                                  TypeEffect
-                                  (Type
-                                    (r_state/0),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3);
+                                  (OCaml.Effect.State.state/3,
+                                    r_state/0)
                                 ],
                                 Apply
                                   (?,
@@ -87,20 +73,14 @@ Value
                         Lift
                           (?,
                             [
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3)
                             ],
                             [
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3);
-                              TypeEffect
-                              (Type
-                                (r_state/0),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3);
+                              (OCaml.Effect.State.state/3,
+                                r_state/0)
                             ],
                             Apply
                               (4,
@@ -142,10 +122,8 @@ Value
         Monad
           ([
             OCaml.Failure/3;
-            TypeEffect
-            (Type (s_state/0), OCaml.Effect.State.state/3);
-            TypeEffect
-            (Type (string/3), OCaml.Effect.State.state/3)
+            (OCaml.Effect.State.state/3, s_state/0);
+            (OCaml.Effect.State.state/3, string/3)
           ], B)),
         Match
           (?, Variable (?, x/0),
@@ -156,25 +134,17 @@ Value
                     Lift
                       (?,
                         [
-                          TypeEffect
-                          (Type
-                            (s_state/0),
-                            OCaml.Effect.State.state/3);
-                          TypeEffect
-                          (Type
-                            (string/3),
-                            OCaml.Effect.State.state/3)
+                          (OCaml.Effect.State.state/3,
+                            s_state/0);
+                          (OCaml.Effect.State.state/3,
+                            string/3)
                         ],
                         [
                           OCaml.Failure/3;
-                          TypeEffect
-                          (Type
-                            (s_state/0),
-                            OCaml.Effect.State.state/3);
-                          TypeEffect
-                          (Type
-                            (string/3),
-                            OCaml.Effect.State.state/3)
+                          (OCaml.Effect.State.state/3,
+                            s_state/0);
+                          (OCaml.Effect.State.state/3,
+                            string/3)
                         ],
                         Bind
                           (?,
@@ -183,20 +153,14 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (string/3),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        string/3)
                                     ],
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (s_state/0),
-                                        OCaml.Effect.State.state/3);
-                                      TypeEffect
-                                      (Type
-                                        (string/3),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        s_state/0);
+                                      (OCaml.Effect.State.state/3,
+                                        string/3)
                                     ],
                                     Apply
                                       (?,
@@ -212,20 +176,14 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (s_state/0),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        s_state/0)
                                     ],
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (s_state/0),
-                                        OCaml.Effect.State.state/3);
-                                      TypeEffect
-                                      (Type
-                                        (string/3),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        s_state/0);
+                                      (OCaml.Effect.State.state/3,
+                                        string/3)
                                     ],
                                     Apply
                                       (?,
@@ -245,20 +203,14 @@ Value
                             Lift
                               (?,
                                 [
-                                  TypeEffect
-                                  (Type
-                                    (string/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    string/3)
                                 ],
                                 [
-                                  TypeEffect
-                                  (Type
-                                    (s_state/0),
-                                    OCaml.Effect.State.state/3);
-                                  TypeEffect
-                                  (Type
-                                    (string/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    s_state/0);
+                                  (OCaml.Effect.State.state/3,
+                                    string/3)
                                 ],
                                 Apply
                                   (8,
@@ -279,14 +231,10 @@ Value
                         ],
                         [
                           OCaml.Failure/3;
-                          TypeEffect
-                          (Type
-                            (s_state/0),
-                            OCaml.Effect.State.state/3);
-                          TypeEffect
-                          (Type
-                            (string/3),
-                            OCaml.Effect.State.state/3)
+                          (OCaml.Effect.State.state/3,
+                            s_state/0);
+                          (OCaml.Effect.State.state/3,
+                            string/3)
                         ],
                         Apply
                           (8,
@@ -308,10 +256,8 @@ Value
       ((reset, [ A ], [ (x, A) ],
         Monad
           ([
-            TypeEffect
-            (Type (Z/3), OCaml.Effect.State.state/3);
-            TypeEffect
-            (Type (r_state/0), OCaml.Effect.State.state/3)
+            (OCaml.Effect.State.state/3, Z/3);
+            (OCaml.Effect.State.state/3, r_state/0)
           ], Type (unit/3))),
         Match
           (?, Variable (?, x/0),
@@ -324,20 +270,14 @@ Value
                         Lift
                           (?,
                             [
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3)
                             ],
                             [
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3);
-                              TypeEffect
-                              (Type
-                                (r_state/0),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3);
+                              (OCaml.Effect.State.state/3,
+                                r_state/0)
                             ],
                             Apply
                               (?,
@@ -353,20 +293,14 @@ Value
                         Lift
                           (?,
                             [
-                              TypeEffect
-                              (Type
-                                (r_state/0),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                r_state/0)
                             ],
                             [
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3);
-                              TypeEffect
-                              (Type
-                                (r_state/0),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3);
+                              (OCaml.Effect.State.state/3,
+                                r_state/0)
                             ],
                             Apply
                               (?,
@@ -386,20 +320,14 @@ Value
                     Lift
                       (?,
                         [
-                          TypeEffect
-                          (Type
-                            (Z/3),
-                            OCaml.Effect.State.state/3)
+                          (OCaml.Effect.State.state/3,
+                            Z/3)
                         ],
                         [
-                          TypeEffect
-                          (Type
-                            (Z/3),
-                            OCaml.Effect.State.state/3);
-                          TypeEffect
-                          (Type
-                            (r_state/0),
-                            OCaml.Effect.State.state/3)
+                          (OCaml.Effect.State.state/3,
+                            Z/3);
+                          (OCaml.Effect.State.state/3,
+                            r_state/0)
                         ],
                         Apply
                           (11,
@@ -424,10 +352,8 @@ Value
       ((incr, [ A ], [ (x, A) ],
         Monad
           ([
-            TypeEffect
-            (Type (Z/3), OCaml.Effect.State.state/3);
-            TypeEffect
-            (Type (r_state/0), OCaml.Effect.State.state/3)
+            (OCaml.Effect.State.state/3, Z/3);
+            (OCaml.Effect.State.state/3, r_state/0)
           ], Type (unit/3))),
         Match
           (?, Variable (?, x/0),
@@ -440,20 +366,14 @@ Value
                         Lift
                           (?,
                             [
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3)
                             ],
                             [
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3);
-                              TypeEffect
-                              (Type
-                                (r_state/0),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3);
+                              (OCaml.Effect.State.state/3,
+                                r_state/0)
                             ],
                             Apply
                               (?,
@@ -469,20 +389,14 @@ Value
                         Lift
                           (?,
                             [
-                              TypeEffect
-                              (Type
-                                (r_state/0),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                r_state/0)
                             ],
                             [
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3);
-                              TypeEffect
-                              (Type
-                                (r_state/0),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3);
+                              (OCaml.Effect.State.state/3,
+                                r_state/0)
                             ],
                             Apply
                               (?,
@@ -510,20 +424,14 @@ Value
                                     Lift
                                       (?,
                                         [
-                                          TypeEffect
-                                          (Type
-                                            (Z/3),
-                                            OCaml.Effect.State.state/3)
+                                          (OCaml.Effect.State.state/3,
+                                            Z/3)
                                         ],
                                         [
-                                          TypeEffect
-                                          (Type
-                                            (Z/3),
-                                            OCaml.Effect.State.state/3);
-                                          TypeEffect
-                                          (Type
-                                            (r_state/0),
-                                            OCaml.Effect.State.state/3)
+                                          (OCaml.Effect.State.state/3,
+                                            Z/3);
+                                          (OCaml.Effect.State.state/3,
+                                            r_state/0)
                                         ],
                                         Apply
                                           (?,
@@ -539,20 +447,14 @@ Value
                                     Lift
                                       (?,
                                         [
-                                          TypeEffect
-                                          (Type
-                                            (r_state/0),
-                                            OCaml.Effect.State.state/3)
+                                          (OCaml.Effect.State.state/3,
+                                            r_state/0)
                                         ],
                                         [
-                                          TypeEffect
-                                          (Type
-                                            (Z/3),
-                                            OCaml.Effect.State.state/3);
-                                          TypeEffect
-                                          (Type
-                                            (r_state/0),
-                                            OCaml.Effect.State.state/3)
+                                          (OCaml.Effect.State.state/3,
+                                            Z/3);
+                                          (OCaml.Effect.State.state/3,
+                                            r_state/0)
                                         ],
                                         Apply
                                           (?,
@@ -572,20 +474,14 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3)
                                     ],
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3);
-                                      TypeEffect
-                                      (Type
-                                        (r_state/0),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3);
+                                      (OCaml.Effect.State.state/3,
+                                        r_state/0)
                                     ],
                                     Apply
                                       (14,
@@ -619,20 +515,14 @@ Value
                         Lift
                           (?,
                             [
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3)
                             ],
                             [
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3);
-                              TypeEffect
-                              (Type
-                                (r_state/0),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3);
+                              (OCaml.Effect.State.state/3,
+                                r_state/0)
                             ],
                             Apply
                               (14,

--- a/tests/ex18.v
+++ b/tests/ex18.v
@@ -5,10 +5,10 @@ Local Open Scope type_scope.
 Import ListNotations.
 
 Definition r : OCaml.Effect.State.t Z := OCaml.Effect.State.init 12.
-Definition r_state := nat.
+Definition r_state := OCaml.Effect.State.state nat.
 
 Definition plus_one {A : Type} (x : A)
-  : M [ OCaml.Effect.State.state Z; OCaml.Effect.State.state r_state ] Z :=
+  : M [ OCaml.Effect.State.state Z; r_state ] Z :=
   match x with
   | _ =>
     let! x_1 :=
@@ -21,28 +21,23 @@ Definition plus_one {A : Type} (x : A)
 
 Definition s : OCaml.Effect.State.t string := OCaml.Effect.State.init
   "Hi" % string.
-Definition s_state := nat.
+Definition s_state := OCaml.Effect.State.state nat.
 
 Definition fail {A B : Type} (x : A)
-  : M
-    [
-      OCaml.Failure;
-      OCaml.Effect.State.state s_state;
-      OCaml.Effect.State.state string
-    ] B :=
+  : M [ OCaml.Effect.State.state string; OCaml.Failure; s_state ] B :=
   match x with
   | _ =>
     let! x_1 :=
-      lift [_;_;_] "011"
+      lift [_;_;_] "101"
         (let! x_1 :=
-          let! x_1 := lift [_;_] "01" (OCaml.Effect.State.peekstate tt) in
-          lift [_;_] "10" (OCaml.Effect.State.global s x_1) in
-        lift [_;_] "01" (OCaml.Effect.State.read x_1)) in
-    lift [_;_;_] "100" (OCaml.Pervasives.failwith x_1)
+          let! x_1 := lift [_;_] "10" (OCaml.Effect.State.peekstate tt) in
+          lift [_;_] "01" (OCaml.Effect.State.global s x_1) in
+        lift [_;_] "10" (OCaml.Effect.State.read x_1)) in
+    lift [_;_;_] "010" (OCaml.Pervasives.failwith x_1)
   end.
 
 Definition reset {A : Type} (x : A)
-  : M [ OCaml.Effect.State.state Z; OCaml.Effect.State.state r_state ] unit :=
+  : M [ OCaml.Effect.State.state Z; r_state ] unit :=
   match x with
   | _ =>
     let! x_1 :=
@@ -52,7 +47,7 @@ Definition reset {A : Type} (x : A)
   end.
 
 Definition incr {A : Type} (x : A)
-  : M [ OCaml.Effect.State.state Z; OCaml.Effect.State.state r_state ] unit :=
+  : M [ OCaml.Effect.State.state Z; r_state ] unit :=
   match x with
   | _ =>
     let! x_1 :=

--- a/tests/ex19.effects
+++ b/tests/ex19.effects
@@ -131,7 +131,7 @@ Value
             Run
               ((?, Effect ([ OCaml.Failure/3 ], .)), Error/0, [ ],
                 IfThenElse
-                  ((14, Effect ([ OCaml.Failure/3; Error/0 ], .)),
+                  ((14, Effect ([ Error/0; OCaml.Failure/3 ], .)),
                     Variable ((14, Effect ([ ], .)), b/0),
                     Apply
                       ((14, Effect ([ OCaml.Failure/3 ], .)),

--- a/tests/ex19.monadise
+++ b/tests/ex19.monadise
@@ -76,12 +76,12 @@ Value
         Bind
           (?,
             Run
-              (?, Error/0, [ OCaml.Failure/3; Error/0 ],
+              (?, Error/0, [ Error/0; OCaml.Failure/3 ],
                 IfThenElse
                   (14, Variable (14, b/0),
                     Lift
                       (?, [ OCaml.Failure/3 ],
-                        [ OCaml.Failure/3; Error/0 ],
+                        [ Error/0; OCaml.Failure/3 ],
                         Apply
                           (14,
                             Variable
@@ -94,7 +94,7 @@ Value
                             ])),
                     Lift
                       (?, [ Error/0 ],
-                        [ OCaml.Failure/3; Error/0 ],
+                        [ Error/0; OCaml.Failure/3 ],
                         Apply
                           (14, Variable (14, raise_Error/0),
                             [ Tuple (?) ])))), Some x,

--- a/tests/ex19.v
+++ b/tests/ex19.v
@@ -26,11 +26,11 @@ Definition x2 {A B : Type} (x : A) : M [ OCaml.Failure ] B :=
 
 Definition x3 (b : bool) : M [ OCaml.Failure ] Z :=
   let! x :=
-    Exception.run 1
+    Exception.run 0
       (if b then
-        lift [_;_] "10" (OCaml.Pervasives.failwith "arg" % string)
+        lift [_;_] "01" (OCaml.Pervasives.failwith "arg" % string)
       else
-        lift [_;_] "01" (raise_Error tt)) tt in
+        lift [_;_] "10" (raise_Error tt)) tt in
   match x with
   | inl x => ret x
   | inr tt => ret 12

--- a/tests/ex39.effects
+++ b/tests/ex39.effects
@@ -5,44 +5,23 @@ Value
   (non_rec, @.,
     [
       ((get_local_ref, [ ], [ (tt, Type (unit/3)) ], Type (Z/3)),
-        LetVar
-          (4,
-            Effect
-              ([ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
-                .)) x =
+        LetVar (4, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)) x =
           Apply
-            ((4,
-              Effect
-                ([
-                  TypeEffect
-                  (Type (Z/3), OCaml.Effect.State.state/3)
-                ], .)),
+            ((4, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)),
               Variable
                 ((4,
                   Effect
                     ([ ],
-                      .
-                        -[
-                          TypeEffect
-                          (Type (Z/3),
-                            OCaml.Effect.State.state/3)
-                        ]-> .)), OCaml.Pervasives.ref/3),
+                      . -[ (OCaml.Effect.State.state/3, Z/3) ]->
+                        .)), OCaml.Pervasives.ref/3),
               [ Constant ((4, Effect ([ ], .)), Int(12)) ]) in
         Apply
-          ((5,
-            Effect
-              ([ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
-                .)),
+          ((5, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)),
             Variable
               ((5,
                 Effect
-                  ([ ],
-                    .
-                      -[
-                        TypeEffect
-                        (Type (Z/3),
-                          OCaml.Effect.State.state/3)
-                      ]-> .)), OCaml.Effect.State.read/3),
+                  ([ ], . -[ (OCaml.Effect.State.state/3, Z/3) ]-> .)),
+                OCaml.Effect.State.read/3),
             [ Variable ((5, Effect ([ ], .)), x/0) ]))
     ])
 
@@ -51,41 +30,20 @@ Value
   (non_rec, @.,
     [
       ((set_local_ref, [ ], [ (tt, Type (unit/3)) ], Type (Z/3)),
-        LetVar
-          (8,
-            Effect
-              ([ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
-                .)) x =
+        LetVar (8, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)) x =
           Apply
-            ((8,
-              Effect
-                ([
-                  TypeEffect
-                  (Type (Z/3), OCaml.Effect.State.state/3)
-                ], .)),
+            ((8, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)),
               Variable
                 ((8,
                   Effect
                     ([ ],
-                      .
-                        -[
-                          TypeEffect
-                          (Type (Z/3),
-                            OCaml.Effect.State.state/3)
-                        ]-> .)), OCaml.Pervasives.ref/3),
+                      . -[ (OCaml.Effect.State.state/3, Z/3) ]->
+                        .)), OCaml.Pervasives.ref/3),
               [ Constant ((8, Effect ([ ], .)), Int(12)) ]) in
         Sequence
-          ((9,
-            Effect
-              ([ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
-                .)),
+          ((9, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)),
             Apply
-              ((9,
-                Effect
-                  ([
-                    TypeEffect
-                    (Type (Z/3), OCaml.Effect.State.state/3)
-                  ], .)),
+              ((9, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)),
                 Variable
                   ((9,
                     Effect
@@ -93,9 +51,8 @@ Value
                         . ->
                           .
                             -[
-                              TypeEffect
-                              (Type (Z/3),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3)
                             ]-> .)),
                     OCaml.Effect.State.write/3),
                 [
@@ -103,21 +60,15 @@ Value
                   Constant ((9, Effect ([ ], .)), Int(15))
                 ]),
             Apply
-              ((10,
-                Effect
-                  ([
-                    TypeEffect
-                    (Type (Z/3), OCaml.Effect.State.state/3)
-                  ], .)),
+              ((10, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)),
                 Variable
                   ((10,
                     Effect
                       ([ ],
                         .
                           -[
-                            TypeEffect
-                            (Type (Z/3),
-                              OCaml.Effect.State.state/3)
+                            (OCaml.Effect.State.state/3,
+                              Z/3)
                           ]-> .)), OCaml.Effect.State.read/3),
                 [ Variable ((10, Effect ([ ], .)), x/0) ])))
     ])
@@ -129,41 +80,20 @@ Value
       ((add_multiple_by_refs, [ ],
         [ (a, Type (Z/3)); (b, Type (Z/3)); (c, Type (Z/3)); (d, Type (Z/3)) ],
         Type (Z/3)),
-        LetVar
-          (13,
-            Effect
-              ([ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
-                .)) x =
+        LetVar (13, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)) x =
           Apply
-            ((13,
-              Effect
-                ([
-                  TypeEffect
-                  (Type (Z/3), OCaml.Effect.State.state/3)
-                ], .)),
+            ((13, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)),
               Variable
                 ((13,
                   Effect
                     ([ ],
-                      .
-                        -[
-                          TypeEffect
-                          (Type (Z/3),
-                            OCaml.Effect.State.state/3)
-                        ]-> .)), OCaml.Pervasives.ref/3),
+                      . -[ (OCaml.Effect.State.state/3, Z/3) ]->
+                        .)), OCaml.Pervasives.ref/3),
               [ Variable ((13, Effect ([ ], .)), a/0) ]) in
         Sequence
-          ((14,
-            Effect
-              ([ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
-                .)),
+          ((14, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)),
             Apply
-              ((14,
-                Effect
-                  ([
-                    TypeEffect
-                    (Type (Z/3), OCaml.Effect.State.state/3)
-                  ], .)),
+              ((14, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)),
                 Variable
                   ((14,
                     Effect
@@ -171,9 +101,8 @@ Value
                         . ->
                           .
                             -[
-                              TypeEffect
-                              (Type (Z/3),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3)
                             ]-> .)),
                     OCaml.Effect.State.write/3),
                 [
@@ -182,10 +111,8 @@ Value
                     ((14,
                       Effect
                         ([
-                          TypeEffect
-                          (Type
-                            (Z/3),
-                            OCaml.Effect.State.state/3)
+                          (OCaml.Effect.State.state/3,
+                            Z/3)
                         ],
                           .)),
                       Variable
@@ -200,10 +127,8 @@ Value
                           ((14,
                             Effect
                               ([
-                                TypeEffect
-                                (Type
-                                  (Z/3),
-                                  OCaml.Effect.State.state/3)
+                                (OCaml.Effect.State.state/3,
+                                  Z/3)
                               ],
                                 .)),
                             Variable
@@ -213,10 +138,8 @@ Value
                                   ],
                                     .
                                       -[
-                                        TypeEffect
-                                        (Type
-                                          (Z/3),
-                                          OCaml.Effect.State.state/3)
+                                        (OCaml.Effect.State.state/3,
+                                          Z/3)
                                       ]->
                                       .)),
                                 OCaml.Effect.State.read/3),
@@ -238,47 +161,28 @@ Value
                             b/0)
                       ])
                 ]),
-            LetVar
-              (15,
-                Effect
-                  ([
-                    TypeEffect
-                    (Type (Z/3), OCaml.Effect.State.state/3)
-                  ], .)) y =
+            LetVar (15, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .))
+              y =
               Apply
                 ((15,
-                  Effect
-                    ([
-                      TypeEffect
-                      (Type (Z/3), OCaml.Effect.State.state/3)
-                    ], .)),
+                  Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)),
                   Variable
                     ((15,
                       Effect
                         ([ ],
                           .
                             -[
-                              TypeEffect
-                              (Type (Z/3),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3)
                             ]-> .)),
                       OCaml.Pervasives.ref/3),
                   [ Variable ((15, Effect ([ ], .)), c/0) ]) in
             Sequence
-              ((16,
-                Effect
-                  ([
-                    TypeEffect
-                    (Type (Z/3), OCaml.Effect.State.state/3)
-                  ], .)),
+              ((16, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)),
                 Apply
                   ((16,
                     Effect
-                      ([
-                        TypeEffect
-                        (Type (Z/3),
-                          OCaml.Effect.State.state/3)
-                      ], .)),
+                      ([ (OCaml.Effect.State.state/3, Z/3) ], .)),
                     Variable
                       ((16,
                         Effect
@@ -286,9 +190,8 @@ Value
                             . ->
                               .
                                 -[
-                                  TypeEffect
-                                  (Type (Z/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3)
                                 ]-> .)),
                         OCaml.Effect.State.write/3),
                     [
@@ -297,10 +200,8 @@ Value
                         ((16,
                           Effect
                             ([
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3)
                             ],
                               .)),
                           Variable
@@ -315,10 +216,8 @@ Value
                               ((16,
                                 Effect
                                   ([
-                                    TypeEffect
-                                    (Type
-                                      (Z/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      Z/3)
                                   ],
                                     .)),
                                 Variable
@@ -328,10 +227,8 @@ Value
                                       ],
                                         .
                                           -[
-                                            TypeEffect
-                                            (Type
-                                              (Z/3),
-                                              OCaml.Effect.State.state/3)
+                                            (OCaml.Effect.State.state/3,
+                                              Z/3)
                                           ]->
                                           .)),
                                     OCaml.Effect.State.read/3),
@@ -356,28 +253,21 @@ Value
                 LetVar
                   (17,
                     Effect
-                      ([
-                        TypeEffect
-                        (Type (Z/3),
-                          OCaml.Effect.State.state/3)
-                      ], .)) z =
+                      ([ (OCaml.Effect.State.state/3, Z/3) ], .))
+                  z =
                   Apply
                     ((17,
                       Effect
-                        ([
-                          TypeEffect
-                          (Type (Z/3),
-                            OCaml.Effect.State.state/3)
-                        ], .)),
+                        ([ (OCaml.Effect.State.state/3, Z/3) ],
+                          .)),
                       Variable
                         ((17,
                           Effect
                             ([ ],
                               .
                                 -[
-                                  TypeEffect
-                                  (Type (Z/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3)
                                 ]-> .)),
                           OCaml.Pervasives.ref/3),
                       [
@@ -385,10 +275,8 @@ Value
                           ((17,
                             Effect
                               ([
-                                TypeEffect
-                                (Type
-                                  (Z/3),
-                                  OCaml.Effect.State.state/3)
+                                (OCaml.Effect.State.state/3,
+                                  Z/3)
                               ],
                                 .)),
                             Variable
@@ -403,10 +291,8 @@ Value
                                 ((17,
                                   Effect
                                     ([
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3)
                                     ],
                                       .)),
                                   Variable
@@ -416,10 +302,8 @@ Value
                                         ],
                                           .
                                             -[
-                                              TypeEffect
-                                              (Type
-                                                (Z/3),
-                                                OCaml.Effect.State.state/3)
+                                              (OCaml.Effect.State.state/3,
+                                                Z/3)
                                             ]->
                                             .)),
                                       OCaml.Effect.State.read/3),
@@ -436,10 +320,8 @@ Value
                                 ((17,
                                   Effect
                                     ([
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3)
                                     ],
                                       .)),
                                   Variable
@@ -449,10 +331,8 @@ Value
                                         ],
                                           .
                                             -[
-                                              TypeEffect
-                                              (Type
-                                                (Z/3),
-                                                OCaml.Effect.State.state/3)
+                                              (OCaml.Effect.State.state/3,
+                                                Z/3)
                                             ]->
                                             .)),
                                       OCaml.Effect.State.read/3),
@@ -470,20 +350,15 @@ Value
                 Apply
                   ((18,
                     Effect
-                      ([
-                        TypeEffect
-                        (Type (Z/3),
-                          OCaml.Effect.State.state/3)
-                      ], .)),
+                      ([ (OCaml.Effect.State.state/3, Z/3) ], .)),
                     Variable
                       ((18,
                         Effect
                           ([ ],
                             .
                               -[
-                                TypeEffect
-                                (Type (Z/3),
-                                  OCaml.Effect.State.state/3)
+                                (OCaml.Effect.State.state/3,
+                                  Z/3)
                               ]-> .)),
                         OCaml.Effect.State.read/3),
                     [ Variable ((18, Effect ([ ], .)), z/0) ]))))
@@ -496,21 +371,14 @@ Value
       ((set_ref, [ ], [ (x, Type (OCaml.Effect.State.t/3, Type (Z/3))) ],
         Type (unit/3)),
         Apply
-          ((21,
-            Effect
-              ([ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
-                .)),
+          ((21, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)),
             Variable
               ((21,
                 Effect
                   ([ ],
                     . ->
-                      .
-                        -[
-                          TypeEffect
-                          (Type (Z/3),
-                            OCaml.Effect.State.state/3)
-                        ]-> .)), OCaml.Effect.State.write/3),
+                      . -[ (OCaml.Effect.State.state/3, Z/3) ]->
+                        .)), OCaml.Effect.State.write/3),
             [
               Variable ((21, Effect ([ ], .)), x/0);
               Constant ((21, Effect ([ ], .)), Int(15))
@@ -524,20 +392,12 @@ Value
       ((get_ref, [ ], [ (x, Type (OCaml.Effect.State.t/3, Type (Z/3))) ],
         Type (Z/3)),
         Apply
-          ((24,
-            Effect
-              ([ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
-                .)),
+          ((24, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)),
             Variable
               ((24,
                 Effect
-                  ([ ],
-                    .
-                      -[
-                        TypeEffect
-                        (Type (Z/3),
-                          OCaml.Effect.State.state/3)
-                      ]-> .)), OCaml.Effect.State.read/3),
+                  ([ ], . -[ (OCaml.Effect.State.state/3, Z/3) ]-> .)),
+                OCaml.Effect.State.read/3),
             [ Variable ((24, Effect ([ ], .)), x/0) ]))
     ])
 
@@ -548,31 +408,22 @@ Value
       ((update_ref, [ ], [ (x, Type (OCaml.Effect.State.t/3, Type (Z/3))) ],
         Type (unit/3)),
         Apply
-          ((27,
-            Effect
-              ([ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
-                .)),
+          ((27, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)),
             Variable
               ((27,
                 Effect
                   ([ ],
                     . ->
-                      .
-                        -[
-                          TypeEffect
-                          (Type (Z/3),
-                            OCaml.Effect.State.state/3)
-                        ]-> .)), OCaml.Effect.State.write/3),
+                      . -[ (OCaml.Effect.State.state/3, Z/3) ]->
+                        .)), OCaml.Effect.State.write/3),
             [
               Variable ((27, Effect ([ ], .)), x/0);
               Apply
                 ((27,
                   Effect
                     ([
-                      TypeEffect
-                      (Type
-                        (Z/3),
-                        OCaml.Effect.State.state/3)
+                      (OCaml.Effect.State.state/3,
+                        Z/3)
                     ], .)),
                   Variable
                     ((27,
@@ -586,10 +437,8 @@ Value
                       ((27,
                         Effect
                           ([
-                            TypeEffect
-                            (Type
-                              (Z/3),
-                              OCaml.Effect.State.state/3)
+                            (OCaml.Effect.State.state/3,
+                              Z/3)
                           ],
                             .)),
                         Variable
@@ -599,10 +448,8 @@ Value
                               ],
                                 .
                                   -[
-                                    TypeEffect
-                                    (Type
-                                      (Z/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      Z/3)
                                   ]->
                                   .)),
                             OCaml.Effect.State.read/3),
@@ -633,20 +480,12 @@ Value
       ((new_ref, [ ], [ (x, Type (unit/3)) ],
         Type (OCaml.Effect.State.t/3, Type (Z/3))),
         Apply
-          ((30,
-            Effect
-              ([ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
-                .)),
+          ((30, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)),
             Variable
               ((30,
                 Effect
-                  ([ ],
-                    .
-                      -[
-                        TypeEffect
-                        (Type (Z/3),
-                          OCaml.Effect.State.state/3)
-                      ]-> .)), OCaml.Pervasives.ref/3),
+                  ([ ], . -[ (OCaml.Effect.State.state/3, Z/3) ]-> .)),
+                OCaml.Pervasives.ref/3),
             [ Constant ((30, Effect ([ ], .)), Int(15)) ]))
     ])
 
@@ -661,34 +500,23 @@ Value
           ((34,
             Effect
               ([
-                TypeEffect
-                (Type (Z/3), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (r_state/0), OCaml.Effect.State.state/3)
+                (OCaml.Effect.State.state/3, Z/3);
+                (OCaml.Effect.State.state/3, r_state/0)
               ], .)),
             Variable
               ((34,
                 Effect
-                  ([ ],
-                    .
-                      -[
-                        TypeEffect
-                        (Type (Z/3),
-                          OCaml.Effect.State.state/3)
-                      ]-> .)), set_ref/0),
+                  ([ ], . -[ (OCaml.Effect.State.state/3, Z/3) ]-> .)),
+                set_ref/0),
             [
               Apply
                 ((?,
                   Effect
                     ([
-                      TypeEffect
-                      (Type
-                        (Z/3),
-                        OCaml.Effect.State.state/3);
-                      TypeEffect
-                      (Type
-                        (r_state/0),
-                        OCaml.Effect.State.state/3)
+                      (OCaml.Effect.State.state/3,
+                        Z/3);
+                      (OCaml.Effect.State.state/3,
+                        r_state/0)
                     ], .)),
                   Variable
                     ((?,
@@ -699,10 +527,8 @@ Value
                             ->
                             .
                               -[
-                                TypeEffect
-                                (Type
-                                  (r_state/0),
-                                  OCaml.Effect.State.state/3)
+                                (OCaml.Effect.State.state/3,
+                                  r_state/0)
                               ]->
                               .)),
                       OCaml.Effect.State.global/3),
@@ -718,10 +544,8 @@ Value
                       ((?,
                         Effect
                           ([
-                            TypeEffect
-                            (Type
-                              (Z/3),
-                              OCaml.Effect.State.state/3)
+                            (OCaml.Effect.State.state/3,
+                              Z/3)
                           ],
                             .)),
                         Variable
@@ -731,10 +555,8 @@ Value
                               ],
                                 .
                                   -[
-                                    TypeEffect
-                                    (Type
-                                      (Z/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      Z/3)
                                   ]->
                                   .)),
                             OCaml.Effect.State.peekstate/3),
@@ -759,34 +581,23 @@ Value
           ((36,
             Effect
               ([
-                TypeEffect
-                (Type (Z/3), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (r_state/0), OCaml.Effect.State.state/3)
+                (OCaml.Effect.State.state/3, Z/3);
+                (OCaml.Effect.State.state/3, r_state/0)
               ], .)),
             Variable
               ((36,
                 Effect
-                  ([ ],
-                    .
-                      -[
-                        TypeEffect
-                        (Type (Z/3),
-                          OCaml.Effect.State.state/3)
-                      ]-> .)), get_ref/0),
+                  ([ ], . -[ (OCaml.Effect.State.state/3, Z/3) ]-> .)),
+                get_ref/0),
             [
               Apply
                 ((?,
                   Effect
                     ([
-                      TypeEffect
-                      (Type
-                        (Z/3),
-                        OCaml.Effect.State.state/3);
-                      TypeEffect
-                      (Type
-                        (r_state/0),
-                        OCaml.Effect.State.state/3)
+                      (OCaml.Effect.State.state/3,
+                        Z/3);
+                      (OCaml.Effect.State.state/3,
+                        r_state/0)
                     ], .)),
                   Variable
                     ((?,
@@ -797,10 +608,8 @@ Value
                             ->
                             .
                               -[
-                                TypeEffect
-                                (Type
-                                  (r_state/0),
-                                  OCaml.Effect.State.state/3)
+                                (OCaml.Effect.State.state/3,
+                                  r_state/0)
                               ]->
                               .)),
                       OCaml.Effect.State.global/3),
@@ -816,10 +625,8 @@ Value
                       ((?,
                         Effect
                           ([
-                            TypeEffect
-                            (Type
-                              (Z/3),
-                              OCaml.Effect.State.state/3)
+                            (OCaml.Effect.State.state/3,
+                              Z/3)
                           ],
                             .)),
                         Variable
@@ -829,10 +636,8 @@ Value
                               ],
                                 .
                                   -[
-                                    TypeEffect
-                                    (Type
-                                      (Z/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      Z/3)
                                   ]->
                                   .)),
                             OCaml.Effect.State.peekstate/3),
@@ -857,19 +662,15 @@ Value
           (39,
             Effect
               ([
-                TypeEffect
-                (Type (Z/3), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (r_state/0), OCaml.Effect.State.state/3)
+                (OCaml.Effect.State.state/3, Z/3);
+                (OCaml.Effect.State.state/3, r_state/0)
               ], .)) i =
           Apply
             ((39,
               Effect
                 ([
-                  TypeEffect
-                  (Type (Z/3), OCaml.Effect.State.state/3);
-                  TypeEffect
-                  (Type (r_state/0), OCaml.Effect.State.state/3)
+                  (OCaml.Effect.State.state/3, Z/3);
+                  (OCaml.Effect.State.state/3, r_state/0)
                 ], .)),
               Variable
                 ((39,
@@ -877,31 +678,24 @@ Value
                     ([ ],
                       .
                         -[
-                          TypeEffect
-                          (Type (Z/3),
-                            OCaml.Effect.State.state/3);
-                          TypeEffect
-                          (Type (r_state/0),
-                            OCaml.Effect.State.state/3)
+                          (OCaml.Effect.State.state/3, Z/3);
+                          (OCaml.Effect.State.state/3,
+                            r_state/0)
                         ]-> .)), get_r/0),
               [ Constructor ((39, Effect ([ ], .)), tt/3) ]) in
         Sequence
           ((40,
             Effect
               ([
-                TypeEffect
-                (Type (Z/3), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (r_state/0), OCaml.Effect.State.state/3)
+                (OCaml.Effect.State.state/3, Z/3);
+                (OCaml.Effect.State.state/3, r_state/0)
               ], .)),
             Apply
               ((40,
                 Effect
                   ([
-                    TypeEffect
-                    (Type (Z/3), OCaml.Effect.State.state/3);
-                    TypeEffect
-                    (Type (r_state/0), OCaml.Effect.State.state/3)
+                    (OCaml.Effect.State.state/3, Z/3);
+                    (OCaml.Effect.State.state/3, r_state/0)
                   ], .)),
                 Variable
                   ((40,
@@ -909,32 +703,25 @@ Value
                       ([ ],
                         .
                           -[
-                            TypeEffect
-                            (Type (Z/3),
-                              OCaml.Effect.State.state/3);
-                            TypeEffect
-                            (Type (r_state/0),
-                              OCaml.Effect.State.state/3)
+                            (OCaml.Effect.State.state/3,
+                              Z/3);
+                            (OCaml.Effect.State.state/3,
+                              r_state/0)
                           ]-> .)), set_r/0),
                 [ Constructor ((40, Effect ([ ], .)), tt/3) ]),
             LetVar
               (41,
                 Effect
                   ([
-                    TypeEffect
-                    (Type (Z/3), OCaml.Effect.State.state/3);
-                    TypeEffect
-                    (Type (r_state/0), OCaml.Effect.State.state/3)
+                    (OCaml.Effect.State.state/3, Z/3);
+                    (OCaml.Effect.State.state/3, r_state/0)
                   ], .)) j =
               Apply
                 ((41,
                   Effect
                     ([
-                      TypeEffect
-                      (Type (Z/3), OCaml.Effect.State.state/3);
-                      TypeEffect
-                      (Type (r_state/0),
-                        OCaml.Effect.State.state/3)
+                      (OCaml.Effect.State.state/3, Z/3);
+                      (OCaml.Effect.State.state/3, r_state/0)
                     ], .)),
                   Variable
                     ((41,
@@ -942,33 +729,26 @@ Value
                         ([ ],
                           .
                             -[
-                              TypeEffect
-                              (Type (Z/3),
-                                OCaml.Effect.State.state/3);
-                              TypeEffect
-                              (Type (r_state/0),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3);
+                              (OCaml.Effect.State.state/3,
+                                r_state/0)
                             ]-> .)), get_r/0),
                   [ Constructor ((41, Effect ([ ], .)), tt/3) ]) in
             Sequence
               ((42,
                 Effect
                   ([
-                    TypeEffect
-                    (Type (Z/3), OCaml.Effect.State.state/3);
-                    TypeEffect
-                    (Type (r_state/0), OCaml.Effect.State.state/3)
+                    (OCaml.Effect.State.state/3, Z/3);
+                    (OCaml.Effect.State.state/3, r_state/0)
                   ], .)),
                 Apply
                   ((42,
                     Effect
                       ([
-                        TypeEffect
-                        (Type (Z/3),
-                          OCaml.Effect.State.state/3);
-                        TypeEffect
-                        (Type (r_state/0),
-                          OCaml.Effect.State.state/3)
+                        (OCaml.Effect.State.state/3, Z/3);
+                        (OCaml.Effect.State.state/3,
+                          r_state/0)
                       ], .)),
                     Variable
                       ((42,
@@ -977,9 +757,8 @@ Value
                             . ->
                               .
                                 -[
-                                  TypeEffect
-                                  (Type (Z/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3)
                                 ]-> .)),
                         OCaml.Effect.State.write/3),
                     [
@@ -987,14 +766,10 @@ Value
                         ((?,
                           Effect
                             ([
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3);
-                              TypeEffect
-                              (Type
-                                (r_state/0),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3);
+                              (OCaml.Effect.State.state/3,
+                                r_state/0)
                             ],
                               .)),
                           Variable
@@ -1006,10 +781,8 @@ Value
                                     ->
                                     .
                                       -[
-                                        TypeEffect
-                                        (Type
-                                          (r_state/0),
-                                          OCaml.Effect.State.state/3)
+                                        (OCaml.Effect.State.state/3,
+                                          r_state/0)
                                       ]->
                                       .)),
                               OCaml.Effect.State.global/3),
@@ -1025,10 +798,8 @@ Value
                               ((?,
                                 Effect
                                   ([
-                                    TypeEffect
-                                    (Type
-                                      (Z/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      Z/3)
                                   ],
                                     .)),
                                 Variable
@@ -1038,10 +809,8 @@ Value
                                       ],
                                         .
                                           -[
-                                            TypeEffect
-                                            (Type
-                                              (Z/3),
-                                              OCaml.Effect.State.state/3)
+                                            (OCaml.Effect.State.state/3,
+                                              Z/3)
                                           ]->
                                           .)),
                                     OCaml.Effect.State.peekstate/3),
@@ -1088,12 +857,9 @@ Value
                   ((43,
                     Effect
                       ([
-                        TypeEffect
-                        (Type (Z/3),
-                          OCaml.Effect.State.state/3);
-                        TypeEffect
-                        (Type (r_state/0),
-                          OCaml.Effect.State.state/3)
+                        (OCaml.Effect.State.state/3, Z/3);
+                        (OCaml.Effect.State.state/3,
+                          r_state/0)
                       ], .)),
                     Variable
                       ((43,
@@ -1101,9 +867,8 @@ Value
                           ([ ],
                             .
                               -[
-                                TypeEffect
-                                (Type (Z/3),
-                                  OCaml.Effect.State.state/3)
+                                (OCaml.Effect.State.state/3,
+                                  Z/3)
                               ]-> .)),
                         OCaml.Effect.State.read/3),
                     [
@@ -1111,14 +876,10 @@ Value
                         ((?,
                           Effect
                             ([
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3);
-                              TypeEffect
-                              (Type
-                                (r_state/0),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3);
+                              (OCaml.Effect.State.state/3,
+                                r_state/0)
                             ],
                               .)),
                           Variable
@@ -1130,10 +891,8 @@ Value
                                     ->
                                     .
                                       -[
-                                        TypeEffect
-                                        (Type
-                                          (r_state/0),
-                                          OCaml.Effect.State.state/3)
+                                        (OCaml.Effect.State.state/3,
+                                          r_state/0)
                                       ]->
                                       .)),
                               OCaml.Effect.State.global/3),
@@ -1149,10 +908,8 @@ Value
                               ((?,
                                 Effect
                                   ([
-                                    TypeEffect
-                                    (Type
-                                      (Z/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      Z/3)
                                   ],
                                     .)),
                                 Variable
@@ -1162,10 +919,8 @@ Value
                                       ],
                                         .
                                           -[
-                                            TypeEffect
-                                            (Type
-                                              (Z/3),
-                                              OCaml.Effect.State.state/3)
+                                            (OCaml.Effect.State.state/3,
+                                              Z/3)
                                           ]->
                                           .)),
                                     OCaml.Effect.State.peekstate/3),
@@ -1191,76 +946,52 @@ Value
           (46,
             Effect
               ([
-                TypeEffect
-                (Type (Z/3), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (bool/3), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (r_state/0), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (string/3), OCaml.Effect.State.state/3)
+                (OCaml.Effect.State.state/3, Z/3);
+                (OCaml.Effect.State.state/3, bool/3);
+                (OCaml.Effect.State.state/3, r_state/0);
+                (OCaml.Effect.State.state/3, string/3)
               ], .)) b =
           Apply
-            ((46,
-              Effect
-                ([
-                  TypeEffect
-                  (Type (bool/3), OCaml.Effect.State.state/3)
-                ], .)),
+            ((46, Effect ([ (OCaml.Effect.State.state/3, bool/3) ], .)),
               Variable
                 ((46,
                   Effect
                     ([ ],
                       .
                         -[
-                          TypeEffect
-                          (Type (bool/3),
-                            OCaml.Effect.State.state/3)
+                          (OCaml.Effect.State.state/3,
+                            bool/3)
                         ]-> .)), OCaml.Pervasives.ref/3),
               [ Constructor ((46, Effect ([ ], .)), true/3) ]) in
         LetVar
           (47,
             Effect
               ([
-                TypeEffect
-                (Type (Z/3), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (bool/3), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (r_state/0), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (string/3), OCaml.Effect.State.state/3)
+                (OCaml.Effect.State.state/3, Z/3);
+                (OCaml.Effect.State.state/3, bool/3);
+                (OCaml.Effect.State.state/3, r_state/0);
+                (OCaml.Effect.State.state/3, string/3)
               ], .)) str =
           Apply
-            ((47,
-              Effect
-                ([
-                  TypeEffect
-                  (Type (string/3), OCaml.Effect.State.state/3)
-                ], .)),
+            ((47, Effect ([ (OCaml.Effect.State.state/3, string/3) ], .)),
               Variable
                 ((47,
                   Effect
                     ([ ],
                       .
                         -[
-                          TypeEffect
-                          (Type (string/3),
-                            OCaml.Effect.State.state/3)
+                          (OCaml.Effect.State.state/3,
+                            string/3)
                         ]-> .)), OCaml.Pervasives.ref/3),
               [ Constant ((47, Effect ([ ], .)), String("")) ]) in
         LetFun
           (48,
             Effect
               ([
-                TypeEffect
-                (Type (Z/3), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (bool/3), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (r_state/0), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (string/3), OCaml.Effect.State.state/3)
+                (OCaml.Effect.State.state/3, Z/3);
+                (OCaml.Effect.State.state/3, bool/3);
+                (OCaml.Effect.State.state/3, r_state/0);
+                (OCaml.Effect.State.state/3, string/3)
               ], .))
           (non_rec, @.,
             [
@@ -1269,14 +1000,10 @@ Value
                   ((?,
                     Effect
                       ([
-                        TypeEffect
-                        (Type
-                          (bool/3),
-                          OCaml.Effect.State.state/3);
-                        TypeEffect
-                        (Type
-                          (string/3),
-                          OCaml.Effect.State.state/3)
+                        (OCaml.Effect.State.state/3,
+                          bool/3);
+                        (OCaml.Effect.State.state/3,
+                          string/3)
                       ],
                         .)),
                     Variable
@@ -1293,24 +1020,18 @@ Value
                           ((49,
                             Effect
                               ([
-                                TypeEffect
-                                (Type
-                                  (bool/3),
-                                  OCaml.Effect.State.state/3);
-                                TypeEffect
-                                (Type
-                                  (string/3),
-                                  OCaml.Effect.State.state/3)
+                                (OCaml.Effect.State.state/3,
+                                  bool/3);
+                                (OCaml.Effect.State.state/3,
+                                  string/3)
                               ],
                                 .)),
                             Apply
                               ((49,
                                 Effect
                                   ([
-                                    TypeEffect
-                                    (Type
-                                      (bool/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      bool/3)
                                   ],
                                     .)),
                                 Variable
@@ -1322,10 +1043,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              TypeEffect
-                                              (Type
-                                                (bool/3),
-                                                OCaml.Effect.State.state/3)
+                                              (OCaml.Effect.State.state/3,
+                                                bool/3)
                                             ]->
                                             .)),
                                     OCaml.Effect.State.write/3),
@@ -1341,10 +1060,8 @@ Value
                                     ((49,
                                       Effect
                                         ([
-                                          TypeEffect
-                                          (Type
-                                            (bool/3),
-                                            OCaml.Effect.State.state/3)
+                                          (OCaml.Effect.State.state/3,
+                                            bool/3)
                                         ],
                                           .)),
                                       Variable
@@ -1354,10 +1071,8 @@ Value
                                             ],
                                               .
                                                 -[
-                                                  TypeEffect
-                                                  (Type
-                                                    (bool/3),
-                                                    OCaml.Effect.State.state/3)
+                                                  (OCaml.Effect.State.state/3,
+                                                    bool/3)
                                                 ]->
                                                 .)),
                                           OCaml.Effect.State.read/3),
@@ -1375,10 +1090,8 @@ Value
                               ((50,
                                 Effect
                                   ([
-                                    TypeEffect
-                                    (Type
-                                      (string/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      string/3)
                                   ],
                                     .)),
                                 Variable
@@ -1390,10 +1103,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              TypeEffect
-                                              (Type
-                                                (string/3),
-                                                OCaml.Effect.State.state/3)
+                                              (OCaml.Effect.State.state/3,
+                                                string/3)
                                             ]->
                                             .)),
                                     OCaml.Effect.State.write/3),
@@ -1409,10 +1120,8 @@ Value
                                     ((50,
                                       Effect
                                         ([
-                                          TypeEffect
-                                          (Type
-                                            (string/3),
-                                            OCaml.Effect.State.state/3)
+                                          (OCaml.Effect.State.state/3,
+                                            string/3)
                                         ],
                                           .)),
                                       Variable
@@ -1434,10 +1143,8 @@ Value
                                           ((50,
                                             Effect
                                               ([
-                                                TypeEffect
-                                                (Type
-                                                  (string/3),
-                                                  OCaml.Effect.State.state/3)
+                                                (OCaml.Effect.State.state/3,
+                                                  string/3)
                                               ],
                                                 .)),
                                             Variable
@@ -1447,10 +1154,8 @@ Value
                                                   ],
                                                     .
                                                       -[
-                                                        TypeEffect
-                                                        (Type
-                                                          (string/3),
-                                                          OCaml.Effect.State.state/3)
+                                                        (OCaml.Effect.State.state/3,
+                                                          string/3)
                                                       ]->
                                                       .)),
                                                 OCaml.Effect.State.read/3),
@@ -1471,23 +1176,17 @@ Value
           ((51,
             Effect
               ([
-                TypeEffect
-                (Type (Z/3), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (bool/3), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (r_state/0), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (string/3), OCaml.Effect.State.state/3)
+                (OCaml.Effect.State.state/3, Z/3);
+                (OCaml.Effect.State.state/3, bool/3);
+                (OCaml.Effect.State.state/3, r_state/0);
+                (OCaml.Effect.State.state/3, string/3)
               ], .)),
             Apply
               ((51,
                 Effect
                   ([
-                    TypeEffect
-                    (Type (bool/3), OCaml.Effect.State.state/3);
-                    TypeEffect
-                    (Type (string/3), OCaml.Effect.State.state/3)
+                    (OCaml.Effect.State.state/3, bool/3);
+                    (OCaml.Effect.State.state/3, string/3)
                   ], .)),
                 Variable
                   ((51,
@@ -1495,37 +1194,27 @@ Value
                       ([ ],
                         .
                           -[
-                            TypeEffect
-                            (Type (bool/3),
-                              OCaml.Effect.State.state/3);
-                            TypeEffect
-                            (Type (string/3),
-                              OCaml.Effect.State.state/3)
+                            (OCaml.Effect.State.state/3,
+                              bool/3);
+                            (OCaml.Effect.State.state/3,
+                              string/3)
                           ]-> .)), update/0),
                 [ Constructor ((51, Effect ([ ], .)), tt/3) ]),
             Sequence
               ((52,
                 Effect
                   ([
-                    TypeEffect
-                    (Type (Z/3), OCaml.Effect.State.state/3);
-                    TypeEffect
-                    (Type (bool/3), OCaml.Effect.State.state/3);
-                    TypeEffect
-                    (Type (r_state/0), OCaml.Effect.State.state/3);
-                    TypeEffect
-                    (Type (string/3), OCaml.Effect.State.state/3)
+                    (OCaml.Effect.State.state/3, Z/3);
+                    (OCaml.Effect.State.state/3, bool/3);
+                    (OCaml.Effect.State.state/3, r_state/0);
+                    (OCaml.Effect.State.state/3, string/3)
                   ], .)),
                 Apply
                   ((52,
                     Effect
                       ([
-                        TypeEffect
-                        (Type (bool/3),
-                          OCaml.Effect.State.state/3);
-                        TypeEffect
-                        (Type (string/3),
-                          OCaml.Effect.State.state/3)
+                        (OCaml.Effect.State.state/3, bool/3);
+                        (OCaml.Effect.State.state/3, string/3)
                       ], .)),
                     Variable
                       ((52,
@@ -1533,41 +1222,30 @@ Value
                           ([ ],
                             .
                               -[
-                                TypeEffect
-                                (Type (bool/3),
-                                  OCaml.Effect.State.state/3);
-                                TypeEffect
-                                (Type (string/3),
-                                  OCaml.Effect.State.state/3)
+                                (OCaml.Effect.State.state/3,
+                                  bool/3);
+                                (OCaml.Effect.State.state/3,
+                                  string/3)
                               ]-> .)), update/0),
                     [ Constructor ((52, Effect ([ ], .)), tt/3) ]),
                 Sequence
                   ((53,
                     Effect
                       ([
-                        TypeEffect
-                        (Type (Z/3),
-                          OCaml.Effect.State.state/3);
-                        TypeEffect
-                        (Type (bool/3),
-                          OCaml.Effect.State.state/3);
-                        TypeEffect
-                        (Type (r_state/0),
-                          OCaml.Effect.State.state/3);
-                        TypeEffect
-                        (Type (string/3),
-                          OCaml.Effect.State.state/3)
+                        (OCaml.Effect.State.state/3, Z/3);
+                        (OCaml.Effect.State.state/3, bool/3);
+                        (OCaml.Effect.State.state/3,
+                          r_state/0);
+                        (OCaml.Effect.State.state/3, string/3)
                       ], .)),
                     Apply
                       ((53,
                         Effect
                           ([
-                            TypeEffect
-                            (Type (bool/3),
-                              OCaml.Effect.State.state/3);
-                            TypeEffect
-                            (Type (string/3),
-                              OCaml.Effect.State.state/3)
+                            (OCaml.Effect.State.state/3,
+                              bool/3);
+                            (OCaml.Effect.State.state/3,
+                              string/3)
                           ], .)),
                         Variable
                           ((53,
@@ -1575,13 +1253,10 @@ Value
                               ([ ],
                                 .
                                   -[
-                                    TypeEffect
-                                    (Type (bool/3),
-                                      OCaml.Effect.State.state/3);
-                                    TypeEffect
-                                    (Type
-                                      (string/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      bool/3);
+                                    (OCaml.Effect.State.state/3,
+                                      string/3)
                                   ]-> .)), update/0),
                         [
                           Constructor
@@ -1596,26 +1271,21 @@ Value
                       ((54,
                         Effect
                           ([
-                            TypeEffect
-                            (Type (Z/3),
-                              OCaml.Effect.State.state/3);
-                            TypeEffect
-                            (Type (bool/3),
-                              OCaml.Effect.State.state/3);
-                            TypeEffect
-                            (Type (r_state/0),
-                              OCaml.Effect.State.state/3);
-                            TypeEffect
-                            (Type (string/3),
-                              OCaml.Effect.State.state/3)
+                            (OCaml.Effect.State.state/3,
+                              Z/3);
+                            (OCaml.Effect.State.state/3,
+                              bool/3);
+                            (OCaml.Effect.State.state/3,
+                              r_state/0);
+                            (OCaml.Effect.State.state/3,
+                              string/3)
                           ], .)),
                         Apply
                           ((54,
                             Effect
                               ([
-                                TypeEffect
-                                (Type (bool/3),
-                                  OCaml.Effect.State.state/3)
+                                (OCaml.Effect.State.state/3,
+                                  bool/3)
                               ], .)),
                             Variable
                               ((54,
@@ -1623,10 +1293,8 @@ Value
                                   ([ ],
                                     .
                                       -[
-                                        TypeEffect
-                                        (Type
-                                          (bool/3),
-                                          OCaml.Effect.State.state/3)
+                                        (OCaml.Effect.State.state/3,
+                                          bool/3)
                                       ]-> .)),
                                 OCaml.Effect.State.read/3),
                             [
@@ -1642,9 +1310,8 @@ Value
                           ((54,
                             Effect
                               ([
-                                TypeEffect
-                                (Type (string/3),
-                                  OCaml.Effect.State.state/3)
+                                (OCaml.Effect.State.state/3,
+                                  string/3)
                               ], .)),
                             Variable
                               ((54,
@@ -1652,10 +1319,8 @@ Value
                                   ([ ],
                                     .
                                       -[
-                                        TypeEffect
-                                        (Type
-                                          (string/3),
-                                          OCaml.Effect.State.state/3)
+                                        (OCaml.Effect.State.state/3,
+                                          string/3)
                                       ]-> .)),
                                 OCaml.Effect.State.read/3),
                             [
@@ -1671,12 +1336,10 @@ Value
                           ((54,
                             Effect
                               ([
-                                TypeEffect
-                                (Type (Z/3),
-                                  OCaml.Effect.State.state/3);
-                                TypeEffect
-                                (Type (r_state/0),
-                                  OCaml.Effect.State.state/3)
+                                (OCaml.Effect.State.state/3,
+                                  Z/3);
+                                (OCaml.Effect.State.state/3,
+                                  r_state/0)
                               ], .)),
                             Variable
                               ((54,
@@ -1684,10 +1347,8 @@ Value
                                   ([ ],
                                     .
                                       -[
-                                        TypeEffect
-                                        (Type
-                                          (Z/3),
-                                          OCaml.Effect.State.state/3)
+                                        (OCaml.Effect.State.state/3,
+                                          Z/3)
                                       ]-> .)),
                                 OCaml.Effect.State.read/3),
                             [
@@ -1695,14 +1356,10 @@ Value
                                 ((?,
                                   Effect
                                     ([
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3);
-                                      TypeEffect
-                                      (Type
-                                        (r_state/0),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3);
+                                      (OCaml.Effect.State.state/3,
+                                        r_state/0)
                                     ],
                                       .)),
                                   Variable
@@ -1714,10 +1371,8 @@ Value
                                             ->
                                             .
                                               -[
-                                                TypeEffect
-                                                (Type
-                                                  (r_state/0),
-                                                  OCaml.Effect.State.state/3)
+                                                (OCaml.Effect.State.state/3,
+                                                  r_state/0)
                                               ]->
                                               .)),
                                       OCaml.Effect.State.global/3),
@@ -1733,10 +1388,8 @@ Value
                                       ((?,
                                         Effect
                                           ([
-                                            TypeEffect
-                                            (Type
-                                              (Z/3),
-                                              OCaml.Effect.State.state/3)
+                                            (OCaml.Effect.State.state/3,
+                                              Z/3)
                                           ],
                                             .)),
                                         Variable
@@ -1746,10 +1399,8 @@ Value
                                               ],
                                                 .
                                                   -[
-                                                    TypeEffect
-                                                    (Type
-                                                      (Z/3),
-                                                      OCaml.Effect.State.state/3)
+                                                    (OCaml.Effect.State.state/3,
+                                                      Z/3)
                                                   ]->
                                                   .)),
                                             OCaml.Effect.State.peekstate/3),
@@ -1775,12 +1426,9 @@ Value
           ((?,
             Effect
               ([
-                TypeEffect
-                (Type (Z/3), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (list/3, Type (Z/3)), OCaml.Effect.State.state/3);
-                TypeEffect
-                (Type (r_state/0), OCaml.Effect.State.state/3)
+                (OCaml.Effect.State.state/3, Z/3);
+                (OCaml.Effect.State.state/3, (list/3, Z/3));
+                (OCaml.Effect.State.state/3, r_state/0)
               ], .)), Variable ((?, Effect ([ ], .)), x/0),
             [
               (Constructor (tt/3),
@@ -1788,20 +1436,13 @@ Value
                   (57,
                     Effect
                       ([
-                        TypeEffect
-                        (Type
-                          (Z/3),
-                          OCaml.Effect.State.state/3);
-                        TypeEffect
-                        (Type
+                        (OCaml.Effect.State.state/3,
+                          Z/3);
+                        (OCaml.Effect.State.state/3,
                           (list/3,
-                            Type
-                              (Z/3)),
-                          OCaml.Effect.State.state/3);
-                        TypeEffect
-                        (Type
-                          (r_state/0),
-                          OCaml.Effect.State.state/3)
+                            Z/3));
+                        (OCaml.Effect.State.state/3,
+                          r_state/0)
                       ],
                         .))
                   (non_rec, @.,
@@ -1827,20 +1468,16 @@ Value
                           ((58,
                             Effect
                               ([
-                                TypeEffect
-                                (Type
-                                  (Z/3),
-                                  OCaml.Effect.State.state/3)
+                                (OCaml.Effect.State.state/3,
+                                  Z/3)
                               ],
                                 .)),
                             Apply
                               ((58,
                                 Effect
                                   ([
-                                    TypeEffect
-                                    (Type
-                                      (Z/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      Z/3)
                                   ],
                                     .)),
                                 Variable
@@ -1852,10 +1489,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              TypeEffect
-                                              (Type
-                                                (Z/3),
-                                                OCaml.Effect.State.state/3)
+                                              (OCaml.Effect.State.state/3,
+                                                Z/3)
                                             ]->
                                             .)),
                                     OCaml.Effect.State.write/3),
@@ -1888,20 +1523,13 @@ Value
                   (60,
                     Effect
                       ([
-                        TypeEffect
-                        (Type
-                          (Z/3),
-                          OCaml.Effect.State.state/3);
-                        TypeEffect
-                        (Type
+                        (OCaml.Effect.State.state/3,
+                          Z/3);
+                        (OCaml.Effect.State.state/3,
                           (list/3,
-                            Type
-                              (Z/3)),
-                          OCaml.Effect.State.state/3);
-                        TypeEffect
-                        (Type
-                          (r_state/0),
-                          OCaml.Effect.State.state/3)
+                            Z/3));
+                        (OCaml.Effect.State.state/3,
+                          r_state/0)
                       ],
                         .))
                   f1_test =
@@ -1909,21 +1537,15 @@ Value
                     ((60,
                       Effect
                         ([
-                          TypeEffect
-                          (Type
-                            (Z/3),
-                            OCaml.Effect.State.state/3);
-                          TypeEffect
-                          (Type
-                            (r_state/0),
-                            OCaml.Effect.State.state/3)
+                          (OCaml.Effect.State.state/3,
+                            Z/3);
+                          (OCaml.Effect.State.state/3,
+                            r_state/0)
                         ],
                           .
                             -[
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3)
                             ]->
                             .)),
                       Variable
@@ -1935,10 +1557,8 @@ Value
                                 ->
                                 .
                                   -[
-                                    TypeEffect
-                                    (Type
-                                      (Z/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      Z/3)
                                   ]->
                                   .)),
                           f1/0),
@@ -1947,14 +1567,10 @@ Value
                           ((?,
                             Effect
                               ([
-                                TypeEffect
-                                (Type
-                                  (Z/3),
-                                  OCaml.Effect.State.state/3);
-                                TypeEffect
-                                (Type
-                                  (r_state/0),
-                                  OCaml.Effect.State.state/3)
+                                (OCaml.Effect.State.state/3,
+                                  Z/3);
+                                (OCaml.Effect.State.state/3,
+                                  r_state/0)
                               ],
                                 .)),
                             Variable
@@ -1966,10 +1582,8 @@ Value
                                       ->
                                       .
                                         -[
-                                          TypeEffect
-                                          (Type
-                                            (r_state/0),
-                                            OCaml.Effect.State.state/3)
+                                          (OCaml.Effect.State.state/3,
+                                            r_state/0)
                                         ]->
                                         .)),
                                 OCaml.Effect.State.global/3),
@@ -1985,10 +1599,8 @@ Value
                                 ((?,
                                   Effect
                                     ([
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3)
                                     ],
                                       .)),
                                   Variable
@@ -1998,10 +1610,8 @@ Value
                                         ],
                                           .
                                             -[
-                                              TypeEffect
-                                              (Type
-                                                (Z/3),
-                                                OCaml.Effect.State.state/3)
+                                              (OCaml.Effect.State.state/3,
+                                                Z/3)
                                             ]->
                                             .)),
                                       OCaml.Effect.State.peekstate/3),
@@ -2020,16 +1630,11 @@ Value
                   (61,
                     Effect
                       ([
-                        TypeEffect
-                        (Type
-                          (Z/3),
-                          OCaml.Effect.State.state/3);
-                        TypeEffect
-                        (Type
+                        (OCaml.Effect.State.state/3,
+                          Z/3);
+                        (OCaml.Effect.State.state/3,
                           (list/3,
-                            Type
-                              (Z/3)),
-                          OCaml.Effect.State.state/3)
+                            Z/3))
                       ],
                         .))
                   f1_test =
@@ -2037,10 +1642,8 @@ Value
                     ((61,
                       Effect
                         ([
-                          TypeEffect
-                          (Type
-                            (Z/3),
-                            OCaml.Effect.State.state/3)
+                          (OCaml.Effect.State.state/3,
+                            Z/3)
                         ],
                           .)),
                       Variable
@@ -2050,10 +1653,8 @@ Value
                             ],
                               .
                                 -[
-                                  TypeEffect
-                                  (Type
-                                    (Z/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3)
                                 ]->
                                 .)),
                           f1_test/0),
@@ -2071,16 +1672,11 @@ Value
                   (62,
                     Effect
                       ([
-                        TypeEffect
-                        (Type
-                          (Z/3),
-                          OCaml.Effect.State.state/3);
-                        TypeEffect
-                        (Type
+                        (OCaml.Effect.State.state/3,
+                          Z/3);
+                        (OCaml.Effect.State.state/3,
                           (list/3,
-                            Type
-                              (Z/3)),
-                          OCaml.Effect.State.state/3)
+                            Z/3))
                       ],
                         .))
                   (non_rec, @.,
@@ -2110,16 +1706,11 @@ Value
                           ((63,
                             Effect
                               ([
-                                TypeEffect
-                                (Type
-                                  (Z/3),
-                                  OCaml.Effect.State.state/3);
-                                TypeEffect
-                                (Type
+                                (OCaml.Effect.State.state/3,
+                                  Z/3);
+                                (OCaml.Effect.State.state/3,
                                   (list/3,
-                                    Type
-                                      (Z/3)),
-                                  OCaml.Effect.State.state/3)
+                                    Z/3))
                               ],
                                 .)),
                             Variable
@@ -2129,10 +1720,8 @@ Value
                                   ],
                                     .
                                       -[
-                                        TypeEffect
-                                        (Type
-                                          (Z/3),
-                                          OCaml.Effect.State.state/3)
+                                        (OCaml.Effect.State.state/3,
+                                          Z/3)
                                       ]->
                                       .)),
                                 OCaml.Pervasives.ref/3),
@@ -2141,12 +1730,9 @@ Value
                                 ((63,
                                   Effect
                                     ([
-                                      TypeEffect
-                                      (Type
+                                      (OCaml.Effect.State.state/3,
                                         (list/3,
-                                          Type
-                                            (Z/3)),
-                                        OCaml.Effect.State.state/3)
+                                          Z/3))
                                     ],
                                       .)),
                                   Variable
@@ -2161,12 +1747,9 @@ Value
                                       ((63,
                                         Effect
                                           ([
-                                            TypeEffect
-                                            (Type
+                                            (OCaml.Effect.State.state/3,
                                               (list/3,
-                                                Type
-                                                  (Z/3)),
-                                              OCaml.Effect.State.state/3)
+                                                Z/3))
                                           ],
                                             .)),
                                         Variable
@@ -2181,12 +1764,9 @@ Value
                                             ((63,
                                               Effect
                                                 ([
-                                                  TypeEffect
-                                                  (Type
+                                                  (OCaml.Effect.State.state/3,
                                                     (list/3,
-                                                      Type
-                                                        (Z/3)),
-                                                    OCaml.Effect.State.state/3)
+                                                      Z/3))
                                                 ],
                                                   .)),
                                               Variable
@@ -2196,12 +1776,9 @@ Value
                                                     ],
                                                       .
                                                         -[
-                                                          TypeEffect
-                                                          (Type
+                                                          (OCaml.Effect.State.state/3,
                                                             (list/3,
-                                                              Type
-                                                                (Z/3)),
-                                                            OCaml.Effect.State.state/3)
+                                                              Z/3))
                                                         ]->
                                                         .)),
                                                   OCaml.Effect.State.read/3),
@@ -2245,16 +1822,11 @@ Value
                   (64,
                     Effect
                       ([
-                        TypeEffect
-                        (Type
-                          (Z/3),
-                          OCaml.Effect.State.state/3);
-                        TypeEffect
-                        (Type
+                        (OCaml.Effect.State.state/3,
+                          Z/3);
+                        (OCaml.Effect.State.state/3,
                           (list/3,
-                            Type
-                              (Z/3)),
-                          OCaml.Effect.State.state/3)
+                            Z/3))
                       ],
                         .))
                   f2_test =
@@ -2262,25 +1834,17 @@ Value
                     ((64,
                       Effect
                         ([
-                          TypeEffect
-                          (Type
+                          (OCaml.Effect.State.state/3,
                             (list/3,
-                              Type
-                                (Z/3)),
-                            OCaml.Effect.State.state/3)
+                              Z/3))
                         ],
                           .
                             -[
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3);
-                              TypeEffect
-                              (Type
+                              (OCaml.Effect.State.state/3,
+                                Z/3);
+                              (OCaml.Effect.State.state/3,
                                 (list/3,
-                                  Type
-                                    (Z/3)),
-                                OCaml.Effect.State.state/3)
+                                  Z/3))
                             ]->
                             .)),
                       Variable
@@ -2292,16 +1856,11 @@ Value
                                 ->
                                 .
                                   -[
-                                    TypeEffect
-                                    (Type
-                                      (Z/3),
-                                      OCaml.Effect.State.state/3);
-                                    TypeEffect
-                                    (Type
+                                    (OCaml.Effect.State.state/3,
+                                      Z/3);
+                                    (OCaml.Effect.State.state/3,
                                       (list/3,
-                                        Type
-                                          (Z/3)),
-                                      OCaml.Effect.State.state/3)
+                                        Z/3))
                                   ]->
                                   .)),
                           f2/0),
@@ -2310,12 +1869,9 @@ Value
                           ((64,
                             Effect
                               ([
-                                TypeEffect
-                                (Type
+                                (OCaml.Effect.State.state/3,
                                   (list/3,
-                                    Type
-                                      (Z/3)),
-                                  OCaml.Effect.State.state/3)
+                                    Z/3))
                               ],
                                 .)),
                             Variable
@@ -2325,12 +1881,9 @@ Value
                                   ],
                                     .
                                       -[
-                                        TypeEffect
-                                        (Type
+                                        (OCaml.Effect.State.state/3,
                                           (list/3,
-                                            Type
-                                              (Z/3)),
-                                          OCaml.Effect.State.state/3)
+                                            Z/3))
                                       ]->
                                       .)),
                                 OCaml.Pervasives.ref/3),
@@ -2391,16 +1944,11 @@ Value
                   (65,
                     Effect
                       ([
-                        TypeEffect
-                        (Type
-                          (Z/3),
-                          OCaml.Effect.State.state/3);
-                        TypeEffect
-                        (Type
+                        (OCaml.Effect.State.state/3,
+                          Z/3);
+                        (OCaml.Effect.State.state/3,
                           (list/3,
-                            Type
-                              (Z/3)),
-                          OCaml.Effect.State.state/3)
+                            Z/3))
                       ],
                         .))
                   f2_test =
@@ -2408,16 +1956,11 @@ Value
                     ((65,
                       Effect
                         ([
-                          TypeEffect
-                          (Type
-                            (Z/3),
-                            OCaml.Effect.State.state/3);
-                          TypeEffect
-                          (Type
+                          (OCaml.Effect.State.state/3,
+                            Z/3);
+                          (OCaml.Effect.State.state/3,
                             (list/3,
-                              Type
-                                (Z/3)),
-                            OCaml.Effect.State.state/3)
+                              Z/3))
                         ],
                           .)),
                       Variable
@@ -2427,16 +1970,11 @@ Value
                             ],
                               .
                                 -[
-                                  TypeEffect
-                                  (Type
-                                    (Z/3),
-                                    OCaml.Effect.State.state/3);
-                                  TypeEffect
-                                  (Type
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3);
+                                  (OCaml.Effect.State.state/3,
                                     (list/3,
-                                      Type
-                                        (Z/3)),
-                                    OCaml.Effect.State.state/3)
+                                      Z/3))
                                 ]->
                                 .)),
                           f2_test/0),
@@ -2482,10 +2020,8 @@ Value
                   ((66,
                     Effect
                       ([
-                        TypeEffect
-                        (Type
-                          (Z/3),
-                          OCaml.Effect.State.state/3)
+                        (OCaml.Effect.State.state/3,
+                          Z/3)
                       ],
                         .)),
                     Variable
@@ -2497,10 +2033,8 @@ Value
                               ->
                               .
                                 -[
-                                  TypeEffect
-                                  (Type
-                                    (Z/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3)
                                 ]->
                                 .)),
                         f1/0),
@@ -2516,10 +2050,8 @@ Value
                         ((66,
                           Effect
                             ([
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3)
                             ],
                               .)),
                           Variable
@@ -2529,10 +2061,8 @@ Value
                                 ],
                                   .
                                     -[
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3)
                                     ]->
                                     .)),
                               OCaml.Effect.State.read/3),
@@ -2556,20 +2086,16 @@ Value
       ((multiple_returns_test, [ ], [ (x, Type (unit/3)) ],
         (Type (Z/3) * Type (OCaml.Effect.State.t/3, Type (Z/3)))),
         Match
-          ((?,
-            Effect
-              ([ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
-                .)), Variable ((?, Effect ([ ], .)), x/0),
+          ((?, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)),
+            Variable ((?, Effect ([ ], .)), x/0),
             [
               (Constructor (tt/3),
                 LetFun
                   (69,
                     Effect
                       ([
-                        TypeEffect
-                        (Type
-                          (Z/3),
-                          OCaml.Effect.State.state/3)
+                        (OCaml.Effect.State.state/3,
+                          Z/3)
                       ],
                         .))
                   (non_rec, @.,
@@ -2603,34 +2129,26 @@ Value
                           ((70,
                             Effect
                               ([
-                                TypeEffect
-                                (Type
-                                  (Z/3),
-                                  OCaml.Effect.State.state/3)
+                                (OCaml.Effect.State.state/3,
+                                  Z/3)
                               ],
                                 .
                                   -[
-                                    TypeEffect
-                                    (Type
-                                      (Z/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      Z/3)
                                   ]->
                                   .
                                     -[
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3)
                                     ]->
                                     .)),
                             Apply
                               ((70,
                                 Effect
                                   ([
-                                    TypeEffect
-                                    (Type
-                                      (Z/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      Z/3)
                                   ],
                                     .)),
                                 Variable
@@ -2642,10 +2160,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              TypeEffect
-                                              (Type
-                                                (Z/3),
-                                                OCaml.Effect.State.state/3)
+                                              (OCaml.Effect.State.state/3,
+                                                Z/3)
                                             ]->
                                             .)),
                                     OCaml.Effect.State.write/3),
@@ -2672,17 +2188,13 @@ Value
                                   ],
                                     .
                                       -[
-                                        TypeEffect
-                                        (Type
-                                          (Z/3),
-                                          OCaml.Effect.State.state/3)
+                                        (OCaml.Effect.State.state/3,
+                                          Z/3)
                                       ]->
                                       .
                                         -[
-                                          TypeEffect
-                                          (Type
-                                            (Z/3),
-                                            OCaml.Effect.State.state/3)
+                                          (OCaml.Effect.State.state/3,
+                                            Z/3)
                                         ]->
                                         .)),
                                 z,
@@ -2690,27 +2202,21 @@ Value
                                   ((71,
                                     Effect
                                       ([
-                                        TypeEffect
-                                        (Type
-                                          (Z/3),
-                                          OCaml.Effect.State.state/3)
+                                        (OCaml.Effect.State.state/3,
+                                          Z/3)
                                       ],
                                         .
                                           -[
-                                            TypeEffect
-                                            (Type
-                                              (Z/3),
-                                              OCaml.Effect.State.state/3)
+                                            (OCaml.Effect.State.state/3,
+                                              Z/3)
                                           ]->
                                           .)),
                                     Apply
                                       ((72,
                                         Effect
                                           ([
-                                            TypeEffect
-                                            (Type
-                                              (Z/3),
-                                              OCaml.Effect.State.state/3)
+                                            (OCaml.Effect.State.state/3,
+                                              Z/3)
                                           ],
                                             .)),
                                         Variable
@@ -2722,10 +2228,8 @@ Value
                                                   ->
                                                   .
                                                     -[
-                                                      TypeEffect
-                                                      (Type
-                                                        (Z/3),
-                                                        OCaml.Effect.State.state/3)
+                                                      (OCaml.Effect.State.state/3,
+                                                        Z/3)
                                                     ]->
                                                     .)),
                                             OCaml.Effect.State.write/3),
@@ -2741,10 +2245,8 @@ Value
                                             ((72,
                                               Effect
                                                 ([
-                                                  TypeEffect
-                                                  (Type
-                                                    (Z/3),
-                                                    OCaml.Effect.State.state/3)
+                                                  (OCaml.Effect.State.state/3,
+                                                    Z/3)
                                                 ],
                                                   .)),
                                               Variable
@@ -2759,10 +2261,8 @@ Value
                                                   ((72,
                                                     Effect
                                                       ([
-                                                        TypeEffect
-                                                        (Type
-                                                          (Z/3),
-                                                          OCaml.Effect.State.state/3)
+                                                        (OCaml.Effect.State.state/3,
+                                                          Z/3)
                                                       ],
                                                         .)),
                                                     Variable
@@ -2772,10 +2272,8 @@ Value
                                                           ],
                                                             .
                                                               -[
-                                                                TypeEffect
-                                                                (Type
-                                                                  (Z/3),
-                                                                  OCaml.Effect.State.state/3)
+                                                                (OCaml.Effect.State.state/3,
+                                                                  Z/3)
                                                               ]->
                                                               .)),
                                                         OCaml.Effect.State.read/3),
@@ -2804,10 +2302,8 @@ Value
                                           ],
                                             .
                                               -[
-                                                TypeEffect
-                                                (Type
-                                                  (Z/3),
-                                                  OCaml.Effect.State.state/3)
+                                                (OCaml.Effect.State.state/3,
+                                                  Z/3)
                                               ]->
                                               .)),
                                         w,
@@ -2815,10 +2311,8 @@ Value
                                           (73,
                                             Effect
                                               ([
-                                                TypeEffect
-                                                (Type
-                                                  (Z/3),
-                                                  OCaml.Effect.State.state/3)
+                                                (OCaml.Effect.State.state/3,
+                                                  Z/3)
                                               ],
                                                 .))
                                           tmp
@@ -2827,10 +2321,8 @@ Value
                                             ((74,
                                               Effect
                                                 ([
-                                                  TypeEffect
-                                                  (Type
-                                                    (Z/3),
-                                                    OCaml.Effect.State.state/3)
+                                                  (OCaml.Effect.State.state/3,
+                                                    Z/3)
                                                 ],
                                                   .)),
                                               Variable
@@ -2840,10 +2332,8 @@ Value
                                                     ],
                                                       .
                                                         -[
-                                                          TypeEffect
-                                                          (Type
-                                                            (Z/3),
-                                                            OCaml.Effect.State.state/3)
+                                                          (OCaml.Effect.State.state/3,
+                                                            Z/3)
                                                         ]->
                                                         .)),
                                                   OCaml.Effect.State.read/3),
@@ -2861,20 +2351,16 @@ Value
                                           ((75,
                                             Effect
                                               ([
-                                                TypeEffect
-                                                (Type
-                                                  (Z/3),
-                                                  OCaml.Effect.State.state/3)
+                                                (OCaml.Effect.State.state/3,
+                                                  Z/3)
                                               ],
                                                 .)),
                                             Apply
                                               ((75,
                                                 Effect
                                                   ([
-                                                    TypeEffect
-                                                    (Type
-                                                      (Z/3),
-                                                      OCaml.Effect.State.state/3)
+                                                    (OCaml.Effect.State.state/3,
+                                                      Z/3)
                                                   ],
                                                     .)),
                                                 Variable
@@ -2886,10 +2372,8 @@ Value
                                                           ->
                                                           .
                                                             -[
-                                                              TypeEffect
-                                                              (Type
-                                                                (Z/3),
-                                                                OCaml.Effect.State.state/3)
+                                                              (OCaml.Effect.State.state/3,
+                                                                Z/3)
                                                             ]->
                                                             .)),
                                                     OCaml.Effect.State.write/3),
@@ -2905,10 +2389,8 @@ Value
                                                     ((75,
                                                       Effect
                                                         ([
-                                                          TypeEffect
-                                                          (Type
-                                                            (Z/3),
-                                                            OCaml.Effect.State.state/3)
+                                                          (OCaml.Effect.State.state/3,
+                                                            Z/3)
                                                         ],
                                                           .)),
                                                       Variable
@@ -2930,10 +2412,8 @@ Value
                                                           ((75,
                                                             Effect
                                                               ([
-                                                                TypeEffect
-                                                                (Type
-                                                                  (Z/3),
-                                                                  OCaml.Effect.State.state/3)
+                                                                (OCaml.Effect.State.state/3,
+                                                                  Z/3)
                                                               ],
                                                                 .)),
                                                             Variable
@@ -2943,10 +2423,8 @@ Value
                                                                   ],
                                                                     .
                                                                       -[
-                                                                        TypeEffect
-                                                                        (Type
-                                                                          (Z/3),
-                                                                          OCaml.Effect.State.state/3)
+                                                                        (OCaml.Effect.State.state/3,
+                                                                          Z/3)
                                                                       ]->
                                                                       .)),
                                                                 OCaml.Effect.State.read/3),
@@ -2965,20 +2443,16 @@ Value
                                               ((76,
                                                 Effect
                                                   ([
-                                                    TypeEffect
-                                                    (Type
-                                                      (Z/3),
-                                                      OCaml.Effect.State.state/3)
+                                                    (OCaml.Effect.State.state/3,
+                                                      Z/3)
                                                   ],
                                                     .)),
                                                 Apply
                                                   ((76,
                                                     Effect
                                                       ([
-                                                        TypeEffect
-                                                        (Type
-                                                          (Z/3),
-                                                          OCaml.Effect.State.state/3)
+                                                        (OCaml.Effect.State.state/3,
+                                                          Z/3)
                                                       ],
                                                         .)),
                                                     Variable
@@ -2990,10 +2464,8 @@ Value
                                                               ->
                                                               .
                                                                 -[
-                                                                  TypeEffect
-                                                                  (Type
-                                                                    (Z/3),
-                                                                    OCaml.Effect.State.state/3)
+                                                                  (OCaml.Effect.State.state/3,
+                                                                    Z/3)
                                                                 ]->
                                                                 .)),
                                                         OCaml.Effect.State.write/3),
@@ -3026,10 +2498,8 @@ Value
                   (80,
                     Effect
                       ([
-                        TypeEffect
-                        (Type
-                          (Z/3),
-                          OCaml.Effect.State.state/3)
+                        (OCaml.Effect.State.state/3,
+                          Z/3)
                       ],
                         .))
                   s =
@@ -3037,10 +2507,8 @@ Value
                     ((80,
                       Effect
                         ([
-                          TypeEffect
-                          (Type
-                            (Z/3),
-                            OCaml.Effect.State.state/3)
+                          (OCaml.Effect.State.state/3,
+                            Z/3)
                         ],
                           .)),
                       Variable
@@ -3050,10 +2518,8 @@ Value
                             ],
                               .
                                 -[
-                                  TypeEffect
-                                  (Type
-                                    (Z/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3)
                                 ]->
                                 .)),
                           OCaml.Pervasives.ref/3),
@@ -3071,10 +2537,8 @@ Value
                   (81,
                     Effect
                       ([
-                        TypeEffect
-                        (Type
-                          (Z/3),
-                          OCaml.Effect.State.state/3)
+                        (OCaml.Effect.State.state/3,
+                          Z/3)
                       ],
                         .))
                   f1 =
@@ -3082,31 +2546,23 @@ Value
                     ((81,
                       Effect
                         ([
-                          TypeEffect
-                          (Type
-                            (Z/3),
-                            OCaml.Effect.State.state/3)
+                          (OCaml.Effect.State.state/3,
+                            Z/3)
                         ],
                           .
                             -[
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3)
                             ]->
                             .
                               -[
-                                TypeEffect
-                                (Type
-                                  (Z/3),
-                                  OCaml.Effect.State.state/3)
+                                (OCaml.Effect.State.state/3,
+                                  Z/3)
                               ]->
                               .
                                 -[
-                                  TypeEffect
-                                  (Type
-                                    (Z/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3)
                                 ]->
                                 .)),
                       Variable
@@ -3118,24 +2574,18 @@ Value
                                 ->
                                 .
                                   -[
-                                    TypeEffect
-                                    (Type
-                                      (Z/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      Z/3)
                                   ]->
                                   .
                                     -[
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3)
                                     ]->
                                     .
                                       -[
-                                        TypeEffect
-                                        (Type
-                                          (Z/3),
-                                          OCaml.Effect.State.state/3)
+                                        (OCaml.Effect.State.state/3,
+                                          Z/3)
                                       ]->
                                       .)),
                           f/0),
@@ -3144,10 +2594,8 @@ Value
                           ((81,
                             Effect
                               ([
-                                TypeEffect
-                                (Type
-                                  (Z/3),
-                                  OCaml.Effect.State.state/3)
+                                (OCaml.Effect.State.state/3,
+                                  Z/3)
                               ],
                                 .)),
                             Variable
@@ -3157,10 +2605,8 @@ Value
                                   ],
                                     .
                                       -[
-                                        TypeEffect
-                                        (Type
-                                          (Z/3),
-                                          OCaml.Effect.State.state/3)
+                                        (OCaml.Effect.State.state/3,
+                                          Z/3)
                                       ]->
                                       .)),
                                 OCaml.Pervasives.ref/3),
@@ -3179,10 +2625,8 @@ Value
                   (82,
                     Effect
                       ([
-                        TypeEffect
-                        (Type
-                          (Z/3),
-                          OCaml.Effect.State.state/3)
+                        (OCaml.Effect.State.state/3,
+                          Z/3)
                       ],
                         .))
                   f2 =
@@ -3190,24 +2634,18 @@ Value
                     ((82,
                       Effect
                         ([
-                          TypeEffect
-                          (Type
-                            (Z/3),
-                            OCaml.Effect.State.state/3)
+                          (OCaml.Effect.State.state/3,
+                            Z/3)
                         ],
                           .
                             -[
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3)
                             ]->
                             .
                               -[
-                                TypeEffect
-                                (Type
-                                  (Z/3),
-                                  OCaml.Effect.State.state/3)
+                                (OCaml.Effect.State.state/3,
+                                  Z/3)
                               ]->
                               .)),
                       Variable
@@ -3217,24 +2655,18 @@ Value
                             ],
                               .
                                 -[
-                                  TypeEffect
-                                  (Type
-                                    (Z/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3)
                                 ]->
                                 .
                                   -[
-                                    TypeEffect
-                                    (Type
-                                      (Z/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      Z/3)
                                   ]->
                                   .
                                     -[
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3)
                                     ]->
                                     .)),
                           f1/0),
@@ -3252,10 +2684,8 @@ Value
                   (83,
                     Effect
                       ([
-                        TypeEffect
-                        (Type
-                          (Z/3),
-                          OCaml.Effect.State.state/3)
+                        (OCaml.Effect.State.state/3,
+                          Z/3)
                       ],
                         .))
                   f3 =
@@ -3263,17 +2693,13 @@ Value
                     ((83,
                       Effect
                         ([
-                          TypeEffect
-                          (Type
-                            (Z/3),
-                            OCaml.Effect.State.state/3)
+                          (OCaml.Effect.State.state/3,
+                            Z/3)
                         ],
                           .
                             -[
-                              TypeEffect
-                              (Type
-                                (Z/3),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3)
                             ]->
                             .)),
                       Variable
@@ -3283,17 +2709,13 @@ Value
                             ],
                               .
                                 -[
-                                  TypeEffect
-                                  (Type
-                                    (Z/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3)
                                 ]->
                                 .
                                   -[
-                                    TypeEffect
-                                    (Type
-                                      (Z/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      Z/3)
                                   ]->
                                   .)),
                           f2/0),
@@ -3311,10 +2733,8 @@ Value
                   (84,
                     Effect
                       ([
-                        TypeEffect
-                        (Type
-                          (Z/3),
-                          OCaml.Effect.State.state/3)
+                        (OCaml.Effect.State.state/3,
+                          Z/3)
                       ],
                         .))
                   f4 =
@@ -3322,10 +2742,8 @@ Value
                     ((84,
                       Effect
                         ([
-                          TypeEffect
-                          (Type
-                            (Z/3),
-                            OCaml.Effect.State.state/3)
+                          (OCaml.Effect.State.state/3,
+                            Z/3)
                         ],
                           .)),
                       Variable
@@ -3335,10 +2753,8 @@ Value
                             ],
                               .
                                 -[
-                                  TypeEffect
-                                  (Type
-                                    (Z/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3)
                                 ]->
                                 .)),
                           f3/0),
@@ -3356,20 +2772,16 @@ Value
                   ((85,
                     Effect
                       ([
-                        TypeEffect
-                        (Type
-                          (Z/3),
-                          OCaml.Effect.State.state/3)
+                        (OCaml.Effect.State.state/3,
+                          Z/3)
                       ],
                         .)),
                     Apply
                       ((85,
                         Effect
                           ([
-                            TypeEffect
-                            (Type
-                              (Z/3),
-                              OCaml.Effect.State.state/3)
+                            (OCaml.Effect.State.state/3,
+                              Z/3)
                           ],
                             .)),
                         Variable
@@ -3379,10 +2791,8 @@ Value
                               ],
                                 .
                                   -[
-                                    TypeEffect
-                                    (Type
-                                      (Z/3),
-                                      OCaml.Effect.State.state/3)
+                                    (OCaml.Effect.State.state/3,
+                                      Z/3)
                                   ]->
                                   .)),
                             OCaml.Effect.State.read/3),

--- a/tests/ex39.effects
+++ b/tests/ex39.effects
@@ -497,12 +497,7 @@ Value
     [
       ((set_r, [ ], [ (x, Type (unit/3)) ], Type (unit/3)),
         Apply
-          ((34,
-            Effect
-              ([
-                (OCaml.Effect.State.state/3, Z/3);
-                (OCaml.Effect.State.state/3, r_state/0)
-              ], .)),
+          ((34, Effect ([ (OCaml.Effect.State.state/3, Z/3); r_state/0 ], .)),
             Variable
               ((34,
                 Effect
@@ -515,8 +510,7 @@ Value
                     ([
                       (OCaml.Effect.State.state/3,
                         Z/3);
-                      (OCaml.Effect.State.state/3,
-                        r_state/0)
+                      r_state/0
                     ], .)),
                   Variable
                     ((?,
@@ -527,8 +521,7 @@ Value
                             ->
                             .
                               -[
-                                (OCaml.Effect.State.state/3,
-                                  r_state/0)
+                                r_state/0
                               ]->
                               .)),
                       OCaml.Effect.State.global/3),
@@ -578,12 +571,7 @@ Value
     [
       ((get_r, [ ], [ (x, Type (unit/3)) ], Type (Z/3)),
         Apply
-          ((36,
-            Effect
-              ([
-                (OCaml.Effect.State.state/3, Z/3);
-                (OCaml.Effect.State.state/3, r_state/0)
-              ], .)),
+          ((36, Effect ([ (OCaml.Effect.State.state/3, Z/3); r_state/0 ], .)),
             Variable
               ((36,
                 Effect
@@ -596,8 +584,7 @@ Value
                     ([
                       (OCaml.Effect.State.state/3,
                         Z/3);
-                      (OCaml.Effect.State.state/3,
-                        r_state/0)
+                      r_state/0
                     ], .)),
                   Variable
                     ((?,
@@ -608,8 +595,7 @@ Value
                             ->
                             .
                               -[
-                                (OCaml.Effect.State.state/3,
-                                  r_state/0)
+                                r_state/0
                               ]->
                               .)),
                       OCaml.Effect.State.global/3),
@@ -659,19 +645,12 @@ Value
     [
       ((r_add_15, [ ], [ (x, Type (unit/3)) ], Type (Z/3)),
         LetVar
-          (39,
-            Effect
-              ([
-                (OCaml.Effect.State.state/3, Z/3);
-                (OCaml.Effect.State.state/3, r_state/0)
-              ], .)) i =
+          (39, Effect ([ (OCaml.Effect.State.state/3, Z/3); r_state/0 ], .))
+          i =
           Apply
             ((39,
               Effect
-                ([
-                  (OCaml.Effect.State.state/3, Z/3);
-                  (OCaml.Effect.State.state/3, r_state/0)
-                ], .)),
+                ([ (OCaml.Effect.State.state/3, Z/3); r_state/0 ], .)),
               Variable
                 ((39,
                   Effect
@@ -679,24 +658,16 @@ Value
                       .
                         -[
                           (OCaml.Effect.State.state/3, Z/3);
-                          (OCaml.Effect.State.state/3,
-                            r_state/0)
+                          r_state/0
                         ]-> .)), get_r/0),
               [ Constructor ((39, Effect ([ ], .)), tt/3) ]) in
         Sequence
-          ((40,
-            Effect
-              ([
-                (OCaml.Effect.State.state/3, Z/3);
-                (OCaml.Effect.State.state/3, r_state/0)
-              ], .)),
+          ((40, Effect ([ (OCaml.Effect.State.state/3, Z/3); r_state/0 ], .)),
             Apply
               ((40,
                 Effect
-                  ([
-                    (OCaml.Effect.State.state/3, Z/3);
-                    (OCaml.Effect.State.state/3, r_state/0)
-                  ], .)),
+                  ([ (OCaml.Effect.State.state/3, Z/3); r_state/0 ],
+                    .)),
                 Variable
                   ((40,
                     Effect
@@ -705,23 +676,20 @@ Value
                           -[
                             (OCaml.Effect.State.state/3,
                               Z/3);
-                            (OCaml.Effect.State.state/3,
-                              r_state/0)
+                            r_state/0
                           ]-> .)), set_r/0),
                 [ Constructor ((40, Effect ([ ], .)), tt/3) ]),
             LetVar
               (41,
                 Effect
-                  ([
-                    (OCaml.Effect.State.state/3, Z/3);
-                    (OCaml.Effect.State.state/3, r_state/0)
-                  ], .)) j =
+                  ([ (OCaml.Effect.State.state/3, Z/3); r_state/0 ],
+                    .)) j =
               Apply
                 ((41,
                   Effect
                     ([
                       (OCaml.Effect.State.state/3, Z/3);
-                      (OCaml.Effect.State.state/3, r_state/0)
+                      r_state/0
                     ], .)),
                   Variable
                     ((41,
@@ -731,24 +699,20 @@ Value
                             -[
                               (OCaml.Effect.State.state/3,
                                 Z/3);
-                              (OCaml.Effect.State.state/3,
-                                r_state/0)
+                              r_state/0
                             ]-> .)), get_r/0),
                   [ Constructor ((41, Effect ([ ], .)), tt/3) ]) in
             Sequence
               ((42,
                 Effect
-                  ([
-                    (OCaml.Effect.State.state/3, Z/3);
-                    (OCaml.Effect.State.state/3, r_state/0)
-                  ], .)),
+                  ([ (OCaml.Effect.State.state/3, Z/3); r_state/0 ],
+                    .)),
                 Apply
                   ((42,
                     Effect
                       ([
                         (OCaml.Effect.State.state/3, Z/3);
-                        (OCaml.Effect.State.state/3,
-                          r_state/0)
+                        r_state/0
                       ], .)),
                     Variable
                       ((42,
@@ -768,8 +732,7 @@ Value
                             ([
                               (OCaml.Effect.State.state/3,
                                 Z/3);
-                              (OCaml.Effect.State.state/3,
-                                r_state/0)
+                              r_state/0
                             ],
                               .)),
                           Variable
@@ -781,8 +744,7 @@ Value
                                     ->
                                     .
                                       -[
-                                        (OCaml.Effect.State.state/3,
-                                          r_state/0)
+                                        r_state/0
                                       ]->
                                       .)),
                               OCaml.Effect.State.global/3),
@@ -858,8 +820,7 @@ Value
                     Effect
                       ([
                         (OCaml.Effect.State.state/3, Z/3);
-                        (OCaml.Effect.State.state/3,
-                          r_state/0)
+                        r_state/0
                       ], .)),
                     Variable
                       ((43,
@@ -878,8 +839,7 @@ Value
                             ([
                               (OCaml.Effect.State.state/3,
                                 Z/3);
-                              (OCaml.Effect.State.state/3,
-                                r_state/0)
+                              r_state/0
                             ],
                               .)),
                           Variable
@@ -891,8 +851,7 @@ Value
                                     ->
                                     .
                                       -[
-                                        (OCaml.Effect.State.state/3,
-                                          r_state/0)
+                                        r_state/0
                                       ]->
                                       .)),
                               OCaml.Effect.State.global/3),
@@ -948,8 +907,8 @@ Value
               ([
                 (OCaml.Effect.State.state/3, Z/3);
                 (OCaml.Effect.State.state/3, bool/3);
-                (OCaml.Effect.State.state/3, r_state/0);
-                (OCaml.Effect.State.state/3, string/3)
+                (OCaml.Effect.State.state/3, string/3);
+                r_state/0
               ], .)) b =
           Apply
             ((46, Effect ([ (OCaml.Effect.State.state/3, bool/3) ], .)),
@@ -969,8 +928,8 @@ Value
               ([
                 (OCaml.Effect.State.state/3, Z/3);
                 (OCaml.Effect.State.state/3, bool/3);
-                (OCaml.Effect.State.state/3, r_state/0);
-                (OCaml.Effect.State.state/3, string/3)
+                (OCaml.Effect.State.state/3, string/3);
+                r_state/0
               ], .)) str =
           Apply
             ((47, Effect ([ (OCaml.Effect.State.state/3, string/3) ], .)),
@@ -990,8 +949,8 @@ Value
               ([
                 (OCaml.Effect.State.state/3, Z/3);
                 (OCaml.Effect.State.state/3, bool/3);
-                (OCaml.Effect.State.state/3, r_state/0);
-                (OCaml.Effect.State.state/3, string/3)
+                (OCaml.Effect.State.state/3, string/3);
+                r_state/0
               ], .))
           (non_rec, @.,
             [
@@ -1178,8 +1137,8 @@ Value
               ([
                 (OCaml.Effect.State.state/3, Z/3);
                 (OCaml.Effect.State.state/3, bool/3);
-                (OCaml.Effect.State.state/3, r_state/0);
-                (OCaml.Effect.State.state/3, string/3)
+                (OCaml.Effect.State.state/3, string/3);
+                r_state/0
               ], .)),
             Apply
               ((51,
@@ -1206,8 +1165,8 @@ Value
                   ([
                     (OCaml.Effect.State.state/3, Z/3);
                     (OCaml.Effect.State.state/3, bool/3);
-                    (OCaml.Effect.State.state/3, r_state/0);
-                    (OCaml.Effect.State.state/3, string/3)
+                    (OCaml.Effect.State.state/3, string/3);
+                    r_state/0
                   ], .)),
                 Apply
                   ((52,
@@ -1234,9 +1193,8 @@ Value
                       ([
                         (OCaml.Effect.State.state/3, Z/3);
                         (OCaml.Effect.State.state/3, bool/3);
-                        (OCaml.Effect.State.state/3,
-                          r_state/0);
-                        (OCaml.Effect.State.state/3, string/3)
+                        (OCaml.Effect.State.state/3, string/3);
+                        r_state/0
                       ], .)),
                     Apply
                       ((53,
@@ -1276,9 +1234,8 @@ Value
                             (OCaml.Effect.State.state/3,
                               bool/3);
                             (OCaml.Effect.State.state/3,
-                              r_state/0);
-                            (OCaml.Effect.State.state/3,
-                              string/3)
+                              string/3);
+                            r_state/0
                           ], .)),
                         Apply
                           ((54,
@@ -1338,8 +1295,7 @@ Value
                               ([
                                 (OCaml.Effect.State.state/3,
                                   Z/3);
-                                (OCaml.Effect.State.state/3,
-                                  r_state/0)
+                                r_state/0
                               ], .)),
                             Variable
                               ((54,
@@ -1358,8 +1314,7 @@ Value
                                     ([
                                       (OCaml.Effect.State.state/3,
                                         Z/3);
-                                      (OCaml.Effect.State.state/3,
-                                        r_state/0)
+                                      r_state/0
                                     ],
                                       .)),
                                   Variable
@@ -1371,8 +1326,7 @@ Value
                                             ->
                                             .
                                               -[
-                                                (OCaml.Effect.State.state/3,
-                                                  r_state/0)
+                                                r_state/0
                                               ]->
                                               .)),
                                       OCaml.Effect.State.global/3),
@@ -1428,7 +1382,7 @@ Value
               ([
                 (OCaml.Effect.State.state/3, Z/3);
                 (OCaml.Effect.State.state/3, (list/3, Z/3));
-                (OCaml.Effect.State.state/3, r_state/0)
+                r_state/0
               ], .)), Variable ((?, Effect ([ ], .)), x/0),
             [
               (Constructor (tt/3),
@@ -1441,8 +1395,7 @@ Value
                         (OCaml.Effect.State.state/3,
                           (list/3,
                             Z/3));
-                        (OCaml.Effect.State.state/3,
-                          r_state/0)
+                        r_state/0
                       ],
                         .))
                   (non_rec, @.,
@@ -1528,8 +1481,7 @@ Value
                         (OCaml.Effect.State.state/3,
                           (list/3,
                             Z/3));
-                        (OCaml.Effect.State.state/3,
-                          r_state/0)
+                        r_state/0
                       ],
                         .))
                   f1_test =
@@ -1539,8 +1491,7 @@ Value
                         ([
                           (OCaml.Effect.State.state/3,
                             Z/3);
-                          (OCaml.Effect.State.state/3,
-                            r_state/0)
+                          r_state/0
                         ],
                           .
                             -[
@@ -1569,8 +1520,7 @@ Value
                               ([
                                 (OCaml.Effect.State.state/3,
                                   Z/3);
-                                (OCaml.Effect.State.state/3,
-                                  r_state/0)
+                                r_state/0
                               ],
                                 .)),
                             Variable
@@ -1582,8 +1532,7 @@ Value
                                       ->
                                       .
                                         -[
-                                          (OCaml.Effect.State.state/3,
-                                            r_state/0)
+                                          r_state/0
                                         ]->
                                         .)),
                                 OCaml.Effect.State.global/3),
@@ -2812,5 +2761,165 @@ Value
                           ],
                             .)),
                         s/0)))
+            ]))
+    ])
+
+87
+Value
+  (non_rec, @.,
+    [
+      ((type_vars_test, [ A; B ],
+        [
+          (x, Type (OCaml.Effect.State.t/3, A));
+          (y, Type (OCaml.Effect.State.t/3, B));
+          (a, A);
+          (b, B)
+        ], Type (unit/3)),
+        Sequence
+          ((88,
+            Effect
+              ([
+                (OCaml.Effect.State.state/3, A);
+                (OCaml.Effect.State.state/3, B)
+              ], .)),
+            Apply
+              ((88, Effect ([ (OCaml.Effect.State.state/3, A) ], .)),
+                Variable
+                  ((88,
+                    Effect
+                      ([ ],
+                        . ->
+                          .
+                            -[
+                              (OCaml.Effect.State.state/3,
+                                A)
+                            ]-> .)),
+                    OCaml.Effect.State.write/3),
+                [
+                  Variable ((88, Effect ([ ], .)), x/0);
+                  Variable ((88, Effect ([ ], .)), a/0)
+                ]),
+            Apply
+              ((89, Effect ([ (OCaml.Effect.State.state/3, B) ], .)),
+                Variable
+                  ((89,
+                    Effect
+                      ([ ],
+                        . ->
+                          .
+                            -[
+                              (OCaml.Effect.State.state/3,
+                                B)
+                            ]-> .)),
+                    OCaml.Effect.State.write/3),
+                [
+                  Variable ((89, Effect ([ ], .)), y/0);
+                  Variable ((89, Effect ([ ], .)), b/0)
+                ])))
+    ])
+
+91
+Value
+  (non_rec, @.,
+    [
+      ((resolves_test1, [ A ],
+        [ (x, Type (OCaml.Effect.State.t/3, A)); (a, A); (b, A) ],
+        Type (unit/3)),
+        Apply
+          ((92, Effect ([ (OCaml.Effect.State.state/3, A) ], .)),
+            Variable
+              ((92,
+                Effect
+                  ([ ],
+                    . ->
+                      . ->
+                        . ->
+                          .
+                            -[
+                              (OCaml.Effect.State.state/3,
+                                A);
+                              (OCaml.Effect.State.state/3,
+                                A)
+                            ]-> .)), type_vars_test/0),
+            [
+              Variable ((92, Effect ([ ], .)), x/0);
+              Variable ((92, Effect ([ ], .)), x/0);
+              Variable ((92, Effect ([ ], .)), a/0);
+              Variable ((92, Effect ([ ], .)), b/0)
+            ]))
+    ])
+
+94
+Value
+  (non_rec, @.,
+    [
+      ((resolves_test2, [ A ],
+        [
+          (x, Type (OCaml.Effect.State.t/3, Type (Z/3)));
+          (y, Type (OCaml.Effect.State.t/3, A));
+          (a, Type (Z/3));
+          (b, A)
+        ], Type (unit/3)),
+        Apply
+          ((95,
+            Effect
+              ([
+                (OCaml.Effect.State.state/3, A);
+                (OCaml.Effect.State.state/3, Z/3)
+              ], .)),
+            Variable
+              ((95,
+                Effect
+                  ([ ],
+                    . ->
+                      . ->
+                        . ->
+                          .
+                            -[
+                              (OCaml.Effect.State.state/3,
+                                Z/3);
+                              (OCaml.Effect.State.state/3,
+                                A)
+                            ]-> .)), type_vars_test/0),
+            [
+              Variable ((95, Effect ([ ], .)), x/0);
+              Variable ((95, Effect ([ ], .)), y/0);
+              Variable ((95, Effect ([ ], .)), a/0);
+              Variable ((95, Effect ([ ], .)), b/0)
+            ]))
+    ])
+
+97
+Value
+  (non_rec, @.,
+    [
+      ((resolves_test3, [ ],
+        [
+          (x, Type (OCaml.Effect.State.t/3, Type (Z/3)));
+          (y, Type (OCaml.Effect.State.t/3, Type (Z/3)));
+          (a, Type (Z/3));
+          (b, Type (Z/3))
+        ], Type (unit/3)),
+        Apply
+          ((98, Effect ([ (OCaml.Effect.State.state/3, Z/3) ], .)),
+            Variable
+              ((98,
+                Effect
+                  ([ ],
+                    . ->
+                      . ->
+                        . ->
+                          .
+                            -[
+                              (OCaml.Effect.State.state/3,
+                                Z/3);
+                              (OCaml.Effect.State.state/3,
+                                Z/3)
+                            ]-> .)), type_vars_test/0),
+            [
+              Variable ((98, Effect ([ ], .)), x/0);
+              Variable ((98, Effect ([ ], .)), y/0);
+              Variable ((98, Effect ([ ], .)), a/0);
+              Variable ((98, Effect ([ ], .)), b/0)
             ]))
     ])

--- a/tests/ex39.exp
+++ b/tests/ex39.exp
@@ -841,3 +841,83 @@ Value
                         s/0)))
             ]))
     ])
+
+87
+Value
+  (non_rec, @.,
+    [
+      ((type_vars_test, [ A; B ],
+        [
+          (x, Type (OCaml.Effect.State.t/3, A));
+          (y, Type (OCaml.Effect.State.t/3, B));
+          (a, A);
+          (b, B)
+        ], Type (unit/3)),
+        Sequence
+          (88,
+            Apply
+              (88, Variable (88, OCaml.Effect.State.write/3),
+                [ Variable (88, x/0); Variable (88, a/0) ]),
+            Apply
+              (89, Variable (89, OCaml.Effect.State.write/3),
+                [ Variable (89, y/0); Variable (89, b/0) ])))
+    ])
+
+91
+Value
+  (non_rec, @.,
+    [
+      ((resolves_test1, [ A ],
+        [ (x, Type (OCaml.Effect.State.t/3, A)); (a, A); (b, A) ],
+        Type (unit/3)),
+        Apply
+          (92, Variable (92, type_vars_test/0),
+            [
+              Variable (92, x/0);
+              Variable (92, x/0);
+              Variable (92, a/0);
+              Variable (92, b/0)
+            ]))
+    ])
+
+94
+Value
+  (non_rec, @.,
+    [
+      ((resolves_test2, [ A ],
+        [
+          (x, Type (OCaml.Effect.State.t/3, Type (Z/3)));
+          (y, Type (OCaml.Effect.State.t/3, A));
+          (a, Type (Z/3));
+          (b, A)
+        ], Type (unit/3)),
+        Apply
+          (95, Variable (95, type_vars_test/0),
+            [
+              Variable (95, x/0);
+              Variable (95, y/0);
+              Variable (95, a/0);
+              Variable (95, b/0)
+            ]))
+    ])
+
+97
+Value
+  (non_rec, @.,
+    [
+      ((resolves_test3, [ ],
+        [
+          (x, Type (OCaml.Effect.State.t/3, Type (Z/3)));
+          (y, Type (OCaml.Effect.State.t/3, Type (Z/3)));
+          (a, Type (Z/3));
+          (b, Type (Z/3))
+        ], Type (unit/3)),
+        Apply
+          (98, Variable (98, type_vars_test/0),
+            [
+              Variable (98, x/0);
+              Variable (98, y/0);
+              Variable (98, a/0);
+              Variable (98, b/0)
+            ]))
+    ])

--- a/tests/ex39.interface
+++ b/tests/ex39.interface
@@ -4,34 +4,25 @@
     "Interface",
     "Ex39",
     [
-      [ "Var", "get_local_ref", [ [ "OCaml.Effect.State.state" ] ] ],
-      [ "Var", "set_local_ref", [ [ "OCaml.Effect.State.state" ] ] ],
-      [ "Var", "add_multiple_by_refs", [ [], [], [], [ "OCaml.Effect.State.state" ] ] ],
-      [ "Var", "set_ref", [ [ "OCaml.Effect.State.state" ] ] ],
-      [ "Var", "get_ref", [ [ "OCaml.Effect.State.state" ] ] ],
-      [ "Var", "update_ref", [ [ "OCaml.Effect.State.state" ] ] ],
-      [ "Var", "new_ref", [ [ "OCaml.Effect.State.state" ] ] ],
+      [ "Var", "get_local_ref", [ [] ] ],
+      [ "Var", "set_local_ref", [ [] ] ],
+      [ "Var", "add_multiple_by_refs", [ [], [], [], [] ] ],
+      [ "Var", "set_ref", [ [] ] ],
+      [ "Var", "get_ref", [ [] ] ],
+      [ "Var", "update_ref", [ [] ] ],
+      [ "Var", "new_ref", [ [] ] ],
       [ "Var", "r", [] ],
       [ "Descriptor", "r_state" ],
-      [ "Var", "set_r", [ [ "OCaml.Effect.State.state", "OCaml.Effect.State.state" ] ] ],
-      [ "Var", "get_r", [ [ "OCaml.Effect.State.state", "OCaml.Effect.State.state" ] ] ],
-      [ "Var", "r_add_15", [ [ "OCaml.Effect.State.state", "OCaml.Effect.State.state" ] ] ],
-      [
-        "Var",
-        "mixed_type",
-        [
-          [
-            "OCaml.Effect.State.state", "OCaml.Effect.State.state", "OCaml.Effect.State.state",
-            "OCaml.Effect.State.state"
-          ]
-        ]
-      ],
-      [
-        "Var",
-        "partials_test",
-        [ [ "OCaml.Effect.State.state", "OCaml.Effect.State.state", "OCaml.Effect.State.state" ] ]
-      ],
-      [ "Var", "multiple_returns_test", [ [ "OCaml.Effect.State.state" ] ] ]
+      [ "Var", "set_r", [ [ "r_state" ] ] ],
+      [ "Var", "get_r", [ [ "r_state" ] ] ],
+      [ "Var", "r_add_15", [ [ "r_state" ] ] ],
+      [ "Var", "mixed_type", [ [ "r_state" ] ] ],
+      [ "Var", "partials_test", [ [ "r_state" ] ] ],
+      [ "Var", "multiple_returns_test", [ [] ] ],
+      [ "Var", "type_vars_test", [ [], [], [], [] ] ],
+      [ "Var", "resolves_test1", [ [], [], [] ] ],
+      [ "Var", "resolves_test2", [ [], [], [], [] ] ],
+      [ "Var", "resolves_test3", [ [], [], [], [] ] ]
     ]
   ]
 }

--- a/tests/ex39.ml
+++ b/tests/ex39.ml
@@ -83,3 +83,16 @@ let multiple_returns_test () =
   let f3 = f2 7 in
   let f4 = f3 s in
   (!f4, s)
+
+let type_vars_test (x : 'a ref) (y : 'b ref) (a : 'a) (b : 'b) =
+  x := a;
+  y := b
+
+let resolves_test1 (x : 'a ref) (a : 'a) (b : 'a) =
+  type_vars_test x x a b
+
+let resolves_test2 (x : int ref) (y : 'b ref) (a : int) (b : 'b) =
+  type_vars_test x y a b
+
+let resolves_test3 (x : int ref) (y : int ref) (a : int) (b : int) =
+  type_vars_test x y a b

--- a/tests/ex39.monadise
+++ b/tests/ex39.monadise
@@ -265,10 +265,7 @@ Value
     [
       ((set_r, [ ], [ (x, Type (unit/3)) ],
         Monad
-          ([
-            (OCaml.Effect.State.state/3, Z/3);
-            (OCaml.Effect.State.state/3, r_state/0)
-          ], Type (unit/3))),
+          ([ (OCaml.Effect.State.state/3, Z/3); r_state/0 ], Type (unit/3))),
         Bind
           (?,
             Bind
@@ -277,7 +274,7 @@ Value
                   (?, [ (OCaml.Effect.State.state/3, Z/3) ],
                     [
                       (OCaml.Effect.State.state/3, Z/3);
-                      (OCaml.Effect.State.state/3, r_state/0)
+                      r_state/0
                     ],
                     Apply
                       (?,
@@ -285,10 +282,10 @@ Value
                           (?, OCaml.Effect.State.peekstate/3),
                         [ Tuple (?) ])), Some x_1,
                 Lift
-                  (?, [ (OCaml.Effect.State.state/3, r_state/0) ],
+                  (?, [ r_state/0 ],
                     [
                       (OCaml.Effect.State.state/3, Z/3);
-                      (OCaml.Effect.State.state/3, r_state/0)
+                      r_state/0
                     ],
                     Apply
                       (?,
@@ -300,10 +297,7 @@ Value
                         ]))), Some x_1,
             Lift
               (?, [ (OCaml.Effect.State.state/3, Z/3) ],
-                [
-                  (OCaml.Effect.State.state/3, Z/3);
-                  (OCaml.Effect.State.state/3, r_state/0)
-                ],
+                [ (OCaml.Effect.State.state/3, Z/3); r_state/0 ],
                 Apply
                   (34, Variable (34, set_ref/0),
                     [ Variable (?, x_1/0) ]))))
@@ -314,11 +308,7 @@ Value
   (non_rec, @.,
     [
       ((get_r, [ ], [ (x, Type (unit/3)) ],
-        Monad
-          ([
-            (OCaml.Effect.State.state/3, Z/3);
-            (OCaml.Effect.State.state/3, r_state/0)
-          ], Type (Z/3))),
+        Monad ([ (OCaml.Effect.State.state/3, Z/3); r_state/0 ], Type (Z/3))),
         Bind
           (?,
             Bind
@@ -327,7 +317,7 @@ Value
                   (?, [ (OCaml.Effect.State.state/3, Z/3) ],
                     [
                       (OCaml.Effect.State.state/3, Z/3);
-                      (OCaml.Effect.State.state/3, r_state/0)
+                      r_state/0
                     ],
                     Apply
                       (?,
@@ -335,10 +325,10 @@ Value
                           (?, OCaml.Effect.State.peekstate/3),
                         [ Tuple (?) ])), Some x_1,
                 Lift
-                  (?, [ (OCaml.Effect.State.state/3, r_state/0) ],
+                  (?, [ r_state/0 ],
                     [
                       (OCaml.Effect.State.state/3, Z/3);
-                      (OCaml.Effect.State.state/3, r_state/0)
+                      r_state/0
                     ],
                     Apply
                       (?,
@@ -350,10 +340,7 @@ Value
                         ]))), Some x_1,
             Lift
               (?, [ (OCaml.Effect.State.state/3, Z/3) ],
-                [
-                  (OCaml.Effect.State.state/3, Z/3);
-                  (OCaml.Effect.State.state/3, r_state/0)
-                ],
+                [ (OCaml.Effect.State.state/3, Z/3); r_state/0 ],
                 Apply
                   (36, Variable (36, get_ref/0),
                     [ Variable (?, x_1/0) ]))))
@@ -364,11 +351,7 @@ Value
   (non_rec, @.,
     [
       ((r_add_15, [ ], [ (x, Type (unit/3)) ],
-        Monad
-          ([
-            (OCaml.Effect.State.state/3, Z/3);
-            (OCaml.Effect.State.state/3, r_state/0)
-          ], Type (Z/3))),
+        Monad ([ (OCaml.Effect.State.state/3, Z/3); r_state/0 ], Type (Z/3))),
         Bind
           (?,
             Apply (39, Variable (39, get_r/0), [ Constructor (39, tt/3) ]),
@@ -398,8 +381,7 @@ Value
                                     [
                                       (OCaml.Effect.State.state/3,
                                         Z/3);
-                                      (OCaml.Effect.State.state/3,
-                                        r_state/0)
+                                      r_state/0
                                     ],
                                     Apply
                                       (?,
@@ -412,16 +394,11 @@ Value
                                         ])),
                                 Some x_1,
                                 Lift
-                                  (?,
-                                    [
-                                      (OCaml.Effect.State.state/3,
-                                        r_state/0)
-                                    ],
+                                  (?, [ r_state/0 ],
                                     [
                                       (OCaml.Effect.State.state/3,
                                         Z/3);
-                                      (OCaml.Effect.State.state/3,
-                                        r_state/0)
+                                      r_state/0
                                     ],
                                     Apply
                                       (?,
@@ -446,8 +423,7 @@ Value
                                 [
                                   (OCaml.Effect.State.state/3,
                                     Z/3);
-                                  (OCaml.Effect.State.state/3,
-                                    r_state/0)
+                                  r_state/0
                                 ],
                                 Apply
                                   (42,
@@ -485,8 +461,7 @@ Value
                                     [
                                       (OCaml.Effect.State.state/3,
                                         Z/3);
-                                      (OCaml.Effect.State.state/3,
-                                        r_state/0)
+                                      r_state/0
                                     ],
                                     Apply
                                       (?,
@@ -499,16 +474,11 @@ Value
                                         ])),
                                 Some x_1,
                                 Lift
-                                  (?,
-                                    [
-                                      (OCaml.Effect.State.state/3,
-                                        r_state/0)
-                                    ],
+                                  (?, [ r_state/0 ],
                                     [
                                       (OCaml.Effect.State.state/3,
                                         Z/3);
-                                      (OCaml.Effect.State.state/3,
-                                        r_state/0)
+                                      r_state/0
                                     ],
                                     Apply
                                       (?,
@@ -533,8 +503,7 @@ Value
                                 [
                                   (OCaml.Effect.State.state/3,
                                     Z/3);
-                                  (OCaml.Effect.State.state/3,
-                                    r_state/0)
+                                  r_state/0
                                 ],
                                 Apply
                                   (43,
@@ -552,13 +521,13 @@ Value
 Value
   (non_rec, @.,
     [
-      ((mixed_type, [ ], [ (x, Type (unit/3)) ],
+      ((mixed_type, [ ], [ (es_in, list Effect.t); (x, Type (unit/3)) ],
         Monad
           ([
             (OCaml.Effect.State.state/3, Z/3);
             (OCaml.Effect.State.state/3, bool/3);
-            (OCaml.Effect.State.state/3, r_state/0);
-            (OCaml.Effect.State.state/3, string/3)
+            (OCaml.Effect.State.state/3, string/3);
+            r_state/0
           ], (Type (bool/3) * Type (string/3) * Type (Z/3)))),
         Bind
           (?,
@@ -567,8 +536,8 @@ Value
                 [
                   (OCaml.Effect.State.state/3, Z/3);
                   (OCaml.Effect.State.state/3, bool/3);
-                  (OCaml.Effect.State.state/3, r_state/0);
-                  (OCaml.Effect.State.state/3, string/3)
+                  (OCaml.Effect.State.state/3, string/3);
+                  r_state/0
                 ],
                 Apply
                   (46, Variable (46, OCaml.Pervasives.ref/3),
@@ -580,8 +549,8 @@ Value
                     [
                       (OCaml.Effect.State.state/3, Z/3);
                       (OCaml.Effect.State.state/3, bool/3);
-                      (OCaml.Effect.State.state/3, r_state/0);
-                      (OCaml.Effect.State.state/3, string/3)
+                      (OCaml.Effect.State.state/3, string/3);
+                      r_state/0
                     ],
                     Apply
                       (47,
@@ -726,9 +695,8 @@ Value
                           (OCaml.Effect.State.state/3,
                             bool/3);
                           (OCaml.Effect.State.state/3,
-                            r_state/0);
-                          (OCaml.Effect.State.state/3,
-                            string/3)
+                            string/3);
+                          r_state/0
                         ],
                         Apply
                           (51, Variable (51, update/0),
@@ -750,9 +718,8 @@ Value
                               (OCaml.Effect.State.state/3,
                                 bool/3);
                               (OCaml.Effect.State.state/3,
-                                r_state/0);
-                              (OCaml.Effect.State.state/3,
-                                string/3)
+                                string/3);
+                              r_state/0
                             ],
                             Apply
                               (52,
@@ -779,9 +746,8 @@ Value
                                   (OCaml.Effect.State.state/3,
                                     bool/3);
                                   (OCaml.Effect.State.state/3,
-                                    r_state/0);
-                                  (OCaml.Effect.State.state/3,
-                                    string/3)
+                                    string/3);
+                                  r_state/0
                                 ],
                                 Apply
                                   (53,
@@ -807,9 +773,8 @@ Value
                                       (OCaml.Effect.State.state/3,
                                         bool/3);
                                       (OCaml.Effect.State.state/3,
-                                        r_state/0);
-                                      (OCaml.Effect.State.state/3,
-                                        string/3)
+                                        string/3);
+                                      r_state/0
                                     ],
                                     Apply
                                       (54,
@@ -836,9 +801,8 @@ Value
                                           (OCaml.Effect.State.state/3,
                                             bool/3);
                                           (OCaml.Effect.State.state/3,
-                                            r_state/0);
-                                          (OCaml.Effect.State.state/3,
-                                            string/3)
+                                            string/3);
+                                          r_state/0
                                         ],
                                         Apply
                                           (54,
@@ -858,8 +822,7 @@ Value
                                             [
                                               (OCaml.Effect.State.state/3,
                                                 Z/3);
-                                              (OCaml.Effect.State.state/3,
-                                                r_state/0)
+                                              r_state/0
                                             ],
                                             [
                                               (OCaml.Effect.State.state/3,
@@ -867,9 +830,8 @@ Value
                                               (OCaml.Effect.State.state/3,
                                                 bool/3);
                                               (OCaml.Effect.State.state/3,
-                                                r_state/0);
-                                              (OCaml.Effect.State.state/3,
-                                                string/3)
+                                                string/3);
+                                              r_state/0
                                             ],
                                             Bind
                                               (?,
@@ -884,8 +846,7 @@ Value
                                                         [
                                                           (OCaml.Effect.State.state/3,
                                                             Z/3);
-                                                          (OCaml.Effect.State.state/3,
-                                                            r_state/0)
+                                                          r_state/0
                                                         ],
                                                         Apply
                                                           (?,
@@ -901,14 +862,12 @@ Value
                                                     Lift
                                                       (?,
                                                         [
-                                                          (OCaml.Effect.State.state/3,
-                                                            r_state/0)
+                                                          r_state/0
                                                         ],
                                                         [
                                                           (OCaml.Effect.State.state/3,
                                                             Z/3);
-                                                          (OCaml.Effect.State.state/3,
-                                                            r_state/0)
+                                                          r_state/0
                                                         ],
                                                         Apply
                                                           (?,
@@ -934,8 +893,7 @@ Value
                                                     [
                                                       (OCaml.Effect.State.state/3,
                                                         Z/3);
-                                                      (OCaml.Effect.State.state/3,
-                                                        r_state/0)
+                                                      r_state/0
                                                     ],
                                                     Apply
                                                       (54,
@@ -968,12 +926,12 @@ Value
 Value
   (non_rec, @.,
     [
-      ((partials_test, [ ], [ (x, Type (unit/3)) ],
+      ((partials_test, [ ], [ (es_in, list Effect.t); (x, Type (unit/3)) ],
         Monad
           ([
             (OCaml.Effect.State.state/3, Z/3);
             (OCaml.Effect.State.state/3, (list/3, Z/3));
-            (OCaml.Effect.State.state/3, r_state/0)
+            r_state/0
           ], Type (OCaml.Effect.State.t/3, Type (Z/3)))),
         Match
           (?, Variable (?, x/0),
@@ -1034,8 +992,7 @@ Value
                         [
                           (OCaml.Effect.State.state/3,
                             Z/3);
-                          (OCaml.Effect.State.state/3,
-                            r_state/0)
+                          r_state/0
                         ],
                         [
                           (OCaml.Effect.State.state/3,
@@ -1043,8 +1000,7 @@ Value
                           (OCaml.Effect.State.state/3,
                             (list/3,
                               Z/3));
-                          (OCaml.Effect.State.state/3,
-                            r_state/0)
+                          r_state/0
                         ],
                         Bind
                           (?,
@@ -1059,8 +1015,7 @@ Value
                                     [
                                       (OCaml.Effect.State.state/3,
                                         Z/3);
-                                      (OCaml.Effect.State.state/3,
-                                        r_state/0)
+                                      r_state/0
                                     ],
                                     Apply
                                       (?,
@@ -1076,14 +1031,12 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      (OCaml.Effect.State.state/3,
-                                        r_state/0)
+                                      r_state/0
                                     ],
                                     [
                                       (OCaml.Effect.State.state/3,
                                         Z/3);
-                                      (OCaml.Effect.State.state/3,
-                                        r_state/0)
+                                      r_state/0
                                     ],
                                     Apply
                                       (?,
@@ -1129,8 +1082,7 @@ Value
                           (OCaml.Effect.State.state/3,
                             (list/3,
                               Z/3));
-                          (OCaml.Effect.State.state/3,
-                            r_state/0)
+                          r_state/0
                         ],
                         Bind
                           (?,
@@ -1746,4 +1698,131 @@ Value
                                                   (85,
                                                     s/0))))))))))
             ]))
+    ])
+
+87
+Value
+  (non_rec, @.,
+    [
+      ((type_vars_test, [ A; B ],
+        [
+          (es_in, list Effect.t);
+          (x, Type (OCaml.Effect.State.t/3, A));
+          (y, Type (OCaml.Effect.State.t/3, B));
+          (a, A);
+          (b, B)
+        ],
+        Monad
+          ([
+            (OCaml.Effect.State.state/3, A);
+            (OCaml.Effect.State.state/3, B)
+          ], Type (unit/3))),
+        Bind
+          (?,
+            Lift
+              (?, [ (OCaml.Effect.State.state/3, A) ],
+                [
+                  (OCaml.Effect.State.state/3, A);
+                  (OCaml.Effect.State.state/3, B)
+                ],
+                Apply
+                  (88, Variable (88, OCaml.Effect.State.write/3),
+                    [ Variable (88, x/0); Variable (88, a/0) ])),
+            None,
+            Lift
+              (?, [ (OCaml.Effect.State.state/3, B) ],
+                [
+                  (OCaml.Effect.State.state/3, A);
+                  (OCaml.Effect.State.state/3, B)
+                ],
+                Apply
+                  (89, Variable (89, OCaml.Effect.State.write/3),
+                    [ Variable (89, y/0); Variable (89, b/0) ]))))
+    ])
+
+91
+Value
+  (non_rec, @.,
+    [
+      ((resolves_test1, [ A ],
+        [ (x, Type (OCaml.Effect.State.t/3, A)); (a, A); (b, A) ],
+        Monad ([ (OCaml.Effect.State.state/3, A) ], Type (unit/3))),
+        Lift
+          (?,
+            [
+              (OCaml.Effect.State.state/3, A);
+              (OCaml.Effect.State.state/3, A)
+            ], [ (OCaml.Effect.State.state/3, A) ],
+            Apply
+              (92, Variable (92, type_vars_test/0),
+                [
+                  Variable (92, x/0);
+                  Variable (92, x/0);
+                  Variable (92, a/0);
+                  Variable (92, b/0)
+                ])))
+    ])
+
+94
+Value
+  (non_rec, @.,
+    [
+      ((resolves_test2, [ A ],
+        [
+          (es_in, list Effect.t);
+          (x, Type (OCaml.Effect.State.t/3, Type (Z/3)));
+          (y, Type (OCaml.Effect.State.t/3, A));
+          (a, Type (Z/3));
+          (b, A)
+        ],
+        Monad
+          ([
+            (OCaml.Effect.State.state/3, A);
+            (OCaml.Effect.State.state/3, Z/3)
+          ], Type (unit/3))),
+        Lift
+          (?,
+            [
+              (OCaml.Effect.State.state/3, Z/3);
+              (OCaml.Effect.State.state/3, A)
+            ],
+            [
+              (OCaml.Effect.State.state/3, A);
+              (OCaml.Effect.State.state/3, Z/3)
+            ],
+            Apply
+              (95, Variable (95, type_vars_test/0),
+                [
+                  Variable (95, x/0);
+                  Variable (95, y/0);
+                  Variable (95, a/0);
+                  Variable (95, b/0)
+                ])))
+    ])
+
+97
+Value
+  (non_rec, @.,
+    [
+      ((resolves_test3, [ ],
+        [
+          (x, Type (OCaml.Effect.State.t/3, Type (Z/3)));
+          (y, Type (OCaml.Effect.State.t/3, Type (Z/3)));
+          (a, Type (Z/3));
+          (b, Type (Z/3))
+        ], Monad ([ (OCaml.Effect.State.state/3, Z/3) ], Type (unit/3))),
+        Lift
+          (?,
+            [
+              (OCaml.Effect.State.state/3, Z/3);
+              (OCaml.Effect.State.state/3, Z/3)
+            ], [ (OCaml.Effect.State.state/3, Z/3) ],
+            Apply
+              (98, Variable (98, type_vars_test/0),
+                [
+                  Variable (98, x/0);
+                  Variable (98, y/0);
+                  Variable (98, a/0);
+                  Variable (98, b/0)
+                ])))
     ])

--- a/tests/ex39.monadise
+++ b/tests/ex39.monadise
@@ -5,9 +5,7 @@ Value
   (non_rec, @.,
     [
       ((get_local_ref, [ ], [ (tt, Type (unit/3)) ],
-        Monad
-          ([ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
-            Type (Z/3))),
+        Monad ([ (OCaml.Effect.State.state/3, Z/3) ], Type (Z/3))),
         Bind
           (?,
             Apply
@@ -23,9 +21,7 @@ Value
   (non_rec, @.,
     [
       ((set_local_ref, [ ], [ (tt, Type (unit/3)) ],
-        Monad
-          ([ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
-            Type (Z/3))),
+        Monad ([ (OCaml.Effect.State.state/3, Z/3) ], Type (Z/3))),
         Bind
           (?,
             Apply
@@ -48,9 +44,7 @@ Value
     [
       ((add_multiple_by_refs, [ ],
         [ (a, Type (Z/3)); (b, Type (Z/3)); (c, Type (Z/3)); (d, Type (Z/3)) ],
-        Monad
-          ([ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
-            Type (Z/3))),
+        Monad ([ (OCaml.Effect.State.state/3, Z/3) ], Type (Z/3))),
         Bind
           (?,
             Apply
@@ -207,9 +201,7 @@ Value
   (non_rec, @.,
     [
       ((set_ref, [ ], [ (x, Type (OCaml.Effect.State.t/3, Type (Z/3))) ],
-        Monad
-          ([ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
-            Type (unit/3))),
+        Monad ([ (OCaml.Effect.State.state/3, Z/3) ], Type (unit/3))),
         Apply
           (21, Variable (21, OCaml.Effect.State.write/3),
             [ Variable (21, x/0); Constant (21, Int(15)) ]))
@@ -220,9 +212,7 @@ Value
   (non_rec, @.,
     [
       ((get_ref, [ ], [ (x, Type (OCaml.Effect.State.t/3, Type (Z/3))) ],
-        Monad
-          ([ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
-            Type (Z/3))),
+        Monad ([ (OCaml.Effect.State.state/3, Z/3) ], Type (Z/3))),
         Apply
           (24, Variable (24, OCaml.Effect.State.read/3),
             [ Variable (24, x/0) ]))
@@ -233,9 +223,7 @@ Value
   (non_rec, @.,
     [
       ((update_ref, [ ], [ (x, Type (OCaml.Effect.State.t/3, Type (Z/3))) ],
-        Monad
-          ([ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
-            Type (unit/3))),
+        Monad ([ (OCaml.Effect.State.state/3, Z/3) ], Type (unit/3))),
         Bind
           (?,
             Bind
@@ -262,7 +250,7 @@ Value
     [
       ((new_ref, [ ], [ (x, Type (unit/3)) ],
         Monad
-          ([ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
+          ([ (OCaml.Effect.State.state/3, Z/3) ],
             Type (OCaml.Effect.State.t/3, Type (Z/3)))),
         Apply
           (30, Variable (30, OCaml.Pervasives.ref/3),
@@ -278,27 +266,18 @@ Value
       ((set_r, [ ], [ (x, Type (unit/3)) ],
         Monad
           ([
-            TypeEffect
-            (Type (Z/3), OCaml.Effect.State.state/3);
-            TypeEffect
-            (Type (r_state/0), OCaml.Effect.State.state/3)
+            (OCaml.Effect.State.state/3, Z/3);
+            (OCaml.Effect.State.state/3, r_state/0)
           ], Type (unit/3))),
         Bind
           (?,
             Bind
               (?,
                 Lift
-                  (?,
+                  (?, [ (OCaml.Effect.State.state/3, Z/3) ],
                     [
-                      TypeEffect
-                      (Type (Z/3), OCaml.Effect.State.state/3)
-                    ],
-                    [
-                      TypeEffect
-                      (Type (Z/3), OCaml.Effect.State.state/3);
-                      TypeEffect
-                      (Type (r_state/0),
-                        OCaml.Effect.State.state/3)
+                      (OCaml.Effect.State.state/3, Z/3);
+                      (OCaml.Effect.State.state/3, r_state/0)
                     ],
                     Apply
                       (?,
@@ -306,18 +285,10 @@ Value
                           (?, OCaml.Effect.State.peekstate/3),
                         [ Tuple (?) ])), Some x_1,
                 Lift
-                  (?,
+                  (?, [ (OCaml.Effect.State.state/3, r_state/0) ],
                     [
-                      TypeEffect
-                      (Type (r_state/0),
-                        OCaml.Effect.State.state/3)
-                    ],
-                    [
-                      TypeEffect
-                      (Type (Z/3), OCaml.Effect.State.state/3);
-                      TypeEffect
-                      (Type (r_state/0),
-                        OCaml.Effect.State.state/3)
+                      (OCaml.Effect.State.state/3, Z/3);
+                      (OCaml.Effect.State.state/3, r_state/0)
                     ],
                     Apply
                       (?,
@@ -328,13 +299,10 @@ Value
                           Variable (?, x_1/0)
                         ]))), Some x_1,
             Lift
-              (?,
-                [ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
+              (?, [ (OCaml.Effect.State.state/3, Z/3) ],
                 [
-                  TypeEffect
-                  (Type (Z/3), OCaml.Effect.State.state/3);
-                  TypeEffect
-                  (Type (r_state/0), OCaml.Effect.State.state/3)
+                  (OCaml.Effect.State.state/3, Z/3);
+                  (OCaml.Effect.State.state/3, r_state/0)
                 ],
                 Apply
                   (34, Variable (34, set_ref/0),
@@ -348,27 +316,18 @@ Value
       ((get_r, [ ], [ (x, Type (unit/3)) ],
         Monad
           ([
-            TypeEffect
-            (Type (Z/3), OCaml.Effect.State.state/3);
-            TypeEffect
-            (Type (r_state/0), OCaml.Effect.State.state/3)
+            (OCaml.Effect.State.state/3, Z/3);
+            (OCaml.Effect.State.state/3, r_state/0)
           ], Type (Z/3))),
         Bind
           (?,
             Bind
               (?,
                 Lift
-                  (?,
+                  (?, [ (OCaml.Effect.State.state/3, Z/3) ],
                     [
-                      TypeEffect
-                      (Type (Z/3), OCaml.Effect.State.state/3)
-                    ],
-                    [
-                      TypeEffect
-                      (Type (Z/3), OCaml.Effect.State.state/3);
-                      TypeEffect
-                      (Type (r_state/0),
-                        OCaml.Effect.State.state/3)
+                      (OCaml.Effect.State.state/3, Z/3);
+                      (OCaml.Effect.State.state/3, r_state/0)
                     ],
                     Apply
                       (?,
@@ -376,18 +335,10 @@ Value
                           (?, OCaml.Effect.State.peekstate/3),
                         [ Tuple (?) ])), Some x_1,
                 Lift
-                  (?,
+                  (?, [ (OCaml.Effect.State.state/3, r_state/0) ],
                     [
-                      TypeEffect
-                      (Type (r_state/0),
-                        OCaml.Effect.State.state/3)
-                    ],
-                    [
-                      TypeEffect
-                      (Type (Z/3), OCaml.Effect.State.state/3);
-                      TypeEffect
-                      (Type (r_state/0),
-                        OCaml.Effect.State.state/3)
+                      (OCaml.Effect.State.state/3, Z/3);
+                      (OCaml.Effect.State.state/3, r_state/0)
                     ],
                     Apply
                       (?,
@@ -398,13 +349,10 @@ Value
                           Variable (?, x_1/0)
                         ]))), Some x_1,
             Lift
-              (?,
-                [ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
+              (?, [ (OCaml.Effect.State.state/3, Z/3) ],
                 [
-                  TypeEffect
-                  (Type (Z/3), OCaml.Effect.State.state/3);
-                  TypeEffect
-                  (Type (r_state/0), OCaml.Effect.State.state/3)
+                  (OCaml.Effect.State.state/3, Z/3);
+                  (OCaml.Effect.State.state/3, r_state/0)
                 ],
                 Apply
                   (36, Variable (36, get_ref/0),
@@ -418,10 +366,8 @@ Value
       ((r_add_15, [ ], [ (x, Type (unit/3)) ],
         Monad
           ([
-            TypeEffect
-            (Type (Z/3), OCaml.Effect.State.state/3);
-            TypeEffect
-            (Type (r_state/0), OCaml.Effect.State.state/3)
+            (OCaml.Effect.State.state/3, Z/3);
+            (OCaml.Effect.State.state/3, r_state/0)
           ], Type (Z/3))),
         Bind
           (?,
@@ -446,20 +392,14 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3)
                                     ],
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3);
-                                      TypeEffect
-                                      (Type
-                                        (r_state/0),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3);
+                                      (OCaml.Effect.State.state/3,
+                                        r_state/0)
                                     ],
                                     Apply
                                       (?,
@@ -474,20 +414,14 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (r_state/0),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        r_state/0)
                                     ],
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3);
-                                      TypeEffect
-                                      (Type
-                                        (r_state/0),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3);
+                                      (OCaml.Effect.State.state/3,
+                                        r_state/0)
                                     ],
                                     Apply
                                       (?,
@@ -506,17 +440,14 @@ Value
                             Lift
                               (?,
                                 [
-                                  TypeEffect
-                                  (Type (Z/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3)
                                 ],
                                 [
-                                  TypeEffect
-                                  (Type (Z/3),
-                                    OCaml.Effect.State.state/3);
-                                  TypeEffect
-                                  (Type (r_state/0),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3);
+                                  (OCaml.Effect.State.state/3,
+                                    r_state/0)
                                 ],
                                 Apply
                                   (42,
@@ -548,20 +479,14 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3)
                                     ],
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3);
-                                      TypeEffect
-                                      (Type
-                                        (r_state/0),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3);
+                                      (OCaml.Effect.State.state/3,
+                                        r_state/0)
                                     ],
                                     Apply
                                       (?,
@@ -576,20 +501,14 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (r_state/0),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        r_state/0)
                                     ],
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3);
-                                      TypeEffect
-                                      (Type
-                                        (r_state/0),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3);
+                                      (OCaml.Effect.State.state/3,
+                                        r_state/0)
                                     ],
                                     Apply
                                       (?,
@@ -608,17 +527,14 @@ Value
                             Lift
                               (?,
                                 [
-                                  TypeEffect
-                                  (Type (Z/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3)
                                 ],
                                 [
-                                  TypeEffect
-                                  (Type (Z/3),
-                                    OCaml.Effect.State.state/3);
-                                  TypeEffect
-                                  (Type (r_state/0),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3);
+                                  (OCaml.Effect.State.state/3,
+                                    r_state/0)
                                 ],
                                 Apply
                                   (43,
@@ -639,32 +555,20 @@ Value
       ((mixed_type, [ ], [ (x, Type (unit/3)) ],
         Monad
           ([
-            TypeEffect
-            (Type (Z/3), OCaml.Effect.State.state/3);
-            TypeEffect
-            (Type (bool/3), OCaml.Effect.State.state/3);
-            TypeEffect
-            (Type (r_state/0), OCaml.Effect.State.state/3);
-            TypeEffect
-            (Type (string/3), OCaml.Effect.State.state/3)
+            (OCaml.Effect.State.state/3, Z/3);
+            (OCaml.Effect.State.state/3, bool/3);
+            (OCaml.Effect.State.state/3, r_state/0);
+            (OCaml.Effect.State.state/3, string/3)
           ], (Type (bool/3) * Type (string/3) * Type (Z/3)))),
         Bind
           (?,
             Lift
-              (?,
+              (?, [ (OCaml.Effect.State.state/3, bool/3) ],
                 [
-                  TypeEffect
-                  (Type (bool/3), OCaml.Effect.State.state/3)
-                ],
-                [
-                  TypeEffect
-                  (Type (Z/3), OCaml.Effect.State.state/3);
-                  TypeEffect
-                  (Type (bool/3), OCaml.Effect.State.state/3);
-                  TypeEffect
-                  (Type (r_state/0), OCaml.Effect.State.state/3);
-                  TypeEffect
-                  (Type (string/3), OCaml.Effect.State.state/3)
+                  (OCaml.Effect.State.state/3, Z/3);
+                  (OCaml.Effect.State.state/3, bool/3);
+                  (OCaml.Effect.State.state/3, r_state/0);
+                  (OCaml.Effect.State.state/3, string/3)
                 ],
                 Apply
                   (46, Variable (46, OCaml.Pervasives.ref/3),
@@ -672,23 +576,12 @@ Value
             Bind
               (?,
                 Lift
-                  (?,
+                  (?, [ (OCaml.Effect.State.state/3, string/3) ],
                     [
-                      TypeEffect
-                      (Type (string/3),
-                        OCaml.Effect.State.state/3)
-                    ],
-                    [
-                      TypeEffect
-                      (Type (Z/3), OCaml.Effect.State.state/3);
-                      TypeEffect
-                      (Type (bool/3), OCaml.Effect.State.state/3);
-                      TypeEffect
-                      (Type (r_state/0),
-                        OCaml.Effect.State.state/3);
-                      TypeEffect
-                      (Type (string/3),
-                        OCaml.Effect.State.state/3)
+                      (OCaml.Effect.State.state/3, Z/3);
+                      (OCaml.Effect.State.state/3, bool/3);
+                      (OCaml.Effect.State.state/3, r_state/0);
+                      (OCaml.Effect.State.state/3, string/3)
                     ],
                     Apply
                       (47,
@@ -701,14 +594,10 @@ Value
                       ((update, [ ], [ (x_1, Type (unit/3)) ],
                         Monad
                           ([
-                            TypeEffect
-                            (Type
-                              (bool/3),
-                              OCaml.Effect.State.state/3);
-                            TypeEffect
-                            (Type
-                              (string/3),
-                              OCaml.Effect.State.state/3)
+                            (OCaml.Effect.State.state/3,
+                              bool/3);
+                            (OCaml.Effect.State.state/3,
+                              string/3)
                           ],
                             Type
                               (unit/3))),
@@ -725,20 +614,14 @@ Value
                                     Lift
                                       (?,
                                         [
-                                          TypeEffect
-                                          (Type
-                                            (bool/3),
-                                            OCaml.Effect.State.state/3)
+                                          (OCaml.Effect.State.state/3,
+                                            bool/3)
                                         ],
                                         [
-                                          TypeEffect
-                                          (Type
-                                            (bool/3),
-                                            OCaml.Effect.State.state/3);
-                                          TypeEffect
-                                          (Type
-                                            (string/3),
-                                            OCaml.Effect.State.state/3)
+                                          (OCaml.Effect.State.state/3,
+                                            bool/3);
+                                          (OCaml.Effect.State.state/3,
+                                            string/3)
                                         ],
                                         Bind
                                           (?,
@@ -771,20 +654,14 @@ Value
                                     Lift
                                       (?,
                                         [
-                                          TypeEffect
-                                          (Type
-                                            (string/3),
-                                            OCaml.Effect.State.state/3)
+                                          (OCaml.Effect.State.state/3,
+                                            string/3)
                                         ],
                                         [
-                                          TypeEffect
-                                          (Type
-                                            (bool/3),
-                                            OCaml.Effect.State.state/3);
-                                          TypeEffect
-                                          (Type
-                                            (string/3),
-                                            OCaml.Effect.State.state/3)
+                                          (OCaml.Effect.State.state/3,
+                                            bool/3);
+                                          (OCaml.Effect.State.state/3,
+                                            string/3)
                                         ],
                                         Bind
                                           (?,
@@ -839,26 +716,19 @@ Value
                     Lift
                       (?,
                         [
-                          TypeEffect
-                          (Type (bool/3),
-                            OCaml.Effect.State.state/3);
-                          TypeEffect
-                          (Type (string/3),
-                            OCaml.Effect.State.state/3)
+                          (OCaml.Effect.State.state/3,
+                            bool/3);
+                          (OCaml.Effect.State.state/3,
+                            string/3)
                         ],
                         [
-                          TypeEffect
-                          (Type (Z/3),
-                            OCaml.Effect.State.state/3);
-                          TypeEffect
-                          (Type (bool/3),
-                            OCaml.Effect.State.state/3);
-                          TypeEffect
-                          (Type (r_state/0),
-                            OCaml.Effect.State.state/3);
-                          TypeEffect
-                          (Type (string/3),
-                            OCaml.Effect.State.state/3)
+                          (OCaml.Effect.State.state/3, Z/3);
+                          (OCaml.Effect.State.state/3,
+                            bool/3);
+                          (OCaml.Effect.State.state/3,
+                            r_state/0);
+                          (OCaml.Effect.State.state/3,
+                            string/3)
                         ],
                         Apply
                           (51, Variable (51, update/0),
@@ -869,26 +739,20 @@ Value
                         Lift
                           (?,
                             [
-                              TypeEffect
-                              (Type (bool/3),
-                                OCaml.Effect.State.state/3);
-                              TypeEffect
-                              (Type (string/3),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                bool/3);
+                              (OCaml.Effect.State.state/3,
+                                string/3)
                             ],
                             [
-                              TypeEffect
-                              (Type (Z/3),
-                                OCaml.Effect.State.state/3);
-                              TypeEffect
-                              (Type (bool/3),
-                                OCaml.Effect.State.state/3);
-                              TypeEffect
-                              (Type (r_state/0),
-                                OCaml.Effect.State.state/3);
-                              TypeEffect
-                              (Type (string/3),
-                                OCaml.Effect.State.state/3)
+                              (OCaml.Effect.State.state/3,
+                                Z/3);
+                              (OCaml.Effect.State.state/3,
+                                bool/3);
+                              (OCaml.Effect.State.state/3,
+                                r_state/0);
+                              (OCaml.Effect.State.state/3,
+                                string/3)
                             ],
                             Apply
                               (52,
@@ -904,26 +768,20 @@ Value
                             Lift
                               (?,
                                 [
-                                  TypeEffect
-                                  (Type (bool/3),
-                                    OCaml.Effect.State.state/3);
-                                  TypeEffect
-                                  (Type (string/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    bool/3);
+                                  (OCaml.Effect.State.state/3,
+                                    string/3)
                                 ],
                                 [
-                                  TypeEffect
-                                  (Type (Z/3),
-                                    OCaml.Effect.State.state/3);
-                                  TypeEffect
-                                  (Type (bool/3),
-                                    OCaml.Effect.State.state/3);
-                                  TypeEffect
-                                  (Type (r_state/0),
-                                    OCaml.Effect.State.state/3);
-                                  TypeEffect
-                                  (Type (string/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3);
+                                  (OCaml.Effect.State.state/3,
+                                    bool/3);
+                                  (OCaml.Effect.State.state/3,
+                                    r_state/0);
+                                  (OCaml.Effect.State.state/3,
+                                    string/3)
                                 ],
                                 Apply
                                   (53,
@@ -940,28 +798,18 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (bool/3),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        bool/3)
                                     ],
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3);
-                                      TypeEffect
-                                      (Type
-                                        (bool/3),
-                                        OCaml.Effect.State.state/3);
-                                      TypeEffect
-                                      (Type
-                                        (r_state/0),
-                                        OCaml.Effect.State.state/3);
-                                      TypeEffect
-                                      (Type
-                                        (string/3),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3);
+                                      (OCaml.Effect.State.state/3,
+                                        bool/3);
+                                      (OCaml.Effect.State.state/3,
+                                        r_state/0);
+                                      (OCaml.Effect.State.state/3,
+                                        string/3)
                                     ],
                                     Apply
                                       (54,
@@ -979,28 +827,18 @@ Value
                                     Lift
                                       (?,
                                         [
-                                          TypeEffect
-                                          (Type
-                                            (string/3),
-                                            OCaml.Effect.State.state/3)
+                                          (OCaml.Effect.State.state/3,
+                                            string/3)
                                         ],
                                         [
-                                          TypeEffect
-                                          (Type
-                                            (Z/3),
-                                            OCaml.Effect.State.state/3);
-                                          TypeEffect
-                                          (Type
-                                            (bool/3),
-                                            OCaml.Effect.State.state/3);
-                                          TypeEffect
-                                          (Type
-                                            (r_state/0),
-                                            OCaml.Effect.State.state/3);
-                                          TypeEffect
-                                          (Type
-                                            (string/3),
-                                            OCaml.Effect.State.state/3)
+                                          (OCaml.Effect.State.state/3,
+                                            Z/3);
+                                          (OCaml.Effect.State.state/3,
+                                            bool/3);
+                                          (OCaml.Effect.State.state/3,
+                                            r_state/0);
+                                          (OCaml.Effect.State.state/3,
+                                            string/3)
                                         ],
                                         Apply
                                           (54,
@@ -1018,32 +856,20 @@ Value
                                         Lift
                                           (?,
                                             [
-                                              TypeEffect
-                                              (Type
-                                                (Z/3),
-                                                OCaml.Effect.State.state/3);
-                                              TypeEffect
-                                              (Type
-                                                (r_state/0),
-                                                OCaml.Effect.State.state/3)
+                                              (OCaml.Effect.State.state/3,
+                                                Z/3);
+                                              (OCaml.Effect.State.state/3,
+                                                r_state/0)
                                             ],
                                             [
-                                              TypeEffect
-                                              (Type
-                                                (Z/3),
-                                                OCaml.Effect.State.state/3);
-                                              TypeEffect
-                                              (Type
-                                                (bool/3),
-                                                OCaml.Effect.State.state/3);
-                                              TypeEffect
-                                              (Type
-                                                (r_state/0),
-                                                OCaml.Effect.State.state/3);
-                                              TypeEffect
-                                              (Type
-                                                (string/3),
-                                                OCaml.Effect.State.state/3)
+                                              (OCaml.Effect.State.state/3,
+                                                Z/3);
+                                              (OCaml.Effect.State.state/3,
+                                                bool/3);
+                                              (OCaml.Effect.State.state/3,
+                                                r_state/0);
+                                              (OCaml.Effect.State.state/3,
+                                                string/3)
                                             ],
                                             Bind
                                               (?,
@@ -1052,20 +878,14 @@ Value
                                                     Lift
                                                       (?,
                                                         [
-                                                          TypeEffect
-                                                          (Type
-                                                            (Z/3),
-                                                            OCaml.Effect.State.state/3)
+                                                          (OCaml.Effect.State.state/3,
+                                                            Z/3)
                                                         ],
                                                         [
-                                                          TypeEffect
-                                                          (Type
-                                                            (Z/3),
-                                                            OCaml.Effect.State.state/3);
-                                                          TypeEffect
-                                                          (Type
-                                                            (r_state/0),
-                                                            OCaml.Effect.State.state/3)
+                                                          (OCaml.Effect.State.state/3,
+                                                            Z/3);
+                                                          (OCaml.Effect.State.state/3,
+                                                            r_state/0)
                                                         ],
                                                         Apply
                                                           (?,
@@ -1081,20 +901,14 @@ Value
                                                     Lift
                                                       (?,
                                                         [
-                                                          TypeEffect
-                                                          (Type
-                                                            (r_state/0),
-                                                            OCaml.Effect.State.state/3)
+                                                          (OCaml.Effect.State.state/3,
+                                                            r_state/0)
                                                         ],
                                                         [
-                                                          TypeEffect
-                                                          (Type
-                                                            (Z/3),
-                                                            OCaml.Effect.State.state/3);
-                                                          TypeEffect
-                                                          (Type
-                                                            (r_state/0),
-                                                            OCaml.Effect.State.state/3)
+                                                          (OCaml.Effect.State.state/3,
+                                                            Z/3);
+                                                          (OCaml.Effect.State.state/3,
+                                                            r_state/0)
                                                         ],
                                                         Apply
                                                           (?,
@@ -1114,20 +928,14 @@ Value
                                                 Lift
                                                   (?,
                                                     [
-                                                      TypeEffect
-                                                      (Type
-                                                        (Z/3),
-                                                        OCaml.Effect.State.state/3)
+                                                      (OCaml.Effect.State.state/3,
+                                                        Z/3)
                                                     ],
                                                     [
-                                                      TypeEffect
-                                                      (Type
-                                                        (Z/3),
-                                                        OCaml.Effect.State.state/3);
-                                                      TypeEffect
-                                                      (Type
-                                                        (r_state/0),
-                                                        OCaml.Effect.State.state/3)
+                                                      (OCaml.Effect.State.state/3,
+                                                        Z/3);
+                                                      (OCaml.Effect.State.state/3,
+                                                        r_state/0)
                                                     ],
                                                     Apply
                                                       (54,
@@ -1163,12 +971,9 @@ Value
       ((partials_test, [ ], [ (x, Type (unit/3)) ],
         Monad
           ([
-            TypeEffect
-            (Type (Z/3), OCaml.Effect.State.state/3);
-            TypeEffect
-            (Type (list/3, Type (Z/3)), OCaml.Effect.State.state/3);
-            TypeEffect
-            (Type (r_state/0), OCaml.Effect.State.state/3)
+            (OCaml.Effect.State.state/3, Z/3);
+            (OCaml.Effect.State.state/3, (list/3, Z/3));
+            (OCaml.Effect.State.state/3, r_state/0)
           ], Type (OCaml.Effect.State.t/3, Type (Z/3)))),
         Match
           (?, Variable (?, x/0),
@@ -1192,10 +997,8 @@ Value
                         ],
                         Monad
                           ([
-                            TypeEffect
-                            (Type
-                              (Z/3),
-                              OCaml.Effect.State.state/3)
+                            (OCaml.Effect.State.state/3,
+                              Z/3)
                           ],
                             Type
                               (OCaml.Effect.State.t/3,
@@ -1229,30 +1032,19 @@ Value
                     Lift
                       (?,
                         [
-                          TypeEffect
-                          (Type
-                            (Z/3),
-                            OCaml.Effect.State.state/3);
-                          TypeEffect
-                          (Type
-                            (r_state/0),
-                            OCaml.Effect.State.state/3)
+                          (OCaml.Effect.State.state/3,
+                            Z/3);
+                          (OCaml.Effect.State.state/3,
+                            r_state/0)
                         ],
                         [
-                          TypeEffect
-                          (Type
-                            (Z/3),
-                            OCaml.Effect.State.state/3);
-                          TypeEffect
-                          (Type
+                          (OCaml.Effect.State.state/3,
+                            Z/3);
+                          (OCaml.Effect.State.state/3,
                             (list/3,
-                              Type
-                                (Z/3)),
-                            OCaml.Effect.State.state/3);
-                          TypeEffect
-                          (Type
-                            (r_state/0),
-                            OCaml.Effect.State.state/3)
+                              Z/3));
+                          (OCaml.Effect.State.state/3,
+                            r_state/0)
                         ],
                         Bind
                           (?,
@@ -1261,20 +1053,14 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3)
                                     ],
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3);
-                                      TypeEffect
-                                      (Type
-                                        (r_state/0),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3);
+                                      (OCaml.Effect.State.state/3,
+                                        r_state/0)
                                     ],
                                     Apply
                                       (?,
@@ -1290,20 +1076,14 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (r_state/0),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        r_state/0)
                                     ],
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3);
-                                      TypeEffect
-                                      (Type
-                                        (r_state/0),
-                                        OCaml.Effect.State.state/3)
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3);
+                                      (OCaml.Effect.State.state/3,
+                                        r_state/0)
                                     ],
                                     Apply
                                       (?,
@@ -1337,54 +1117,35 @@ Value
                     Lift
                       (?,
                         [
-                          TypeEffect
-                          (Type
-                            (Z/3),
-                            OCaml.Effect.State.state/3);
-                          TypeEffect
-                          (Type
+                          (OCaml.Effect.State.state/3,
+                            Z/3);
+                          (OCaml.Effect.State.state/3,
                             (list/3,
-                              Type
-                                (Z/3)),
-                            OCaml.Effect.State.state/3)
+                              Z/3))
                         ],
                         [
-                          TypeEffect
-                          (Type
-                            (Z/3),
-                            OCaml.Effect.State.state/3);
-                          TypeEffect
-                          (Type
+                          (OCaml.Effect.State.state/3,
+                            Z/3);
+                          (OCaml.Effect.State.state/3,
                             (list/3,
-                              Type
-                                (Z/3)),
-                            OCaml.Effect.State.state/3);
-                          TypeEffect
-                          (Type
-                            (r_state/0),
-                            OCaml.Effect.State.state/3)
+                              Z/3));
+                          (OCaml.Effect.State.state/3,
+                            r_state/0)
                         ],
                         Bind
                           (?,
                             Lift
                               (?,
                                 [
-                                  TypeEffect
-                                  (Type
-                                    (Z/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3)
                                 ],
                                 [
-                                  TypeEffect
-                                  (Type
-                                    (Z/3),
-                                    OCaml.Effect.State.state/3);
-                                  TypeEffect
-                                  (Type
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3);
+                                  (OCaml.Effect.State.state/3,
                                     (list/3,
-                                      Type
-                                        (Z/3)),
-                                    OCaml.Effect.State.state/3)
+                                      Z/3))
                                 ],
                                 Apply
                                   (61,
@@ -1422,16 +1183,11 @@ Value
                                     ],
                                     Monad
                                       ([
-                                        TypeEffect
-                                        (Type
-                                          (Z/3),
-                                          OCaml.Effect.State.state/3);
-                                        TypeEffect
-                                        (Type
+                                        (OCaml.Effect.State.state/3,
+                                          Z/3);
+                                        (OCaml.Effect.State.state/3,
                                           (list/3,
-                                            Type
-                                              (Z/3)),
-                                          OCaml.Effect.State.state/3)
+                                            Z/3))
                                       ],
                                         Type
                                           (OCaml.Effect.State.t/3,
@@ -1442,24 +1198,16 @@ Value
                                         Lift
                                           (?,
                                             [
-                                              TypeEffect
-                                              (Type
+                                              (OCaml.Effect.State.state/3,
                                                 (list/3,
-                                                  Type
-                                                    (Z/3)),
-                                                OCaml.Effect.State.state/3)
+                                                  Z/3))
                                             ],
                                             [
-                                              TypeEffect
-                                              (Type
-                                                (Z/3),
-                                                OCaml.Effect.State.state/3);
-                                              TypeEffect
-                                              (Type
+                                              (OCaml.Effect.State.state/3,
+                                                Z/3);
+                                              (OCaml.Effect.State.state/3,
                                                 (list/3,
-                                                  Type
-                                                    (Z/3)),
-                                                OCaml.Effect.State.state/3)
+                                                  Z/3))
                                             ],
                                             Bind
                                               (?,
@@ -1518,22 +1266,15 @@ Value
                                         Lift
                                           (?,
                                             [
-                                              TypeEffect
-                                              (Type
-                                                (Z/3),
-                                                OCaml.Effect.State.state/3)
+                                              (OCaml.Effect.State.state/3,
+                                                Z/3)
                                             ],
                                             [
-                                              TypeEffect
-                                              (Type
-                                                (Z/3),
-                                                OCaml.Effect.State.state/3);
-                                              TypeEffect
-                                              (Type
+                                              (OCaml.Effect.State.state/3,
+                                                Z/3);
+                                              (OCaml.Effect.State.state/3,
                                                 (list/3,
-                                                  Type
-                                                    (Z/3)),
-                                                OCaml.Effect.State.state/3)
+                                                  Z/3))
                                             ],
                                             Apply
                                               (63,
@@ -1552,24 +1293,16 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      TypeEffect
-                                      (Type
+                                      (OCaml.Effect.State.state/3,
                                         (list/3,
-                                          Type
-                                            (Z/3)),
-                                        OCaml.Effect.State.state/3)
+                                          Z/3))
                                     ],
                                     [
-                                      TypeEffect
-                                      (Type
-                                        (Z/3),
-                                        OCaml.Effect.State.state/3);
-                                      TypeEffect
-                                      (Type
+                                      (OCaml.Effect.State.state/3,
+                                        Z/3);
+                                      (OCaml.Effect.State.state/3,
                                         (list/3,
-                                          Type
-                                            (Z/3)),
-                                        OCaml.Effect.State.state/3)
+                                          Z/3))
                                     ],
                                     Bind
                                       (?,
@@ -1646,22 +1379,15 @@ Value
                                     Lift
                                       (?,
                                         [
-                                          TypeEffect
-                                          (Type
-                                            (Z/3),
-                                            OCaml.Effect.State.state/3)
+                                          (OCaml.Effect.State.state/3,
+                                            Z/3)
                                         ],
                                         [
-                                          TypeEffect
-                                          (Type
-                                            (Z/3),
-                                            OCaml.Effect.State.state/3);
-                                          TypeEffect
-                                          (Type
+                                          (OCaml.Effect.State.state/3,
+                                            Z/3);
+                                          (OCaml.Effect.State.state/3,
                                             (list/3,
-                                              Type
-                                                (Z/3)),
-                                            OCaml.Effect.State.state/3)
+                                              Z/3))
                                         ],
                                         Bind
                                           (?,
@@ -1699,7 +1425,7 @@ Value
     [
       ((multiple_returns_test, [ ], [ (x, Type (unit/3)) ],
         Monad
-          ([ TypeEffect (Type (Z/3), OCaml.Effect.State.state/3) ],
+          ([ (OCaml.Effect.State.state/3, Z/3) ],
             (Type (Z/3) * Type (OCaml.Effect.State.t/3, Type (Z/3))))),
         Match
           (?, Variable (?, x/0),
@@ -1723,20 +1449,16 @@ Value
                         ],
                         Monad
                           ([
-                            TypeEffect
-                            (Type
-                              (Z/3),
-                              OCaml.Effect.State.state/3)
+                            (OCaml.Effect.State.state/3,
+                              Z/3)
                           ],
                             (Type
                               (Z/3)
                               ->
                               Monad
                                 ([
-                                  TypeEffect
-                                  (Type
-                                    (Z/3),
-                                    OCaml.Effect.State.state/3)
+                                  (OCaml.Effect.State.state/3,
+                                    Z/3)
                                 ],
                                   (Type
                                     (OCaml.Effect.State.t/3,
@@ -1745,10 +1467,8 @@ Value
                                     ->
                                     Monad
                                       ([
-                                        TypeEffect
-                                        (Type
-                                          (Z/3),
-                                          OCaml.Effect.State.state/3)
+                                        (OCaml.Effect.State.state/3,
+                                          Z/3)
                                       ],
                                         Type
                                           (OCaml.Effect.State.t/3,

--- a/tests/ex39.v
+++ b/tests/ex39.v
@@ -55,24 +55,21 @@ Definition new_ref (x : unit)
   OCaml.Pervasives.ref 15.
 
 Definition r : OCaml.Effect.State.t Z := OCaml.Effect.State.init 18.
-Definition r_state := nat.
+Definition r_state := OCaml.Effect.State.state nat.
 
-Definition set_r (x : unit)
-  : M [ OCaml.Effect.State.state Z; OCaml.Effect.State.state r_state ] unit :=
+Definition set_r (x : unit) : M [ OCaml.Effect.State.state Z; r_state ] unit :=
   let! x_1 :=
     let! x_1 := lift [_;_] "10" (OCaml.Effect.State.peekstate tt) in
     lift [_;_] "01" (OCaml.Effect.State.global r x_1) in
   lift [_;_] "10" (set_ref x_1).
 
-Definition get_r (x : unit)
-  : M [ OCaml.Effect.State.state Z; OCaml.Effect.State.state r_state ] Z :=
+Definition get_r (x : unit) : M [ OCaml.Effect.State.state Z; r_state ] Z :=
   let! x_1 :=
     let! x_1 := lift [_;_] "10" (OCaml.Effect.State.peekstate tt) in
     lift [_;_] "01" (OCaml.Effect.State.global r x_1) in
   lift [_;_] "10" (get_ref x_1).
 
-Definition r_add_15 (x : unit)
-  : M [ OCaml.Effect.State.state Z; OCaml.Effect.State.state r_state ] Z :=
+Definition r_add_15 (x : unit) : M [ OCaml.Effect.State.state Z; r_state ] Z :=
   let! i := get_r tt in
   let! _ := set_r tt in
   let! j := get_r tt in
@@ -86,49 +83,71 @@ Definition r_add_15 (x : unit)
     lift [_;_] "01" (OCaml.Effect.State.global r x_1) in
   lift [_;_] "10" (OCaml.Effect.State.read x_1).
 
-Definition mixed_type (x : unit)
+Definition mixed_type {es_in : list Effect.t} (x : unit)
   : M
     [
-      OCaml.Effect.State.state Z;
-      OCaml.Effect.State.state bool;
-      OCaml.Effect.State.state r_state;
-      OCaml.Effect.State.state string
+      OCaml.Effect.Union.union es_in
+        [
+          (OCaml.Effect.State.state Z);
+          (OCaml.Effect.State.state bool);
+          (OCaml.Effect.State.state string)
+        ];
+      r_state
     ] (bool * string * Z) :=
-  let! b := lift [_;_;_;_] "0100" (OCaml.Pervasives.ref true) in
-  let! str := lift [_;_;_;_] "0001" (OCaml.Pervasives.ref "" % string) in
+  let! b :=
+    lift [_;_] "10" (@Union.lift _ _ _ [_;_;_] 1 (OCaml.Pervasives.ref true)) in
+  let! str :=
+    lift [_;_] "10"
+      (@Union.lift _ _ _ [_;_;_] 2 (OCaml.Pervasives.ref "" % string)) in
   let update (x_1 : unit)
-    : M [ OCaml.Effect.State.state bool; OCaml.Effect.State.state string ] unit :=
+    : M
+      [
+        OCaml.Effect.Union.union _
+          [
+            (OCaml.Effect.State.state bool);
+            (OCaml.Effect.State.state string)
+          ]
+      ] unit :=
     match x_1 with
     | tt =>
       let! _ :=
-        lift [_;_] "10"
+        @Union.lift _ _ _ [_;_] 0
           (let! x_2 := OCaml.Effect.State.read b in
           OCaml.Effect.State.write b x_2) in
-      lift [_;_] "01"
+      @Union.lift _ _ _ [_;_] 1
         (let! x_2 :=
           let! x_2 := OCaml.Effect.State.read str in
           ret (String.append "toggle " % string x_2) in
         OCaml.Effect.State.write str x_2)
     end in
-  let! _ := lift [_;_;_;_] "0101" (update tt) in
-  let! _ := lift [_;_;_;_] "0101" (update tt) in
-  let! _ := lift [_;_;_;_] "0101" (update tt) in
-  let! x_1 := lift [_;_;_;_] "0100" (OCaml.Effect.State.read b) in
-  let! x_2 := lift [_;_;_;_] "0001" (OCaml.Effect.State.read str) in
+  let! _ :=
+    lift [_;_] "10"
+      (@Union.mix _ _ _ _ [_;_;_] [1;2]%nat eq_refl eq_refl (update tt)) in
+  let! _ :=
+    lift [_;_] "10"
+      (@Union.mix _ _ _ _ [_;_;_] [1;2]%nat eq_refl eq_refl (update tt)) in
+  let! _ :=
+    lift [_;_] "10"
+      (@Union.mix _ _ _ _ [_;_;_] [1;2]%nat eq_refl eq_refl (update tt)) in
+  let! x_1 :=
+    lift [_;_] "10" (@Union.lift _ _ _ [_;_;_] 1 (OCaml.Effect.State.read b)) in
+  let! x_2 :=
+    lift [_;_] "10" (@Union.lift _ _ _ [_;_;_] 2 (OCaml.Effect.State.read str))
+    in
   let! x_3 :=
-    lift [_;_;_;_] "1010"
+    @Union.lift _ _ _ [_;_;_] 0
       (let! x_3 :=
         let! x_3 := lift [_;_] "10" (OCaml.Effect.State.peekstate tt) in
         lift [_;_] "01" (OCaml.Effect.State.global r x_3) in
       lift [_;_] "10" (OCaml.Effect.State.read x_3)) in
   ret (x_1, x_2, x_3).
 
-Definition partials_test (x : unit)
+Definition partials_test {es_in : list Effect.t} (x : unit)
   : M
     [
-      OCaml.Effect.State.state Z;
-      OCaml.Effect.State.state (list Z);
-      OCaml.Effect.State.state r_state
+      OCaml.Effect.Union.union es_in
+        [ (OCaml.Effect.State.state Z); (OCaml.Effect.State.state (list Z)) ];
+      r_state
     ] (OCaml.Effect.State.t Z) :=
   match x with
   | tt =>
@@ -137,29 +156,35 @@ Definition partials_test (x : unit)
       let! _ := OCaml.Effect.State.write x y in
       ret x in
     let! f1_test :=
-      lift [_;_;_] "101"
+      @Union.lift _ _ _ [_;_] 0
         (let! x_1 :=
           let! x_1 := lift [_;_] "10" (OCaml.Effect.State.peekstate tt) in
           lift [_;_] "01" (OCaml.Effect.State.global r x_1) in
         ret (f1 x_1)) in
-    lift [_;_;_] "110"
-      (let! f1_test := lift [_;_] "10" (f1_test 15) in
+    lift [_;_] "10"
+      (let! f1_test := @Union.lift _ _ _ [_;_] 0 (f1_test 15) in
       let f2 (l1 : OCaml.Effect.State.t (list Z)) (l2 : list string)
-        : M [ OCaml.Effect.State.state Z; OCaml.Effect.State.state (list Z) ]
-          (OCaml.Effect.State.t Z) :=
+        : M
+          [
+            OCaml.Effect.Union.union _
+              [
+                (OCaml.Effect.State.state Z);
+                (OCaml.Effect.State.state (list Z))
+              ]
+          ] (OCaml.Effect.State.t Z) :=
         let! x_1 :=
-          lift [_;_] "01"
+          @Union.lift _ _ _ [_;_] 1
             (let! x_1 :=
               let! x_1 := OCaml.Effect.State.read l1 in
               ret (OCaml.List.length x_1) in
             ret (Z.add x_1 (OCaml.List.length l2))) in
-        lift [_;_] "10" (OCaml.Pervasives.ref x_1) in
+        @Union.lift _ _ _ [_;_] 0 (OCaml.Pervasives.ref x_1) in
       let! f2_test :=
-        lift [_;_] "01"
+        @Union.lift _ _ _ [_;_] 1
           (let! x_1 := OCaml.Pervasives.ref (cons 1 (cons 2 (cons 3 []))) in
           ret (f2 x_1)) in
       let! f2_test := f2_test (cons "hi" % string (cons "hey" % string [])) in
-      lift [_;_] "10"
+      @Union.lift _ _ _ [_;_] 0
         (let! x_1 := OCaml.Effect.State.read f1_test in
         f1 f2_test x_1))
   end.
@@ -202,3 +227,32 @@ Definition multiple_returns_test (x : unit)
     let! x_1 := OCaml.Effect.State.read f4 in
     ret (x_1, s)
   end.
+
+Definition type_vars_test {A B : Type} {es_in : list Effect.t}
+  (x : OCaml.Effect.State.t A) (y : OCaml.Effect.State.t B) (a : A) (b : B)
+  : M
+    [
+      OCaml.Effect.Union.union es_in
+        [ (OCaml.Effect.State.state A); (OCaml.Effect.State.state B) ]
+    ] unit :=
+  let! _ := @Union.lift _ _ _ [_;_] 0 (OCaml.Effect.State.write x a) in
+  @Union.lift _ _ _ [_;_] 1 (OCaml.Effect.State.write y b).
+
+Definition resolves_test1 {A : Type}
+  (x : OCaml.Effect.State.t A) (a : A) (b : A)
+  : M [ OCaml.Effect.State.state A ] unit :=
+  Union.inject 2 (type_vars_test x x a b).
+
+Definition resolves_test2 {A : Type} {es_in : list Effect.t}
+  (x : OCaml.Effect.State.t Z) (y : OCaml.Effect.State.t A) (a : Z) (b : A)
+  : M
+    [
+      OCaml.Effect.Union.union es_in
+        [ (OCaml.Effect.State.state A); (OCaml.Effect.State.state Z) ]
+    ] unit :=
+  @Union.mix _ _ _ _ [_;_] [1;0]%nat eq_refl eq_refl (type_vars_test x y a b).
+
+Definition resolves_test3
+  (x : OCaml.Effect.State.t Z) (y : OCaml.Effect.State.t Z) (a : Z) (b : Z)
+  : M [ OCaml.Effect.State.state Z ] unit :=
+  Union.inject 2 (type_vars_test x y a b).


### PR DESCRIPTION
This PR
* changes the structure of `Effect.Descriptor` to use `Set`s instead of a `Map`
* adds `Function` to `Mod`, to allow storing type data in the environment
* implements type unification, using it to resolve effects as types resolve (e.g. `A -> M [state A] A` becomes `int -> M [state int] int`)
* adds an initial version of a `union` effect, which carries multiple other effects, and use it to unify types (e.g. `A -> B -> M [union _ [state A; state B]]` becomes `A -> A -> M [union _ [state A; state A]]`)
* implements implicit arguments for `Exp.Definition`, using them for an implicit variable in `union` effects
* adds tests for the new type unifications, and updates test output
* tweaks the implementation of global references to create more concise effect names.