### PR TITLE
Update interface format

### DIFF
--- a/src/boundName.ml
+++ b/src/boundName.ml
@@ -1,4 +1,5 @@
 open SmartPrint
+open Yojson.Basic
 open Utils
 
 type t = {
@@ -22,3 +23,10 @@ let stable_compare (x : t) (y : t) : int =
 
 let to_coq (x : t) : SmartPrint.t =
   PathName.to_coq x.local_path
+
+let to_json (x : t) : json =
+  PathName.to_json x.full_path
+
+let of_json (json : json) : t =
+  let x = PathName.of_json json in
+  { full_path = x; local_path = x }

--- a/src/coqOfOCaml.ml
+++ b/src/coqOfOCaml.ml
@@ -16,7 +16,7 @@ let monadise (env : unit FullEnvi.t)
 
 let interface (module_name : string)
   (effects : (Loc.t * Effect.t) Structure.t list) : Interface.t =
-  Interface.Interface (module_name, Interface.of_structures effects)
+  Interface.Interface (CoqName.Name module_name, Interface.of_structures effects)
 
 let coq (monadise : Loc.t Structure.t list) : SmartPrint.t =
   concat (List.map (fun d -> d ^^ newline) [

--- a/src/exception.ml
+++ b/src/exception.ml
@@ -4,6 +4,7 @@ open SmartPrint
 type t = {
   name : CoqName.t;
   raise_name : CoqName.t;
+  effect_path : PathName.t;
   typ : Type.t }
 
 let pp (exn : t) : SmartPrint.t =
@@ -18,9 +19,9 @@ let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t)
     | Types.Cstr_tuple typs -> typs
     | Types.Cstr_record _ -> Error.raise loc "Unhandled named constructor parameters." in
   let typ = Type.Tuple (typs |> List.map (fun typ -> Type.of_type_expr env loc typ)) in
-  { name = FullEnvi.Descriptor.coq_name name env;
-    raise_name = FullEnvi.Descriptor.coq_name ("raise_" ^ name) env;
-    typ = typ}
+  let (raise_name, _, _) = FullEnvi.Descriptor.fresh ("raise_" ^ name) env in
+  let (name, bound_name, _) = FullEnvi.Descriptor.fresh name env in
+  { name; effect_path = bound_name.full_path; raise_name; typ }
 
 let update_env (exn : t) (env : unit FullEnvi.t) : unit FullEnvi.t =
   env

--- a/src/exception.ml
+++ b/src/exception.ml
@@ -13,37 +13,30 @@ let pp (exn : t) : SmartPrint.t =
 let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t)
   (exn : extension_constructor) : t =
   let name = Name.of_ident exn.ext_id in
-  let coq_name = (FullEnvi.Descriptor.resolve [] name env).base in
-  let raise_name = "raise_" ^ name in
-  let coq_raise_name = (FullEnvi.Var.resolve [] raise_name env).base in
   let typs =
     match exn.ext_type.Types.ext_args with
     | Types.Cstr_tuple typs -> typs
     | Types.Cstr_record _ -> Error.raise loc "Unhandled named constructor parameters." in
   let typ = Type.Tuple (typs |> List.map (fun typ -> Type.of_type_expr env loc typ)) in
-  { name = CoqName.of_names name coq_name;
-    raise_name = CoqName.of_names raise_name coq_raise_name;
+  { name = FullEnvi.Descriptor.coq_name name env;
+    raise_name = FullEnvi.Descriptor.coq_name ("raise_" ^ name) env;
     typ = typ}
 
 let update_env (exn : t) (env : unit FullEnvi.t) : unit FullEnvi.t =
-  let (name, coq_name) = CoqName.assoc_names exn.name in
-  let (raise_name, coq_raise_name) = CoqName.assoc_names exn.raise_name in
   env
-  |> FullEnvi.Descriptor.assoc [] name coq_name
-  |> FullEnvi.Var.assoc [] raise_name coq_raise_name ()
+  |> FullEnvi.Descriptor.assoc exn.name
+  |> FullEnvi.Var.assoc exn.raise_name ()
 
 let update_env_with_effects (exn : t) (env : Effect.Type.t FullEnvi.t)
   : Effect.Type.t FullEnvi.t =
-  let (name, coq_name) = CoqName.assoc_names exn.name in
-  let (raise_name, coq_raise_name) = CoqName.assoc_names exn.raise_name in
-  let env = FullEnvi.Descriptor.assoc [] name coq_name env in
+  let env = FullEnvi.Descriptor.assoc exn.name env in
   let bound_effect = FullEnvi.Descriptor.bound Loc.Unknown
-    (PathName.of_name [] name) env in
+    (PathName.of_name [] (CoqName.ocaml_name exn.name)) env in
   let effect_typ =
     Effect.Type.Arrow (
       Effect.Descriptor.singleton bound_effect [],
       Effect.Type.Pure) in
-  FullEnvi.Var.assoc [] raise_name coq_raise_name effect_typ env
+  FullEnvi.Var.assoc exn.raise_name effect_typ env
 
 let to_coq (exn : t) : SmartPrint.t =
   !^ "Definition" ^^ CoqName.to_coq exn.name ^^ !^ ":=" ^^

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -309,10 +309,9 @@ let rec of_expression (env : unit FullEnvi.t) (typ_vars : Name.t Name.Map.t)
               :: index_pattern in
             let pattern = (Pattern.Tuple [p; Pattern.Any], e) :: pattern in
             (index_pattern, pattern)) ([], [no_match]) in
-      let (i, env) = FullEnvi.Var.fresh "i" () env in
-      let x = FullEnvi.Var.bound Loc.Unknown (PathName.of_name [] i) env in
+      let (i, x, env) = FullEnvi.Var.fresh "i" () env in
       let tup_t = Type.Tuple [snd (annotation e); int_t] in
-      LetVar ((Loc.Unknown, typ), CoqName.Name i,
+      LetVar ((Loc.Unknown, typ), i,
         Match ((Loc.Unknown, int_t), e, index_pattern),
         Match (a,
           Tuple ((Loc.Unknown, tup_t), [e; Variable ((Loc.Unknown, int_t), x)]),
@@ -385,17 +384,16 @@ let rec of_expression (env : unit FullEnvi.t) (typ_vars : Name.t Name.Map.t)
     patterns. *)
 and open_cases (env : unit FullEnvi.t) (typ_vars : Name.t Name.Map.t)
   (typ : Type.t) (cases : case list) : Name.t * (Loc.t * Type.t) t =
-  let (x, env) = FullEnvi.Var.fresh "x" () env in
+  let (x, bound_x, env) = FullEnvi.Var.fresh "x" () env in
   let p1 = (List.hd cases).c_lhs in
   let cases = cases |> List.map (fun {c_lhs = p; c_rhs = e} ->
     let p = Pattern.of_pattern env p in
     let env = Pattern.add_to_env p env in
     (p, of_expression env typ_vars e)) in
-  let bound_x = FullEnvi.Var.bound Loc.Unknown (PathName.of_name [] x) env in
   let l = Loc.of_location p1.pat_loc in
   let (typ_x, _, _) =
     Type.of_type_expr_new_typ_vars env l typ_vars p1.pat_type in
-  (x, Match ((Loc.Unknown, typ),
+  (CoqName.ocaml_name x, Match ((Loc.Unknown, typ),
     Variable ((Loc.Unknown, typ_x), bound_x), cases))
 
 and import_let_fun (env : unit FullEnvi.t) (loc : Loc.t)
@@ -581,10 +579,8 @@ and monadise_let_rec_definition (env : unit FullEnvi.t)
     (* Add the suffix "_rec" to the names. *)
     let def' = { def with Definition.cases =
       def.Definition.cases |> List.map (fun (header, e) ->
-        let (name_rec, _) = FullEnvi.Var.fresh
+        let (name_rec, _, _) = FullEnvi.Var.fresh
           (CoqName.ocaml_name header.Header.name ^ "_rec") () env_in_def in
-        let name_rec = (CoqName.of_names name_rec
-          (FullEnvi.Var.resolve [] name_rec env).base) in
         ({ header with Header.name = name_rec }, e)) } in
     let env_after_def' = Definition.env_in_def def' env in
     let nat_type = Type.Apply (FullEnvi.Typ.localize env_after_def' [] "nat",
@@ -593,9 +589,9 @@ and monadise_let_rec_definition (env : unit FullEnvi.t)
     let def' = { def' with Definition.cases =
       def'.Definition.cases |> List.map (fun (header, e) ->
         let name_rec = header.Header.name in
-        let (counter, _) =
+        let (counter, _, _) =
           FullEnvi.Var.fresh "counter" () env_after_def' in
-        let args_rec = (CoqName.of_names counter counter, nat_type)
+        let args_rec = (counter, nat_type)
           :: header.Header.args in
         let header_rec =
           { header with Header.name = name_rec; args = args_rec } in
@@ -942,10 +938,9 @@ let rec monadise (env : unit FullEnvi.t) (e : (Loc.t * Effect.t) t) : Loc.t t =
         monadise_list env es d (map fst e :: es') k
       else
         let e' = monadise env e in
-        let (x, env) = FullEnvi.Var.fresh "x" () env in
-        bind d_e d d e' (Some (CoqName.of_names x x)) (monadise_list env es d
-          (Variable (Loc.Unknown,
-            FullEnvi.Var.bound Loc.Unknown (PathName.of_name [] x) env) :: es') k) in
+        let (x, bound_x, env) = FullEnvi.Var.fresh "x" () env in
+        bind d_e d d e' (Some x) (monadise_list env es d
+          (Variable (Loc.Unknown, bound_x) :: es') k) in
   let d = descriptor e in
   match e with
   | Constant ((l, _), c) -> Constant (l, c)

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -72,6 +72,9 @@ let has_value (env : 'a t) (x : PathName.t) (m : Mod.t) =
   let x = { x with PathName.path = m.Mod.coq_path @ x.PathName.path } in
   PathName.Map.mem x env.values
 
+let has_global_value (env : 'a t) (x : PathName.t) =
+  PathName.Map.mem x env.values
+
 let localize_type (env : 'a t) (typ : Effect.Type.t) : Effect.Type.t =
   Effect.Type.map (localize (has_value env) env) typ
 

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -226,9 +226,14 @@ module ValueCarrier (M : Mod.ValueCarrier) = struct
     M.unpack @@ find loc x env
 
   (** Add a fresh local name beginning with [prefix] in [env]. *)
-  let fresh (prefix : string) (v : 'a) (env : 'a t) : Name.t * 'a t =
+  let fresh (prefix : string) (v : 'a) (env : 'a t)
+    : CoqName.t * BoundName.t * 'a t =
     let name = find_free_name [] prefix env in
-    (name, add [] name v env)
+    let bound_name = {
+      BoundName.full_path = { PathName.path = coq_path env; base = name };
+      local_path = { PathName.path = []; base = name };
+    } in
+    (CoqName.Name name, bound_name, add [] name v env)
 end
 
 module Var = ValueCarrier(Mod.Vars)
@@ -260,9 +265,13 @@ module Function = struct
 
   (** Add a fresh local name beginning with [prefix] in [env]. *)
   let fresh (prefix : string) (v : 'a) (typ : Effect.PureType.t) (env : 'a t)
-    : Name.t * 'a t =
+    : CoqName.t * BoundName.t * 'a t =
     let name = find_free_name [] prefix env in
-    (name, add [] name v typ env)
+    let bound_name = {
+      BoundName.full_path = { PathName.path = coq_path env; base = name };
+      local_path = { PathName.path = []; base = name };
+    } in
+    (CoqName.Name name, bound_name, add [] name v typ env)
 end
 
 module EmptyCarrier (M : Mod.EmptyCarrier) = struct
@@ -281,9 +290,13 @@ module EmptyCarrier (M : Mod.EmptyCarrier) = struct
       (PathName.of_name (coq_path env) coq_name) env
 
   (** Add a fresh local name beginning with [prefix] in [env]. *)
-  let fresh (prefix : string) (env : 'a t) : Name.t * 'a t =
+  let fresh (prefix : string) (env : 'a t) : CoqName.t * BoundName.t * 'a t =
     let name = find_free_name [] prefix env in
-    (name, add [] name env)
+    let bound_name = {
+      BoundName.full_path = { PathName.path = coq_path env; base = name };
+      local_path = { PathName.path = []; base = name };
+    } in
+    (CoqName.Name name, bound_name, add [] name env)
 end
 
 module Descriptor = EmptyCarrier(Mod.Descriptors)
@@ -336,7 +349,8 @@ module Module = struct
     f env
 
   (** Add a fresh local name beginning with [prefix] in [env]. *)
-  let fresh (prefix : string) (v : Mod.t) (env : 'a t) : Name.t * 'a t =
+  let fresh (prefix : string) (v : Mod.t) (env : 'a t)
+    : CoqName.t * BoundName.t * 'a t =
     let path = coq_path env in
     let rec first_n (n : int) : Name.t =
       let name = if n = 0 then
@@ -347,7 +361,11 @@ module Module = struct
         first_n (n + 1)
       else name in
     let name = first_n 0 in
-    (name, add [] name v env)
+    let bound_name = {
+      BoundName.full_path = { PathName.path = coq_path env; base = name };
+      local_path = { PathName.path = []; base = name };
+    } in
+    (CoqName.Name name, bound_name, add [] name v env)
 end
 
 let open_module (loc : Loc.t) (module_name : BoundName.t) (env : 'a t) : 'a t =

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -192,6 +192,11 @@ module Carrier (M : Mod.Carrier) = struct
     | Some path -> path
     | None -> find_free_path x env
 
+  let localize (env : 'a t) (path : Name.t list) (base : Name.t) : BoundName.t =
+    let x = PathName.of_name path base in
+    let x = { BoundName.full_path = x; local_path = x } in
+    FullMod.localize (has_value env) env.active_module x
+
   let coq_name (base : Name.t) (env : 'a t) : CoqName.t =
     CoqName.of_names base (resolve [] base env).PathName.base
 
@@ -295,6 +300,11 @@ module Module = struct
   let has_name (env : 'a t) (x : PathName.t) (m : Mod.t) =
     let x = { x with PathName.path = m.Mod.coq_path @ x.PathName.path } in
     PathName.Map.mem x env.modules
+
+  let localize (env : 'a t) (path : Name.t list) (base : Name.t) : BoundName.t =
+    let x = PathName.of_name path base in
+    let x = { BoundName.full_path = x; local_path = x } in
+    FullMod.localize (has_name env) env.active_module x
 
   let bound_opt (x : PathName.t) (env : 'a t) : BoundName.t option =
     bound_name_opt Mod.Modules.resolve_opt (has_name env) x env

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -212,7 +212,7 @@ let rec of_json (json : json) : t =
 
 let to_json_string (interface : t) : string =
   let pretty = pretty_format ~std:true (`Assoc [
-    "version", `String "1";
+    "version", `String "2";
     "content", to_json interface]) in
   let buffer = Buffer.create 0 in
   let formatter = Format.formatter_of_buffer buffer in

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -186,9 +186,8 @@ end
 
 let rec to_json (interface : t) : json =
   match interface with
-  | Var (x, shape) ->
-    let shape = Shape.of_effect_typ shape in
-    `List [`String "Var"; CoqName.to_json x; Shape.to_json shape]
+  | Var (x, eff) ->
+    `List [`String "Var"; CoqName.to_json x; Effect.Type.to_json eff]
   | Typ x -> `List [`String "Typ"; CoqName.to_json x]
   | Descriptor x -> `List [`String "Descriptor"; CoqName.to_json x]
   | Constructor x -> `List [`String "Constructor"; CoqName.to_json x]
@@ -199,8 +198,8 @@ let rec to_json (interface : t) : json =
 
 let rec of_json (json : json) : t =
   match json with
-  | `List [`String "Var"; x; shape] ->
-    Var (CoqName.of_json x, Shape.to_effect_typ (Shape.of_json shape))
+  | `List [`String "Var"; x; eff] ->
+    Var (CoqName.of_json x, Effect.Type.of_json eff)
   | `List [`String "Typ"; x] -> Typ (CoqName.of_json x)
   | `List [`String "Descriptor"; x] -> Descriptor (CoqName.of_json x)
   | `List [`String "Constructor"; x] -> Constructor (CoqName.of_json x)

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -86,7 +86,7 @@ and of_structure (def : ('a * Effect.t) Structure.t) : t list =
     let name = exn.Exception.name in
     let coq_name = snd @@ CoqName.assoc_names name in
     let raise_name = exn.Exception.raise_name in
-    [ Descriptor name; Var (raise_name, [[PathName.of_name [] coq_name]]) ]
+    [ Descriptor name; Var (raise_name, [[exn.Exception.effect_path]]) ]
   | Structure.Reference (_, r) ->
     let name = r.Reference.name in
     let state_name = r.Reference.state_name in

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -37,36 +37,34 @@ module Shape = struct
 end
 
 type t =
-  | Var of Name.t * Shape.t
-  | Typ of Name.t
-  | Descriptor of Name.t
-  | Constructor of Name.t
-  | Field of Name.t
+  | Var of CoqName.t * Shape.t
+  | Typ of CoqName.t
+  | Descriptor of CoqName.t
+  | Constructor of CoqName.t
+  | Field of CoqName.t
   | Include of PathName.t
-  | Interface of Name.t * t list
+  | Interface of CoqName.t * t list
 
 let rec pp (interface : t) : SmartPrint.t =
   match interface with
-  | Var (x, shape) -> !^ "Var" ^^ OCaml.tuple [Name.pp x; Shape.pp shape]
-  | Typ x -> !^ "Typ" ^^ Name.pp x
-  | Descriptor x -> !^ "Descriptor" ^^ Name.pp x
-  | Constructor x -> !^ "Constructor" ^^ Name.pp x
-  | Field x -> !^ "Field" ^^ Name.pp x
+  | Var (x, shape) -> !^ "Var" ^^ OCaml.tuple [CoqName.pp x; Shape.pp shape]
+  | Typ x -> !^ "Typ" ^^ CoqName.pp x
+  | Descriptor x -> !^ "Descriptor" ^^ CoqName.pp x
+  | Constructor x -> !^ "Constructor" ^^ CoqName.pp x
+  | Field x -> !^ "Field" ^^ CoqName.pp x
   | Include x -> !^ "Include" ^^ PathName.pp x
   | Interface (x, defs) ->
-    !^ "Interface" ^^ Name.pp x ^^ !^ "=" ^^ newline ^^ indent
+    !^ "Interface" ^^ CoqName.pp x ^^ !^ "=" ^^ newline ^^ indent
       (separate newline (List.map pp defs))
 
 let of_typ_definition (typ_def : TypeDefinition.t) : t list =
   match typ_def with
   | TypeDefinition.Inductive (name, _, constructors) ->
-    Typ (CoqName.ocaml_name name) ::
-      List.map (fun (x, _) -> Constructor (CoqName.ocaml_name x)) constructors
+    Typ name :: List.map (fun (x, _) -> Constructor x) constructors
   | TypeDefinition.Record (name, fields) ->
-    Typ (CoqName.ocaml_name name) ::
-      List.map (fun (x, _) -> Field (CoqName.ocaml_name x)) fields
+    Typ name :: List.map (fun (x, _) -> Field x) fields
   | TypeDefinition.Synonym (name, _, _) | TypeDefinition.Abstract (name, _) ->
-    [Typ (CoqName.ocaml_name name)]
+    [Typ name]
 
 let rec of_structures (defs : ('a * Effect.t) Structure.t list) : t list =
   List.flatten (List.map of_structure defs)
@@ -75,45 +73,48 @@ and of_structure (def : ('a * Effect.t) Structure.t) : t list =
   match def with
   | Structure.Require names -> []
   | Structure.Value (_, value) ->
-    let values = value.Exp.Definition.cases |> List.map (fun (header, e) ->
-      let name = CoqName.ocaml_name header.Exp.Header.name in
+    value.Exp.Definition.cases |> List.map (fun (header, e) ->
+      let name = header.Exp.Header.name in
       let typ =
         Effect.function_typ header.Exp.Header.args (snd (Exp.annotation e)) in
-      (name, Shape.of_effect_typ @@ Effect.Type.compress typ)) in
-    values |> List.map (fun (name, typ) -> Var (name, typ))
+      Var (name, Shape.of_effect_typ @@ Effect.Type.compress typ))
   | Structure.Primitive (_, prim) ->
     (* TODO: Update to reflect that primitives are not usually pure. *)
-    [Var (CoqName.ocaml_name prim.PrimitiveDeclaration.name, [])]
+    [Var (prim.PrimitiveDeclaration.name, [])]
   | Structure.TypeDefinition (_, typ_def) -> of_typ_definition typ_def
   | Structure.Exception (_, exn) ->
-    let name = CoqName.ocaml_name exn.Exception.name in
-    let raise_name = CoqName.ocaml_name exn.Exception.raise_name in
-    [ Descriptor name; Var (raise_name, [[PathName.of_name [] name]]) ]
+    let name = exn.Exception.name in
+    let coq_name = snd @@ CoqName.assoc_names name in
+    let raise_name = exn.Exception.raise_name in
+    [ Descriptor name; Var (raise_name, [[PathName.of_name [] coq_name]]) ]
   | Structure.Reference (_, r) ->
-    let name = CoqName.ocaml_name r.Reference.name in
-    let state_name = CoqName.ocaml_name r.Reference.state_name in
+    let name = r.Reference.name in
+    let state_name = r.Reference.state_name in
     [ Var (name, []); Descriptor state_name ]
   | Structure.Open _ -> []
   | Structure.Include (_, name) -> [Include name.local_path]
-  | Structure.Module (_, name, defs) -> [Interface (name, of_structures defs)]
+  | Structure.Module (_, name, defs) ->
+    [Interface (CoqName.of_names name name, of_structures defs)]
 
 let rec to_full_envi (interface : t) (env : Effect.Type.t FullEnvi.t)
   : Effect.Type.t FullEnvi.t =
   match interface with
-  | Var (x, shape) -> FullEnvi.Var.add [] x (Shape.to_effect_typ shape env) env
-  | Typ x -> FullEnvi.Typ.add [] x Effect.Type.Pure env
-  | Descriptor x -> FullEnvi.Descriptor.add [] x env
-  | Constructor x -> FullEnvi.Constructor.add [] x env
-  | Field x -> FullEnvi.Field.add [] x env
+  | Var (x, shape) -> FullEnvi.Var.assoc x (Shape.to_effect_typ shape env) env
+  | Typ x -> FullEnvi.Typ.assoc x Effect.Type.Pure env
+  | Descriptor x -> FullEnvi.Descriptor.assoc x env
+  | Constructor x -> FullEnvi.Constructor.assoc x env
+  | Field x -> FullEnvi.Field.assoc x env
   | Include x -> Include.of_interface x env
   | Interface (x, defs) ->
-    let env = FullEnvi.enter_module (CoqName.Name x) env in
+    let env = FullEnvi.enter_module x env in
     let env = List.fold_left (fun env def -> to_full_envi def env) env defs in
     FullEnvi.leave_module FullEnvi.localize_type env
 
 let load_interface (coq_prefix : Name.t) (interface : t)
   (env : Effect.Type.t FullEnvi.t) : Name.t * Effect.Type.t FullEnvi.t =
-  let name = match interface with | Interface (name, _) -> name | _ -> "" in
+  let name = match interface with
+    | Interface (name, _) -> CoqName.ocaml_name name
+    | _ -> "" in
   let coq_name = if coq_prefix == "" || name == "" then coq_prefix ^ name
     else coq_prefix ^ "." ^ name in
   let env = FullEnvi.enter_module (CoqName.of_names name coq_name) env in
@@ -127,26 +128,38 @@ module Version1 = struct
   let rec to_json (interface : t) : json =
     match interface with
     | Var (x, shape) ->
+      let x = CoqName.ocaml_name x in
       `List [`String "Var"; Name.to_json x; Shape.to_json shape]
-    | Typ x -> `List [`String "Typ"; Name.to_json x]
-    | Descriptor x -> `List [`String "Descriptor"; Name.to_json x]
-    | Constructor x -> `List [`String "Constructor"; Name.to_json x]
-    | Field x -> `List [`String "Field"; Name.to_json x]
+    | Typ x ->
+      let x = CoqName.ocaml_name x in
+      `List [`String "Typ"; Name.to_json x]
+    | Descriptor x ->
+      let x = CoqName.ocaml_name x in
+      `List [`String "Descriptor"; Name.to_json x]
+    | Constructor x ->
+      let x = CoqName.ocaml_name x in
+      `List [`String "Constructor"; Name.to_json x]
+    | Field x ->
+      let x = CoqName.ocaml_name x in
+      `List [`String "Field"; Name.to_json x]
     | Include x -> `List [`String "Include"; PathName.to_json x]
     | Interface (x, defs) ->
+      let x = CoqName.ocaml_name x in
       `List [`String "Interface"; Name.to_json x; `List (List.map to_json defs)]
 
   let rec of_json (json : json) : t =
     match json with
     | `List [`String "Var"; x; shape] ->
-      Var (Name.of_json x, Shape.of_json shape)
-    | `List [`String "Typ"; x] -> Typ (Name.of_json x)
-    | `List [`String "Descriptor"; x] -> Descriptor (Name.of_json x)
-    | `List [`String "Constructor"; x] -> Constructor (Name.of_json x)
-    | `List [`String "Field"; x] -> Field (Name.of_json x)
+      Var (CoqName.Name (Name.of_json x), Shape.of_json shape)
+    | `List [`String "Typ"; x] -> Typ (CoqName.Name (Name.of_json x))
+    | `List [`String "Descriptor"; x] ->
+      Descriptor (CoqName.Name (Name.of_json x))
+    | `List [`String "Constructor"; x] ->
+      Constructor (CoqName.Name (Name.of_json x))
+    | `List [`String "Field"; x] -> Field (CoqName.Name (Name.of_json x))
     | `List [`String "Include"; x] -> Include (PathName.of_json x)
     | `List [`String "Interface"; x; `List defs] ->
-        Interface (Name.of_json x, List.map of_json defs)
+        Interface (CoqName.Name (Name.of_json x), List.map of_json defs)
     | _ -> raise (Error.Json
       "Expected a Var, Typ, Descriptor, Constructor, Field or Interface field.")
 
@@ -165,26 +178,26 @@ end
 let rec to_json (interface : t) : json =
   match interface with
   | Var (x, shape) ->
-    `List [`String "Var"; Name.to_json x; Shape.to_json shape]
-  | Typ x -> `List [`String "Typ"; Name.to_json x]
-  | Descriptor x -> `List [`String "Descriptor"; Name.to_json x]
-  | Constructor x -> `List [`String "Constructor"; Name.to_json x]
-  | Field x -> `List [`String "Field"; Name.to_json x]
+    `List [`String "Var"; CoqName.to_json x; Shape.to_json shape]
+  | Typ x -> `List [`String "Typ"; CoqName.to_json x]
+  | Descriptor x -> `List [`String "Descriptor"; CoqName.to_json x]
+  | Constructor x -> `List [`String "Constructor"; CoqName.to_json x]
+  | Field x -> `List [`String "Field"; CoqName.to_json x]
   | Include x -> `List [`String "Include"; PathName.to_json x]
   | Interface (x, defs) ->
-    `List [`String "Interface"; Name.to_json x; `List (List.map to_json defs)]
+    `List [`String "Interface"; CoqName.to_json x; `List (List.map to_json defs)]
 
 let rec of_json (json : json) : t =
   match json with
   | `List [`String "Var"; x; shape] ->
-    Var (Name.of_json x, Shape.of_json shape)
-  | `List [`String "Typ"; x] -> Typ (Name.of_json x)
-  | `List [`String "Descriptor"; x] -> Descriptor (Name.of_json x)
-  | `List [`String "Constructor"; x] -> Constructor (Name.of_json x)
-  | `List [`String "Field"; x] -> Field (Name.of_json x)
+    Var (CoqName.of_json x, Shape.of_json shape)
+  | `List [`String "Typ"; x] -> Typ (CoqName.of_json x)
+  | `List [`String "Descriptor"; x] -> Descriptor (CoqName.of_json x)
+  | `List [`String "Constructor"; x] -> Constructor (CoqName.of_json x)
+  | `List [`String "Field"; x] -> Field (CoqName.of_json x)
   | `List [`String "Include"; x] -> Include (PathName.of_json x)
   | `List [`String "Interface"; x; `List defs] ->
-      Interface (Name.of_json x, List.map of_json defs)
+      Interface (CoqName.of_json x, List.map of_json defs)
   | _ -> raise (Error.Json
     "Expected a Var, Typ, Descriptor, Constructor, Field or Interface field.")
 

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -13,7 +13,7 @@ module Shape = struct
     | Effect.Type.Pure -> []
     | Effect.Type.Arrow (d, typ) ->
       let ds = Effect.Descriptor.elements d |> List.map (fun x ->
-        x.BoundName.local_path) in
+        x.BoundName.full_path) in
       ds :: of_effect_typ typ
 
   let to_effect_typ (shape : t) (env : 'a FullEnvi.t) : Effect.Type.t =

--- a/src/primitiveDeclaration.ml
+++ b/src/primitiveDeclaration.ml
@@ -35,11 +35,9 @@ let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t) (desc : value_description)
       typ }
 
 let update_env (prim : t) (env : unit FullEnvi.t) : unit FullEnvi.t =
-  let (name, coq_name) = CoqName.assoc_names prim.name in
-  FullEnvi.Var.assoc [] name coq_name () env
+  FullEnvi.Var.assoc prim.name () env
 
 (* TODO: Update to reflect that primitives are not usually pure. *)
 let update_env_with_effects (prim : t) (env : Effect.Type.t FullEnvi.t)
   : Effect.Type.t FullEnvi.t =
-  let (name, coq_name) = CoqName.assoc_names prim.name in
-  FullEnvi.Var.assoc [] name coq_name Effect.Type.Pure env
+  FullEnvi.Var.assoc prim.name Effect.Type.Pure env

--- a/src/reference.ml
+++ b/src/reference.ml
@@ -38,21 +38,17 @@ let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t) (cases : value_binding list)
 
 let update_env (update_exp : unit FullEnvi.t -> 'a Exp.t -> 'b Exp.t)
   (r : 'a t) (env : unit FullEnvi.t) : unit FullEnvi.t * 'b t =
-  let (name, coq_name) = CoqName.assoc_names r.name in
-  let (state_name, coq_state_name) = CoqName.assoc_names r.state_name in
   let env = env
-  |> FullEnvi.Var.assoc [] name coq_name ()
-  |> FullEnvi.Descriptor.assoc [] state_name coq_state_name in
+  |> FullEnvi.Var.assoc r.name ()
+  |> FullEnvi.Descriptor.assoc r.state_name in
   (env, {r with expr = update_exp env r.expr})
 
 let update_env_with_effects (r : (Loc.t * Type.t) t)
   (env : Effect.Type.t FullEnvi.t)
   : Effect.Type.t FullEnvi.t * (Loc.t * Effect.t) t =
-  let (name, coq_name) = CoqName.assoc_names r.name in
-  let (state_name, coq_state_name) = CoqName.assoc_names r.state_name in
   let env = env
-  |> FullEnvi.Var.assoc [] name coq_name Effect.Type.Pure
-  |> FullEnvi.Descriptor.assoc [] state_name coq_state_name in
+  |> FullEnvi.Var.assoc r.name Effect.Type.Pure
+  |> FullEnvi.Descriptor.assoc r.state_name in
   (env, {r with expr = Exp.effects env r.expr})
 
 let to_coq (r : 'a t) : SmartPrint.t =

--- a/tests/ex01.interface
+++ b/tests/ex01.interface
@@ -1,1 +1,1 @@
-{ "version": "1", "content": [ "Interface", "Ex01", [ [ "Var", "f", [] ], [ "Var", "n", [] ] ] ] }
+{ "version": "2", "content": [ "Interface", "Ex01", [ [ "Var", "f", [] ], [ "Var", "n", [] ] ] ] }

--- a/tests/ex02.interface
+++ b/tests/ex02.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex02",

--- a/tests/ex03.interface
+++ b/tests/ex03.interface
@@ -1,1 +1,1 @@
-{ "version": "1", "content": [ "Interface", "Ex03", [ [ "Var", "n1", [] ], [ "Var", "n2", [] ] ] ] }
+{ "version": "2", "content": [ "Interface", "Ex03", [ [ "Var", "n1", [] ], [ "Var", "n2", [] ] ] ] }

--- a/tests/ex04.interface
+++ b/tests/ex04.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex04",

--- a/tests/ex05.interface
+++ b/tests/ex05.interface
@@ -1,1 +1,1 @@
-{ "version": "1", "content": [ "Interface", "Ex05", [ [ "Var", "n", [] ] ] ] }
+{ "version": "2", "content": [ "Interface", "Ex05", [ [ "Var", "n", [] ] ] ] }

--- a/tests/ex06.interface
+++ b/tests/ex06.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex06",

--- a/tests/ex07.interface
+++ b/tests/ex07.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex07",

--- a/tests/ex08.interface
+++ b/tests/ex08.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex08",
@@ -16,7 +16,7 @@
       [ "Var", "of_list_rec", [ [], [ "NonTermination" ] ] ],
       [ "Var", "of_list", [ [ "Counter", "NonTermination" ] ] ],
       [ "Var", "sum_rec", [ [], [ "NonTermination" ] ] ],
-      [ "Var", "sum", [ [ "Counter", "NonTermination" ] ] ],
+      [ "Var", [ "sum", "sum_1" ], [ [ "Counter", "NonTermination" ] ] ],
       [ "Var", "s", [ [ "Counter", "NonTermination" ] ] ],
       [ "Typ", "t3" ],
       [ "Typ", "t4" ],

--- a/tests/ex09.interface
+++ b/tests/ex09.interface
@@ -1,1 +1,1 @@
-{ "version": "1", "content": [ "Interface", "Ex09", [ [ "Var", "l", [ [ "Counter", "NonTermination" ] ] ] ] ] }
+{ "version": "2", "content": [ "Interface", "Ex09", [ [ "Var", "l", [ [ "Counter", "NonTermination" ] ] ] ] ] }

--- a/tests/ex10.interface
+++ b/tests/ex10.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex10",

--- a/tests/ex11.interface
+++ b/tests/ex11.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex11",

--- a/tests/ex12.interface
+++ b/tests/ex12.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex12",

--- a/tests/ex13.interface
+++ b/tests/ex13.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex13",

--- a/tests/ex14.interface
+++ b/tests/ex14.interface
@@ -1,1 +1,1 @@
-{ "version": "1", "content": [ "Interface", "Ex14", [ [ "Var", "f", [] ] ] ] }
+{ "version": "2", "content": [ "Interface", "Ex14", [ [ "Var", "f", [] ] ] ] }

--- a/tests/ex15.interface
+++ b/tests/ex15.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex15",

--- a/tests/ex16.interface
+++ b/tests/ex16.interface
@@ -1,1 +1,1 @@
-{ "version": "1", "content": [ "Interface", "Ex16", [ [ "Typ", "t1" ], [ "Typ", "t2" ] ] ] }
+{ "version": "2", "content": [ "Interface", "Ex16", [ [ "Typ", "t1" ], [ "Typ", "t2" ] ] ] }

--- a/tests/ex17.interface
+++ b/tests/ex17.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex17",
@@ -12,8 +12,8 @@
         "G",
         [
           [ "Descriptor", "Inside" ],
-          [ "Var", "raise_Inside", [ [ "Inside" ] ] ],
-          [ "Var", "g", [ [ "Outside", "Inside" ] ] ]
+          [ "Var", "raise_Inside", [ [ "G.Inside" ] ] ],
+          [ "Var", "g", [ [ "Outside", "G.Inside" ] ] ]
         ]
       ],
       [ "Var", "h_rec", [ [], [ "IO", "NonTermination", "Outside", "G.Inside" ] ] ],

--- a/tests/ex18.interface
+++ b/tests/ex18.interface
@@ -1,17 +1,21 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex18",
     [
       [ "Var", "r", [] ],
       [ "Descriptor", "r_state" ],
-      [ "Var", "plus_one", [ [ "r_state" ] ] ],
+      [ "Var", "plus_one", [ [ [ [ "Apply", "OCaml.Effect.State.state", [ "Apply", "Z" ] ] ], [ "r_state" ] ] ] ],
       [ "Var", "s", [] ],
       [ "Descriptor", "s_state" ],
-      [ "Var", "fail", [ [ "s_state", "OCaml.Failure" ] ] ],
-      [ "Var", "reset", [ [ "r_state" ] ] ],
-      [ "Var", "incr", [ [ "r_state" ] ] ]
+      [
+        "Var",
+        "fail",
+        [ [ [ [ "Apply", "OCaml.Effect.State.state", [ "Apply", "string" ] ] ], [ "s_state", "OCaml.Failure" ] ] ]
+      ],
+      [ "Var", "reset", [ [ [ [ "Apply", "OCaml.Effect.State.state", [ "Apply", "Z" ] ] ], [ "r_state" ] ] ] ],
+      [ "Var", "incr", [ [ [ [ "Apply", "OCaml.Effect.State.state", [ "Apply", "Z" ] ] ], [ "r_state" ] ] ] ]
     ]
   ]
 }

--- a/tests/ex19.interface
+++ b/tests/ex19.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex19",

--- a/tests/ex20.interface
+++ b/tests/ex20.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex20",

--- a/tests/ex21.interface
+++ b/tests/ex21.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex21",

--- a/tests/ex22.interface
+++ b/tests/ex22.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex22",

--- a/tests/ex23.interface
+++ b/tests/ex23.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex23",

--- a/tests/ex24.interface
+++ b/tests/ex24.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex24",

--- a/tests/ex25.interface
+++ b/tests/ex25.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex25",

--- a/tests/ex26.interface
+++ b/tests/ex26.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex26",

--- a/tests/ex27.interface
+++ b/tests/ex27.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex27",

--- a/tests/ex28.interface
+++ b/tests/ex28.interface
@@ -1,1 +1,1 @@
-{ "version": "1", "content": [ "Interface", "Ex28", [ [ "Var", "map", [] ], [ "Var", "map2", [] ] ] ] }
+{ "version": "2", "content": [ "Interface", "Ex28", [ [ "Var", "map", [] ], [ "Var", "map2", [] ] ] ] }

--- a/tests/ex29.interface
+++ b/tests/ex29.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex29",

--- a/tests/ex30.interface
+++ b/tests/ex30.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex30",

--- a/tests/ex31.interface
+++ b/tests/ex31.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex31",

--- a/tests/ex33.interface
+++ b/tests/ex33.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex33",

--- a/tests/ex34.interface
+++ b/tests/ex34.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex34",

--- a/tests/ex35.interface
+++ b/tests/ex35.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex35",

--- a/tests/ex36.interface
+++ b/tests/ex36.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex36",

--- a/tests/ex37.interface
+++ b/tests/ex37.interface
@@ -1,5 +1,5 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex37",

--- a/tests/ex38.interface
+++ b/tests/ex38.interface
@@ -1,1 +1,1 @@
-{ "version": "1", "content": [ "Interface", "Ex38", [ [ "Var", "f", [] ], [ "Var", "m", [] ] ] ] }
+{ "version": "2", "content": [ "Interface", "Ex38", [ [ "Var", "f", [] ], [ "Var", "m", [] ] ] ] }

--- a/tests/ex39.interface
+++ b/tests/ex39.interface
@@ -1,28 +1,77 @@
 {
-  "version": "1",
+  "version": "2",
   "content": [
     "Interface",
     "Ex39",
     [
-      [ "Var", "get_local_ref", [ [] ] ],
-      [ "Var", "set_local_ref", [ [] ] ],
-      [ "Var", "add_multiple_by_refs", [ [], [], [], [] ] ],
-      [ "Var", "set_ref", [ [] ] ],
-      [ "Var", "get_ref", [ [] ] ],
-      [ "Var", "update_ref", [ [] ] ],
-      [ "Var", "new_ref", [ [] ] ],
+      [ "Var", "get_local_ref", [ [ [ "Apply", "OCaml.Effect.State.state", [ "Apply", "Z" ] ] ] ] ],
+      [ "Var", "set_local_ref", [ [ [ "Apply", "OCaml.Effect.State.state", [ "Apply", "Z" ] ] ] ] ],
+      [ "Var", "add_multiple_by_refs", [ [], [], [], [ [ "Apply", "OCaml.Effect.State.state", [ "Apply", "Z" ] ] ] ] ],
+      [ "Var", "set_ref", [ [ [ "Apply", "OCaml.Effect.State.state", [ "Apply", "Z" ] ] ] ] ],
+      [ "Var", "get_ref", [ [ [ "Apply", "OCaml.Effect.State.state", [ "Apply", "Z" ] ] ] ] ],
+      [ "Var", "update_ref", [ [ [ "Apply", "OCaml.Effect.State.state", [ "Apply", "Z" ] ] ] ] ],
+      [ "Var", "new_ref", [ [ [ "Apply", "OCaml.Effect.State.state", [ "Apply", "Z" ] ] ] ] ],
       [ "Var", "r", [] ],
       [ "Descriptor", "r_state" ],
-      [ "Var", "set_r", [ [ "r_state" ] ] ],
-      [ "Var", "get_r", [ [ "r_state" ] ] ],
-      [ "Var", "r_add_15", [ [ "r_state" ] ] ],
-      [ "Var", "mixed_type", [ [ "r_state" ] ] ],
-      [ "Var", "partials_test", [ [ "r_state" ] ] ],
-      [ "Var", "multiple_returns_test", [ [] ] ],
-      [ "Var", "type_vars_test", [ [], [], [], [] ] ],
-      [ "Var", "resolves_test1", [ [], [], [] ] ],
-      [ "Var", "resolves_test2", [ [], [], [], [] ] ],
-      [ "Var", "resolves_test3", [ [], [], [], [] ] ]
+      [ "Var", "set_r", [ [ [ [ "Apply", "OCaml.Effect.State.state", [ "Apply", "Z" ] ] ], [ "r_state" ] ] ] ],
+      [ "Var", "get_r", [ [ [ [ "Apply", "OCaml.Effect.State.state", [ "Apply", "Z" ] ] ], [ "r_state" ] ] ] ],
+      [ "Var", "r_add_15", [ [ [ [ "Apply", "OCaml.Effect.State.state", [ "Apply", "Z" ] ] ], [ "r_state" ] ] ] ],
+      [
+        "Var",
+        "mixed_type",
+        [
+          [
+            [
+              [ "Apply", "OCaml.Effect.State.state", [ "Apply", "Z" ] ],
+              [ "Apply", "OCaml.Effect.State.state", [ "Apply", "bool" ] ],
+              [ "Apply", "OCaml.Effect.State.state", [ "Apply", "string" ] ]
+            ],
+            [ "r_state" ]
+          ]
+        ]
+      ],
+      [
+        "Var",
+        "partials_test",
+        [
+          [
+            [
+              [ "Apply", "OCaml.Effect.State.state", [ "Apply", "Z" ] ],
+              [ "Apply", "OCaml.Effect.State.state", [ "Apply", "list", [ "Apply", "Z" ] ] ]
+            ],
+            [ "r_state" ]
+          ]
+        ]
+      ],
+      [ "Var", "multiple_returns_test", [ [ [ "Apply", "OCaml.Effect.State.state", [ "Apply", "Z" ] ] ] ] ],
+      [
+        "Var",
+        "type_vars_test",
+        [
+          [],
+          [],
+          [],
+          [
+            [ "Apply", "OCaml.Effect.State.state", [ "Variable", "A" ] ],
+            [ "Apply", "OCaml.Effect.State.state", [ "Variable", "B" ] ]
+          ]
+        ]
+      ],
+      [ "Var", "resolves_test1", [ [], [], [ [ "Apply", "OCaml.Effect.State.state", [ "Variable", "A" ] ] ] ] ],
+      [
+        "Var",
+        "resolves_test2",
+        [
+          [],
+          [],
+          [],
+          [
+            [ "Apply", "OCaml.Effect.State.state", [ "Variable", "A" ] ],
+            [ "Apply", "OCaml.Effect.State.state", [ "Apply", "Z" ] ]
+          ]
+        ]
+      ],
+      [ "Var", "resolves_test3", [ [], [], [], [ [ "Apply", "OCaml.Effect.State.state", [ "Apply", "Z" ] ] ] ] ]
     ]
   ]
 }


### PR DESCRIPTION
This PR
* makes some changes to `FullEnvi`, to make it simpler to access values with known fixed Coq names
* separates out the code for interfaces version 1
* carries complex effects (currently `Effect.State.state`) in the interface file
* bumps the interface version to 2
* updates the expected test output