### PR TITLE
Give explicit types whenever necessary in for/while loops

### DIFF
--- a/OCaml/Basics.v
+++ b/OCaml/Basics.v
@@ -134,31 +134,31 @@ Definition raise_Undefined_recursive_module {A : Type} (x : string * Z * Z)
 Definition assert {A : Type} (b : bool) : M [Assert_failure] A :=
   raise_Assert_failure ("coq" % string, 0, 0).
 
-Definition for_to {es : list Effect.t} (start_value end_value : Z)
-  (f : Z -> M es unit) : M es unit :=
+Definition for_to {A : Type} {es : list Effect.t} (start_value end_value : Z)
+  (f : Z -> M es A) : M es unit :=
   let fix for_to (n : nat) (value : Z) : M es unit :=
     match n with
-    | O => f value
+    | O => let! _ := f value in ret tt
     | S n => let! _ := f value in for_to n (value + 1)
     end in
   let difference := end_value - start_value in
   match difference with
   | Zneg _ => Effect.of_raw (fun s => (inl tt, s))
-  | Z0 => f start_value
+  | Z0 => let! _ := f start_value in ret tt
   | Zpos pos => for_to (Pos.to_nat pos) start_value
   end.
 
-Definition for_downto {es : list Effect.t} (start_value end_value : Z)
-  (f : Z -> M es unit) : M es unit :=
+Definition for_downto {A : Type} {es : list Effect.t}
+  (start_value end_value : Z) (f : Z -> M es A) : M es unit :=
   let fix for_to (n : nat) (value : Z) : M es unit :=
     match n with
-    | O => f value
+    | O => let! _ := f value in ret tt
     | S n => let! _ := f value in for_to n (value - 1)
     end in
   let difference := start_value - end_value in
   match difference with
   | Zneg _ => Effect.of_raw (fun s => (inl tt, s))
-  | Z0 => f end_value
+  | Z0 => let! _ := f end_value in ret tt
   | Zpos pos => for_to (Pos.to_nat pos) end_value
   end.
 

--- a/src/type.ml
+++ b/src/type.ml
@@ -127,6 +127,14 @@ let rec unify (ptyp : Effect.PureType.t) (typ : t)
       Name.Map.empty ptyps typs
   | _, _ -> failwith "Could not unify types"
 
+let rec map_vars (f : Name.t -> t) (typ : t) : t =
+  match typ with
+  | Variable x -> f x
+  | Arrow (typ1, typ2) -> Arrow (map_vars f typ1, map_vars f typ2)
+  | Tuple typs -> Tuple (List.map (map_vars f) typs)
+  | Apply (x, typs) -> Apply (x, List.map (map_vars f) typs)
+  | Monad (x, typ) -> Monad (x, map_vars f typ)
+
 let rec typ_args (typ : t) : Name.Set.t =
   match typ with
   | Variable x -> Name.Set.singleton x

--- a/tests/ex42.effects
+++ b/tests/ex42.effects
@@ -325,53 +325,134 @@ Value
           ((20, Effect ([ OCaml.Failure ], .)), i, true,
             Constant ((20, Effect ([ ], .)), Int(0)),
             Variable ((20, Effect ([ ], .)), x),
-            Apply
-              ((21, Effect ([ OCaml.Failure ], .)),
-                Variable
-                  ((21, Effect ([ ], . -[ OCaml.Failure ]-> .)),
-                    OCaml.Pervasives.failwith),
-                [
-                  Constant
-                    ((21, Effect ([ ], .)),
-                      String("x is not less than 0"))
-                ])))
+            Coerce
+              ((?, Effect ([ OCaml.Failure ], .)),
+                Apply
+                  ((21, Effect ([ OCaml.Failure ], .)),
+                    Variable
+                      ((21,
+                        Effect ([ ], . -[ OCaml.Failure ]-> .)),
+                        OCaml.Pervasives.failwith),
+                    [
+                      Constant
+                        ((21,
+                          Effect
+                            ([
+                            ],
+                              .)),
+                          String("x is not less than 0"))
+                    ]), ())))
     ])
 
 24
 Value
   (non_rec, @.,
     [
+      ((complex_raises, [ ], [ (x, Type (Z)) ], Type (unit)),
+        LetFun (25, Effect ([ OCaml.Failure ], .))
+          (non_rec, @.,
+            [
+              ((f, [ A; B ], [ (a, A) ], (A * Type (Z) * B)),
+                Tuple
+                  ((25,
+                    Effect
+                      ([
+                        OCaml.Failure
+                      ],
+                        .)),
+                    Variable
+                      ((25,
+                        Effect
+                          ([
+                          ],
+                            .)),
+                        a),
+                    Constant
+                      ((25,
+                        Effect
+                          ([
+                          ],
+                            .)),
+                        Int(15)),
+                    Apply
+                      ((25,
+                        Effect
+                          ([
+                            OCaml.Failure
+                          ],
+                            .)),
+                        Variable
+                          ((25,
+                            Effect
+                              ([
+                              ],
+                                .
+                                  -[
+                                    OCaml.Failure
+                                  ]->
+                                  .)),
+                            OCaml.Pervasives.failwith),
+                        [
+                          Constant
+                            ((25,
+                              Effect
+                                ([
+                                ],
+                                  .)),
+                              String("x is not less than 0"))
+                        ])))
+            ]) in
+        For
+          ((26, Effect ([ OCaml.Failure ], .)), i, true,
+            Constant ((26, Effect ([ ], .)), Int(0)),
+            Variable ((26, Effect ([ ], .)), x),
+            Coerce
+              ((?, Effect ([ OCaml.Failure ], .)),
+                Apply
+                  ((27, Effect ([ OCaml.Failure ], .)),
+                    Variable
+                      ((27,
+                        Effect ([ ], . -[ OCaml.Failure ]-> .)),
+                        f),
+                    [ Constructor ((27, Effect ([ ], .)), true) ]),
+                (Type (bool) * Type (Z) * ()))))
+    ])
+
+30
+Value
+  (non_rec, @.,
+    [
       ((argument_effects, [ ],
         [ (x, Type (OCaml.Effect.State.t, Type (Z))); (y, Type (Z)) ],
         Type (Z)),
-        LetVar (25, Effect ([ (OCaml.Effect.State.state, Z) ], .)) y =
+        LetVar (31, Effect ([ (OCaml.Effect.State.state, Z) ], .)) y =
           Apply
-            ((25, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+            ((31, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
               Variable
-                ((25,
+                ((31,
                   Effect
                     ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
                   OCaml.Pervasives.ref),
-              [ Variable ((25, Effect ([ ], .)), y) ]) in
-        LetVar (26, Effect ([ (OCaml.Effect.State.state, Z) ], .)) z =
+              [ Variable ((31, Effect ([ ], .)), y) ]) in
+        LetVar (32, Effect ([ (OCaml.Effect.State.state, Z) ], .)) z =
           Apply
-            ((26, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+            ((32, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
               Variable
-                ((26,
+                ((32,
                   Effect
                     ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
                   OCaml.Pervasives.ref),
-              [ Constant ((26, Effect ([ ], .)), Int(0)) ]) in
+              [ Constant ((32, Effect ([ ], .)), Int(0)) ]) in
         Sequence
-          ((27, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+          ((33, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
             For
-              ((27, Effect ([ (OCaml.Effect.State.state, Z) ], .)), i,
-                true, Constant ((27, Effect ([ ], .)), Int(0)),
+              ((33, Effect ([ (OCaml.Effect.State.state, Z) ], .)), i,
+                true, Constant ((33, Effect ([ ], .)), Int(0)),
                 Apply
-                  ((27,
+                  ((33,
                     Effect ([ (OCaml.Effect.State.state, Z) ], .)),
                     Variable
-                      ((27,
+                      ((33,
                         Effect
                           ([ ],
                             .
@@ -380,26 +461,26 @@ Value
                                   Z)
                               ]-> .)),
                         OCaml.Effect.State.read),
-                    [ Variable ((27, Effect ([ ], .)), x) ]),
+                    [ Variable ((33, Effect ([ ], .)), x) ]),
                 Sequence
-                  ((28,
+                  ((34,
                     Effect ([ (OCaml.Effect.State.state, Z) ], .)),
                     For
-                      ((28,
+                      ((34,
                         Effect
                           ([ (OCaml.Effect.State.state, Z) ],
                             .)), j, true,
                         Constant
-                          ((28, Effect ([ ], .)), Int(0)),
+                          ((34, Effect ([ ], .)), Int(0)),
                         Apply
-                          ((28,
+                          ((34,
                             Effect
                               ([
                                 (OCaml.Effect.State.state,
                                   Z)
                               ], .)),
                             Variable
-                              ((28,
+                              ((34,
                                 Effect
                                   ([ ],
                                     .
@@ -410,7 +491,7 @@ Value
                                 OCaml.Effect.State.read),
                             [
                               Variable
-                                ((28,
+                                ((34,
                                   Effect
                                     ([
                                     ],
@@ -418,14 +499,14 @@ Value
                                   y)
                             ]),
                         Apply
-                          ((29,
+                          ((35,
                             Effect
                               ([
                                 (OCaml.Effect.State.state,
                                   Z)
                               ], .)),
                             Variable
-                              ((29,
+                              ((35,
                                 Effect
                                   ([ ],
                                     . ->
@@ -437,14 +518,14 @@ Value
                                 OCaml.Effect.State.write),
                             [
                               Variable
-                                ((29,
+                                ((35,
                                   Effect
                                     ([
                                     ],
                                       .)),
                                   z);
                               Apply
-                                ((29,
+                                ((35,
                                   Effect
                                     ([
                                       (OCaml.Effect.State.state,
@@ -452,7 +533,7 @@ Value
                                     ],
                                       .)),
                                   Variable
-                                    ((29,
+                                    ((35,
                                       Effect
                                         ([
                                         ],
@@ -460,7 +541,7 @@ Value
                                       Z.add),
                                   [
                                     Apply
-                                      ((29,
+                                      ((35,
                                         Effect
                                           ([
                                             (OCaml.Effect.State.state,
@@ -468,7 +549,7 @@ Value
                                           ],
                                             .)),
                                         Variable
-                                          ((29,
+                                          ((35,
                                             Effect
                                               ([
                                               ],
@@ -481,7 +562,7 @@ Value
                                             OCaml.Effect.State.read),
                                         [
                                           Variable
-                                            ((29,
+                                            ((35,
                                               Effect
                                                 ([
                                                 ],
@@ -489,7 +570,7 @@ Value
                                               z)
                                         ]);
                                     Constant
-                                      ((29,
+                                      ((35,
                                         Effect
                                           ([
                                           ],
@@ -498,12 +579,12 @@ Value
                                   ])
                             ])),
                     Apply
-                      ((31,
+                      ((37,
                         Effect
                           ([ (OCaml.Effect.State.state, Z) ],
                             .)),
                         Variable
-                          ((31,
+                          ((37,
                             Effect
                               ([ ],
                                 . ->
@@ -515,14 +596,14 @@ Value
                             OCaml.Effect.State.write),
                         [
                           Variable
-                            ((31,
+                            ((37,
                               Effect
                                 ([
                                 ],
                                   .)),
                               y);
                           Apply
-                            ((31,
+                            ((37,
                               Effect
                                 ([
                                   (OCaml.Effect.State.state,
@@ -530,7 +611,7 @@ Value
                                 ],
                                   .)),
                               Variable
-                                ((31,
+                                ((37,
                                   Effect
                                     ([
                                     ],
@@ -538,7 +619,7 @@ Value
                                   Z.sub),
                               [
                                 Apply
-                                  ((31,
+                                  ((37,
                                     Effect
                                       ([
                                         (OCaml.Effect.State.state,
@@ -546,7 +627,7 @@ Value
                                       ],
                                         .)),
                                     Variable
-                                      ((31,
+                                      ((37,
                                         Effect
                                           ([
                                           ],
@@ -559,7 +640,7 @@ Value
                                         OCaml.Effect.State.read),
                                     [
                                       Variable
-                                        ((31,
+                                        ((37,
                                           Effect
                                             ([
                                             ],
@@ -567,7 +648,7 @@ Value
                                           y)
                                     ]);
                                 Constant
-                                  ((31,
+                                  ((37,
                                     Effect
                                       ([
                                       ],
@@ -576,12 +657,12 @@ Value
                               ])
                         ]))),
             Apply
-              ((33, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+              ((39, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
                 Variable
-                  ((33,
+                  ((39,
                     Effect
                       ([ ],
                         . -[ (OCaml.Effect.State.state, Z) ]->
                           .)), OCaml.Effect.State.read),
-                [ Variable ((33, Effect ([ ], .)), z) ])))
+                [ Variable ((39, Effect ([ ], .)), z) ])))
     ])

--- a/tests/ex42.exp
+++ b/tests/ex42.exp
@@ -127,90 +127,120 @@ Value
 Value
   (non_rec, @.,
     [
+      ((complex_raises, [ ], [ (x, Type (Z)) ], Type (unit)),
+        LetFun 25
+          (non_rec, @.,
+            [
+              ((f, [ A; B ], [ (a, A) ], (A * Type (Z) * B)),
+                Tuple
+                  (25, Variable (25, a),
+                    Constant
+                      (25,
+                        Int(15)),
+                    Apply
+                      (25,
+                        Variable
+                          (25,
+                            OCaml.Pervasives.failwith),
+                        [
+                          Constant
+                            (25,
+                              String("x is not less than 0"))
+                        ])))
+            ]) in
+        For
+          (26, i, true, Constant (26, Int(0)), Variable (26, x),
+            Apply (27, Variable (27, f), [ Constructor (27, true) ])))
+    ])
+
+30
+Value
+  (non_rec, @.,
+    [
       ((argument_effects, [ ],
         [ (x, Type (OCaml.Effect.State.t, Type (Z))); (y, Type (Z)) ],
         Type (Z)),
-        LetVar 25 y =
+        LetVar 31 y =
           Apply
-            (25, Variable (25, OCaml.Pervasives.ref), [ Variable (25, y) ])
+            (31, Variable (31, OCaml.Pervasives.ref), [ Variable (31, y) ])
           in
-        LetVar 26 z =
+        LetVar 32 z =
           Apply
-            (26, Variable (26, OCaml.Pervasives.ref),
-              [ Constant (26, Int(0)) ]) in
+            (32, Variable (32, OCaml.Pervasives.ref),
+              [ Constant (32, Int(0)) ]) in
         Sequence
-          (27,
+          (33,
             For
-              (27, i, true, Constant (27, Int(0)),
+              (33, i, true, Constant (33, Int(0)),
                 Apply
-                  (27, Variable (27, OCaml.Effect.State.read),
-                    [ Variable (27, x) ]),
+                  (33, Variable (33, OCaml.Effect.State.read),
+                    [ Variable (33, x) ]),
                 Sequence
-                  (28,
+                  (34,
                     For
-                      (28, j, true, Constant (28, Int(0)),
+                      (34, j, true, Constant (34, Int(0)),
                         Apply
-                          (28,
+                          (34,
                             Variable
-                              (28,
+                              (34,
                                 OCaml.Effect.State.read),
-                            [ Variable (28, y) ]),
+                            [ Variable (34, y) ]),
                         Apply
-                          (29,
+                          (35,
                             Variable
-                              (29,
+                              (35,
                                 OCaml.Effect.State.write),
                             [
-                              Variable (29, z);
+                              Variable (35, z);
                               Apply
-                                (29,
+                                (35,
                                   Variable
-                                    (29,
+                                    (35,
                                       Z.add),
                                   [
                                     Apply
-                                      (29,
+                                      (35,
                                         Variable
-                                          (29,
+                                          (35,
                                             OCaml.Effect.State.read),
                                         [
                                           Variable
-                                            (29,
+                                            (35,
                                               z)
                                         ]);
                                     Constant
-                                      (29,
+                                      (35,
                                         Int(1))
                                   ])
                             ])),
                     Apply
-                      (31,
+                      (37,
                         Variable
-                          (31, OCaml.Effect.State.write),
+                          (37, OCaml.Effect.State.write),
                         [
-                          Variable (31, y);
+                          Variable (37, y);
                           Apply
-                            (31,
+                            (37,
                               Variable
-                                (31,
+                                (37,
                                   Z.sub),
                               [
                                 Apply
-                                  (31,
+                                  (37,
                                     Variable
-                                      (31,
+                                      (37,
                                         OCaml.Effect.State.read),
                                     [
                                       Variable
-                                        (31,
+                                        (37,
                                           y)
                                     ]);
                                 Constant
-                                  (31,
+                                  (37,
                                     Int(1))
                               ])
                         ]))),
             Apply
-              (33, Variable (33, OCaml.Effect.State.read),
-                [ Variable (33, z) ])))
+              (39, Variable (39, OCaml.Effect.State.read),
+                [ Variable (39, z) ])))
     ])

--- a/tests/ex42.interface
+++ b/tests/ex42.interface
@@ -11,6 +11,7 @@
         [ [ [], [ [ "Apply", "OCaml.Effect.State.state", [ "Apply", "list", [ "Apply", "bool" ] ] ] ] ] ]
       ],
       [ "Var", "raises", [ [ [ "OCaml.Failure" ] ] ] ],
+      [ "Var", "complex_raises", [ [ [ "OCaml.Failure" ] ] ] ],
       [ "Var", "argument_effects", [ [ [], [ [ "Apply", "OCaml.Effect.State.state", [ "Apply", "Z" ] ] ] ] ] ]
     ]
   ]

--- a/tests/ex42.ml
+++ b/tests/ex42.ml
@@ -21,6 +21,12 @@ let raises (x : int) =
     failwith "x is not less than 0"
   done
 
+let complex_raises (x : int) =
+  let f a = (a, 15, failwith "x is not less than 0") in
+  for i = 0 to x do
+    f true
+  done
+
 let argument_effects (x : int ref) (y : int) =
   let y = ref y in
   let z = ref 0 in

--- a/tests/ex42.monadise
+++ b/tests/ex42.monadise
@@ -213,20 +213,105 @@ Value
               Variable (20, x);
               Function
                 (?, i,
-                  Apply
-                    (21,
-                      Variable
+                  Coerce
+                    (?,
+                      Apply
                         (21,
-                          OCaml.Pervasives.failwith),
-                      [
-                        Constant
-                          (21,
-                            String("x is not less than 0"))
-                      ]))
+                          Variable
+                            (21,
+                              OCaml.Pervasives.failwith),
+                          [
+                            Constant
+                              (21,
+                                String("x is not less than 0"))
+                          ]),
+                      Monad
+                        ([
+                          OCaml.Failure
+                        ],
+                          ())))
             ]))
     ])
 
 24
+Value
+  (non_rec, @.,
+    [
+      ((complex_raises, [ ], [ (x, Type (Z)) ],
+        Monad ([ OCaml.Failure ], Type (unit))),
+        LetFun 25
+          (non_rec, @.,
+            [
+              ((f, [ A; B ], [ (a, A) ],
+                Monad
+                  ([ OCaml.Failure ],
+                    (A *
+                      Type
+                        (Z)
+                      *
+                      B))),
+                Bind
+                  (?,
+                    Apply
+                      (25,
+                        Variable
+                          (25,
+                            OCaml.Pervasives.failwith),
+                        [
+                          Constant
+                            (25,
+                              String("x is not less than 0"))
+                        ]),
+                    Some
+                      x_1,
+                    Return
+                      (?,
+                        Tuple
+                          (25,
+                            Variable
+                              (25,
+                                a),
+                            Constant
+                              (25,
+                                Int(15)),
+                            Variable
+                              (?,
+                                x_1)))))
+            ]) in
+        Apply
+          (26, Variable (?, OCaml.Basics.for_to),
+            [
+              Constant (26, Int(0));
+              Variable (26, x);
+              Function
+                (?, i,
+                  Coerce
+                    (?,
+                      Apply
+                        (27,
+                          Variable
+                            (27,
+                              f),
+                          [
+                            Constructor
+                              (27,
+                                true)
+                          ]),
+                      Monad
+                        ([
+                          OCaml.Failure
+                        ],
+                          (Type
+                            (bool)
+                            *
+                            Type
+                              (Z)
+                            *
+                            ()))))
+            ]))
+    ])
+
+30
 Value
   (non_rec, @.,
     [
@@ -236,30 +321,30 @@ Value
         Bind
           (?,
             Apply
-              (25, Variable (25, OCaml.Pervasives.ref),
-                [ Variable (25, y) ]), Some y,
+              (31, Variable (31, OCaml.Pervasives.ref),
+                [ Variable (31, y) ]), Some y,
             Bind
               (?,
                 Apply
-                  (26, Variable (26, OCaml.Pervasives.ref),
-                    [ Constant (26, Int(0)) ]), Some z,
+                  (32, Variable (32, OCaml.Pervasives.ref),
+                    [ Constant (32, Int(0)) ]), Some z,
                 Bind
                   (?,
                     Bind
                       (?,
                         Apply
-                          (27,
+                          (33,
                             Variable
-                              (27,
+                              (33,
                                 OCaml.Effect.State.read),
-                            [ Variable (27, x) ]),
+                            [ Variable (33, x) ]),
                         Some x_1,
                         Apply
-                          (27,
+                          (33,
                             Variable
                               (?, OCaml.Basics.for_to),
                             [
-                              Constant (27, Int(0));
+                              Constant (33, Int(0));
                               Variable (?, x_1);
                               Function
                                 (?,
@@ -269,25 +354,25 @@ Value
                                       Bind
                                         (?,
                                           Apply
-                                            (28,
+                                            (34,
                                               Variable
-                                                (28,
+                                                (34,
                                                   OCaml.Effect.State.read),
                                               [
                                                 Variable
-                                                  (28,
+                                                  (34,
                                                     y)
                                               ]),
                                           Some
                                             x_1,
                                           Apply
-                                            (28,
+                                            (34,
                                               Variable
                                                 (?,
                                                   OCaml.Basics.for_to),
                                               [
                                                 Constant
-                                                  (28,
+                                                  (34,
                                                     Int(0));
                                                 Variable
                                                   (?,
@@ -300,13 +385,13 @@ Value
                                                         Bind
                                                           (?,
                                                             Apply
-                                                              (29,
+                                                              (35,
                                                                 Variable
-                                                                  (29,
+                                                                  (35,
                                                                     OCaml.Effect.State.read),
                                                                 [
                                                                   Variable
-                                                                    (29,
+                                                                    (35,
                                                                       z)
                                                                 ]),
                                                             Some
@@ -314,28 +399,28 @@ Value
                                                             Return
                                                               (?,
                                                                 Apply
-                                                                  (29,
+                                                                  (35,
                                                                     Variable
-                                                                      (29,
+                                                                      (35,
                                                                         Z.add),
                                                                     [
                                                                       Variable
                                                                         (?,
                                                                           x_1);
                                                                       Constant
-                                                                        (29,
+                                                                        (35,
                                                                           Int(1))
                                                                     ]))),
                                                         Some
                                                           x_1,
                                                         Apply
-                                                          (29,
+                                                          (35,
                                                             Variable
-                                                              (29,
+                                                              (35,
                                                                 OCaml.Effect.State.write),
                                                             [
                                                               Variable
-                                                                (29,
+                                                                (35,
                                                                   z);
                                                               Variable
                                                                 (?,
@@ -348,13 +433,13 @@ Value
                                           Bind
                                             (?,
                                               Apply
-                                                (31,
+                                                (37,
                                                   Variable
-                                                    (31,
+                                                    (37,
                                                       OCaml.Effect.State.read),
                                                   [
                                                     Variable
-                                                      (31,
+                                                      (37,
                                                         y)
                                                   ]),
                                               Some
@@ -362,28 +447,28 @@ Value
                                               Return
                                                 (?,
                                                   Apply
-                                                    (31,
+                                                    (37,
                                                       Variable
-                                                        (31,
+                                                        (37,
                                                           Z.sub),
                                                       [
                                                         Variable
                                                           (?,
                                                             x_1);
                                                         Constant
-                                                          (31,
+                                                          (37,
                                                             Int(1))
                                                       ]))),
                                           Some
                                             x_1,
                                           Apply
-                                            (31,
+                                            (37,
                                               Variable
-                                                (31,
+                                                (37,
                                                   OCaml.Effect.State.write),
                                               [
                                                 Variable
-                                                  (31,
+                                                  (37,
                                                     y);
                                                 Variable
                                                   (?,
@@ -391,7 +476,7 @@ Value
                                               ]))))
                             ])), None,
                     Apply
-                      (33,
-                        Variable (33, OCaml.Effect.State.read),
-                        [ Variable (33, z) ])))))
+                      (39,
+                        Variable (39, OCaml.Effect.State.read),
+                        [ Variable (39, z) ])))))
     ])

--- a/tests/ex42.v
+++ b/tests/ex42.v
@@ -36,7 +36,16 @@ Definition nested (x : Z) (y : Z)
 
 Definition raises (x : Z) : M [ OCaml.Failure ] unit :=
   OCaml.Basics.for_to 0 x
-    (fun i => OCaml.Pervasives.failwith "x is not less than 0" % string).
+    (fun i =>
+      (OCaml.Pervasives.failwith "x is not less than 0" % string) :
+        M [ OCaml.Failure ] unit).
+
+Definition complex_raises (x : Z) : M [ OCaml.Failure ] unit :=
+  let f {A B : Type} (a : A) : M [ OCaml.Failure ] (A * Z * B) :=
+    let! x_1 := OCaml.Pervasives.failwith "x is not less than 0" % string in
+    ret (a, 15, x_1) in
+  OCaml.Basics.for_to 0 x
+    (fun i => (f true) : M [ OCaml.Failure ] (bool * Z * unit)).
 
 Definition argument_effects (x : OCaml.Effect.State.t Z) (y : Z)
   : M [ OCaml.Effect.State.state Z ] Z :=

--- a/tests/ex43.effects
+++ b/tests/ex43.effects
@@ -1182,55 +1182,128 @@ Value
 Value
   (non_rec, @.,
     [
+      ((complex_raises, [ ], [ (b, Type (bool)) ], Type (unit)),
+        LetFun (35, Effect ([ Counter; NonTermination; OCaml.Failure ], .))
+          (non_rec, @.,
+            [
+              ((f, [ A; B ], [ (a, A) ], (A * Type (Z) * B)),
+                Tuple
+                  ((35,
+                    Effect
+                      ([
+                        OCaml.Failure
+                      ],
+                        .)),
+                    Variable
+                      ((35,
+                        Effect
+                          ([
+                          ],
+                            .)),
+                        a),
+                    Constant
+                      ((35,
+                        Effect
+                          ([
+                          ],
+                            .)),
+                        Int(15)),
+                    Apply
+                      ((35,
+                        Effect
+                          ([
+                            OCaml.Failure
+                          ],
+                            .)),
+                        Variable
+                          ((35,
+                            Effect
+                              ([
+                              ],
+                                .
+                                  -[
+                                    OCaml.Failure
+                                  ]->
+                                  .)),
+                            OCaml.Pervasives.failwith),
+                        [
+                          Constant
+                            ((35,
+                              Effect
+                                ([
+                                ],
+                                  .)),
+                              String("b is true"))
+                        ])))
+            ]) in
+        While
+          ((36, Effect ([ Counter; NonTermination; OCaml.Failure ], .)),
+            Variable ((36, Effect ([ ], .)), b),
+            Coerce
+              ((?, Effect ([ OCaml.Failure ], .)),
+                Apply
+                  ((37, Effect ([ OCaml.Failure ], .)),
+                    Variable
+                      ((37,
+                        Effect ([ ], . -[ OCaml.Failure ]-> .)),
+                        f),
+                    [ Constructor ((37, Effect ([ ], .)), true) ]),
+                (Type (bool) * Type (Z) * ()))))
+    ])
+
+40
+Value
+  (non_rec, @.,
+    [
       ((argument_effects, [ ],
         [ (x, Type (OCaml.Effect.State.t, Type (Z))); (y, Type (Z)) ],
         Type (Z)),
         LetVar
-          (35,
+          (41,
             Effect
               ([ (OCaml.Effect.State.state, Z); Counter; NonTermination ],
                 .)) y =
           Apply
-            ((35, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+            ((41, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
               Variable
-                ((35,
+                ((41,
                   Effect
                     ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
                   OCaml.Pervasives.ref),
-              [ Variable ((35, Effect ([ ], .)), y) ]) in
+              [ Variable ((41, Effect ([ ], .)), y) ]) in
         LetVar
-          (36,
+          (42,
             Effect
               ([ (OCaml.Effect.State.state, Z); Counter; NonTermination ],
                 .)) z =
           Apply
-            ((36, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+            ((42, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
               Variable
-                ((36,
+                ((42,
                   Effect
                     ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
                   OCaml.Pervasives.ref),
-              [ Constant ((36, Effect ([ ], .)), Int(0)) ]) in
+              [ Constant ((42, Effect ([ ], .)), Int(0)) ]) in
         LetVar
-          (37,
+          (43,
             Effect
               ([ (OCaml.Effect.State.state, Z); Counter; NonTermination ],
                 .)) i =
           Apply
-            ((37, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+            ((43, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
               Variable
-                ((37,
+                ((43,
                   Effect
                     ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
                   OCaml.Pervasives.ref),
-              [ Constant ((37, Effect ([ ], .)), Int(0)) ]) in
+              [ Constant ((43, Effect ([ ], .)), Int(0)) ]) in
         Sequence
-          ((38,
+          ((44,
             Effect
               ([ (OCaml.Effect.State.state, Z); Counter; NonTermination ],
                 .)),
             While
-              ((38,
+              ((44,
                 Effect
                   ([
                     (OCaml.Effect.State.state, Z);
@@ -1238,14 +1311,14 @@ Value
                     NonTermination
                   ], .)),
                 Apply
-                  ((38,
+                  ((44,
                     Effect ([ (OCaml.Effect.State.state, Z) ], .)),
                     Variable
-                      ((38, Effect ([ ], .)),
+                      ((44, Effect ([ ], .)),
                         OCaml.Pervasives.le),
                     [
                       Apply
-                        ((38,
+                        ((44,
                           Effect
                             ([
                               (OCaml.Effect.State.state,
@@ -1253,7 +1326,7 @@ Value
                             ],
                               .)),
                           Variable
-                            ((38,
+                            ((44,
                               Effect
                                 ([
                                 ],
@@ -1266,7 +1339,7 @@ Value
                               OCaml.Effect.State.read),
                           [
                             Variable
-                              ((38,
+                              ((44,
                                 Effect
                                   ([
                                   ],
@@ -1274,7 +1347,7 @@ Value
                                 i)
                           ]);
                       Apply
-                        ((38,
+                        ((44,
                           Effect
                             ([
                               (OCaml.Effect.State.state,
@@ -1282,7 +1355,7 @@ Value
                             ],
                               .)),
                           Variable
-                            ((38,
+                            ((44,
                               Effect
                                 ([
                                 ],
@@ -1295,7 +1368,7 @@ Value
                               OCaml.Effect.State.read),
                           [
                             Variable
-                              ((38,
+                              ((44,
                                 Effect
                                   ([
                                   ],
@@ -1304,7 +1377,7 @@ Value
                           ])
                     ]),
                 LetVar
-                  (39,
+                  (45,
                     Effect
                       ([
                         (OCaml.Effect.State.state, Z);
@@ -1312,11 +1385,11 @@ Value
                         NonTermination
                       ], .)) j =
                   Apply
-                    ((39,
+                    ((45,
                       Effect
                         ([ (OCaml.Effect.State.state, Z) ], .)),
                       Variable
-                        ((39,
+                        ((45,
                           Effect
                             ([ ],
                               .
@@ -1327,7 +1400,7 @@ Value
                           OCaml.Pervasives.ref),
                       [
                         Constant
-                          ((39,
+                          ((45,
                             Effect
                               ([
                               ],
@@ -1335,7 +1408,7 @@ Value
                             Int(0))
                       ]) in
                 Sequence
-                  ((40,
+                  ((46,
                     Effect
                       ([
                         (OCaml.Effect.State.state, Z);
@@ -1343,7 +1416,7 @@ Value
                         NonTermination
                       ], .)),
                     While
-                      ((40,
+                      ((46,
                         Effect
                           ([
                             (OCaml.Effect.State.state, Z);
@@ -1351,18 +1424,18 @@ Value
                             NonTermination
                           ], .)),
                         Apply
-                          ((40,
+                          ((46,
                             Effect
                               ([
                                 (OCaml.Effect.State.state,
                                   Z)
                               ], .)),
                             Variable
-                              ((40, Effect ([ ], .)),
+                              ((46, Effect ([ ], .)),
                                 OCaml.Pervasives.le),
                             [
                               Apply
-                                ((40,
+                                ((46,
                                   Effect
                                     ([
                                       (OCaml.Effect.State.state,
@@ -1370,7 +1443,7 @@ Value
                                     ],
                                       .)),
                                   Variable
-                                    ((40,
+                                    ((46,
                                       Effect
                                         ([
                                         ],
@@ -1383,7 +1456,7 @@ Value
                                       OCaml.Effect.State.read),
                                   [
                                     Variable
-                                      ((40,
+                                      ((46,
                                         Effect
                                           ([
                                           ],
@@ -1391,7 +1464,7 @@ Value
                                         j)
                                   ]);
                               Apply
-                                ((40,
+                                ((46,
                                   Effect
                                     ([
                                       (OCaml.Effect.State.state,
@@ -1399,7 +1472,7 @@ Value
                                     ],
                                       .)),
                                   Variable
-                                    ((40,
+                                    ((46,
                                       Effect
                                         ([
                                         ],
@@ -1412,7 +1485,7 @@ Value
                                       OCaml.Effect.State.read),
                                   [
                                     Variable
-                                      ((40,
+                                      ((46,
                                         Effect
                                           ([
                                           ],
@@ -1421,21 +1494,21 @@ Value
                                   ])
                             ]),
                         Sequence
-                          ((41,
+                          ((47,
                             Effect
                               ([
                                 (OCaml.Effect.State.state,
                                   Z)
                               ], .)),
                             Apply
-                              ((41,
+                              ((47,
                                 Effect
                                   ([
                                     (OCaml.Effect.State.state,
                                       Z)
                                   ], .)),
                                 Variable
-                                  ((41,
+                                  ((47,
                                     Effect
                                       ([ ],
                                         . ->
@@ -1448,14 +1521,14 @@ Value
                                     OCaml.Effect.State.write),
                                 [
                                   Variable
-                                    ((41,
+                                    ((47,
                                       Effect
                                         ([
                                         ],
                                           .)),
                                       z);
                                   Apply
-                                    ((41,
+                                    ((47,
                                       Effect
                                         ([
                                           (OCaml.Effect.State.state,
@@ -1463,7 +1536,7 @@ Value
                                         ],
                                           .)),
                                       Variable
-                                        ((41,
+                                        ((47,
                                           Effect
                                             ([
                                             ],
@@ -1471,7 +1544,7 @@ Value
                                           Z.add),
                                       [
                                         Apply
-                                          ((41,
+                                          ((47,
                                             Effect
                                               ([
                                                 (OCaml.Effect.State.state,
@@ -1479,7 +1552,7 @@ Value
                                               ],
                                                 .)),
                                             Variable
-                                              ((41,
+                                              ((47,
                                                 Effect
                                                   ([
                                                   ],
@@ -1492,7 +1565,7 @@ Value
                                                 OCaml.Effect.State.read),
                                             [
                                               Variable
-                                                ((41,
+                                                ((47,
                                                   Effect
                                                     ([
                                                     ],
@@ -1500,7 +1573,7 @@ Value
                                                   z)
                                             ]);
                                         Constant
-                                          ((41,
+                                          ((47,
                                             Effect
                                               ([
                                               ],
@@ -1509,14 +1582,14 @@ Value
                                       ])
                                 ]),
                             Apply
-                              ((42,
+                              ((48,
                                 Effect
                                   ([
                                     (OCaml.Effect.State.state,
                                       Z)
                                   ], .)),
                                 Variable
-                                  ((42,
+                                  ((48,
                                     Effect
                                       ([ ],
                                         . ->
@@ -1529,14 +1602,14 @@ Value
                                     OCaml.Effect.State.write),
                                 [
                                   Variable
-                                    ((42,
+                                    ((48,
                                       Effect
                                         ([
                                         ],
                                           .)),
                                       j);
                                   Apply
-                                    ((42,
+                                    ((48,
                                       Effect
                                         ([
                                           (OCaml.Effect.State.state,
@@ -1544,7 +1617,7 @@ Value
                                         ],
                                           .)),
                                       Variable
-                                        ((42,
+                                        ((48,
                                           Effect
                                             ([
                                             ],
@@ -1552,7 +1625,7 @@ Value
                                           Z.add),
                                       [
                                         Apply
-                                          ((42,
+                                          ((48,
                                             Effect
                                               ([
                                                 (OCaml.Effect.State.state,
@@ -1560,7 +1633,7 @@ Value
                                               ],
                                                 .)),
                                             Variable
-                                              ((42,
+                                              ((48,
                                                 Effect
                                                   ([
                                                   ],
@@ -1573,7 +1646,7 @@ Value
                                                 OCaml.Effect.State.read),
                                             [
                                               Variable
-                                                ((42,
+                                                ((48,
                                                   Effect
                                                     ([
                                                     ],
@@ -1581,7 +1654,7 @@ Value
                                                   j)
                                             ]);
                                         Constant
-                                          ((42,
+                                          ((48,
                                             Effect
                                               ([
                                               ],
@@ -1590,19 +1663,19 @@ Value
                                       ])
                                 ]))),
                     Sequence
-                      ((44,
+                      ((50,
                         Effect
                           ([ (OCaml.Effect.State.state, Z) ],
                             .)),
                         Apply
-                          ((44,
+                          ((50,
                             Effect
                               ([
                                 (OCaml.Effect.State.state,
                                   Z)
                               ], .)),
                             Variable
-                              ((44,
+                              ((50,
                                 Effect
                                   ([ ],
                                     . ->
@@ -1614,14 +1687,14 @@ Value
                                 OCaml.Effect.State.write),
                             [
                               Variable
-                                ((44,
+                                ((50,
                                   Effect
                                     ([
                                     ],
                                       .)),
                                   y);
                               Apply
-                                ((44,
+                                ((50,
                                   Effect
                                     ([
                                       (OCaml.Effect.State.state,
@@ -1629,7 +1702,7 @@ Value
                                     ],
                                       .)),
                                   Variable
-                                    ((44,
+                                    ((50,
                                       Effect
                                         ([
                                         ],
@@ -1637,7 +1710,7 @@ Value
                                       Z.sub),
                                   [
                                     Apply
-                                      ((44,
+                                      ((50,
                                         Effect
                                           ([
                                             (OCaml.Effect.State.state,
@@ -1645,7 +1718,7 @@ Value
                                           ],
                                             .)),
                                         Variable
-                                          ((44,
+                                          ((50,
                                             Effect
                                               ([
                                               ],
@@ -1658,7 +1731,7 @@ Value
                                             OCaml.Effect.State.read),
                                         [
                                           Variable
-                                            ((44,
+                                            ((50,
                                               Effect
                                                 ([
                                                 ],
@@ -1666,7 +1739,7 @@ Value
                                               y)
                                         ]);
                                     Constant
-                                      ((44,
+                                      ((50,
                                         Effect
                                           ([
                                           ],
@@ -1675,14 +1748,14 @@ Value
                                   ])
                             ]),
                         Apply
-                          ((45,
+                          ((51,
                             Effect
                               ([
                                 (OCaml.Effect.State.state,
                                   Z)
                               ], .)),
                             Variable
-                              ((45,
+                              ((51,
                                 Effect
                                   ([ ],
                                     . ->
@@ -1694,14 +1767,14 @@ Value
                                 OCaml.Effect.State.write),
                             [
                               Variable
-                                ((45,
+                                ((51,
                                   Effect
                                     ([
                                     ],
                                       .)),
                                   i);
                               Apply
-                                ((45,
+                                ((51,
                                   Effect
                                     ([
                                       (OCaml.Effect.State.state,
@@ -1709,7 +1782,7 @@ Value
                                     ],
                                       .)),
                                   Variable
-                                    ((45,
+                                    ((51,
                                       Effect
                                         ([
                                         ],
@@ -1717,7 +1790,7 @@ Value
                                       Z.add),
                                   [
                                     Apply
-                                      ((45,
+                                      ((51,
                                         Effect
                                           ([
                                             (OCaml.Effect.State.state,
@@ -1725,7 +1798,7 @@ Value
                                           ],
                                             .)),
                                         Variable
-                                          ((45,
+                                          ((51,
                                             Effect
                                               ([
                                               ],
@@ -1738,7 +1811,7 @@ Value
                                             OCaml.Effect.State.read),
                                         [
                                           Variable
-                                            ((45,
+                                            ((51,
                                               Effect
                                                 ([
                                                 ],
@@ -1746,7 +1819,7 @@ Value
                                               i)
                                         ]);
                                     Constant
-                                      ((45,
+                                      ((51,
                                         Effect
                                           ([
                                           ],
@@ -1755,12 +1828,12 @@ Value
                                   ])
                             ])))),
             Apply
-              ((47, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+              ((53, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
                 Variable
-                  ((47,
+                  ((53,
                     Effect
                       ([ ],
                         . -[ (OCaml.Effect.State.state, Z) ]->
                           .)), OCaml.Effect.State.read),
-                [ Variable ((47, Effect ([ ], .)), z) ])))
+                [ Variable ((53, Effect ([ ], .)), z) ])))
     ])

--- a/tests/ex43.exp
+++ b/tests/ex43.exp
@@ -406,200 +406,230 @@ Value
 Value
   (non_rec, @.,
     [
+      ((complex_raises, [ ], [ (b, Type (bool)) ], Type (unit)),
+        LetFun 35
+          (non_rec, @.,
+            [
+              ((f, [ A; B ], [ (a, A) ], (A * Type (Z) * B)),
+                Tuple
+                  (35, Variable (35, a),
+                    Constant
+                      (35,
+                        Int(15)),
+                    Apply
+                      (35,
+                        Variable
+                          (35,
+                            OCaml.Pervasives.failwith),
+                        [
+                          Constant
+                            (35,
+                              String("b is true"))
+                        ])))
+            ]) in
+        While
+          (36, Variable (36, b),
+            Apply (37, Variable (37, f), [ Constructor (37, true) ])))
+    ])
+
+40
+Value
+  (non_rec, @.,
+    [
       ((argument_effects, [ ],
         [ (x, Type (OCaml.Effect.State.t, Type (Z))); (y, Type (Z)) ],
         Type (Z)),
-        LetVar 35 y =
+        LetVar 41 y =
           Apply
-            (35, Variable (35, OCaml.Pervasives.ref), [ Variable (35, y) ])
+            (41, Variable (41, OCaml.Pervasives.ref), [ Variable (41, y) ])
           in
-        LetVar 36 z =
+        LetVar 42 z =
           Apply
-            (36, Variable (36, OCaml.Pervasives.ref),
-              [ Constant (36, Int(0)) ]) in
-        LetVar 37 i =
+            (42, Variable (42, OCaml.Pervasives.ref),
+              [ Constant (42, Int(0)) ]) in
+        LetVar 43 i =
           Apply
-            (37, Variable (37, OCaml.Pervasives.ref),
-              [ Constant (37, Int(0)) ]) in
+            (43, Variable (43, OCaml.Pervasives.ref),
+              [ Constant (43, Int(0)) ]) in
         Sequence
-          (38,
+          (44,
             While
-              (38,
+              (44,
                 Apply
-                  (38, Variable (38, OCaml.Pervasives.le),
+                  (44, Variable (44, OCaml.Pervasives.le),
                     [
                       Apply
-                        (38,
+                        (44,
                           Variable
-                            (38,
+                            (44,
                               OCaml.Effect.State.read),
                           [
                             Variable
-                              (38,
+                              (44,
                                 i)
                           ]);
                       Apply
-                        (38,
+                        (44,
                           Variable
-                            (38,
+                            (44,
                               OCaml.Effect.State.read),
                           [
                             Variable
-                              (38,
+                              (44,
                                 x)
                           ])
                     ]),
-                LetVar 39 j =
+                LetVar 45 j =
                   Apply
-                    (39, Variable (39, OCaml.Pervasives.ref),
-                      [ Constant (39, Int(0)) ]) in
+                    (45, Variable (45, OCaml.Pervasives.ref),
+                      [ Constant (45, Int(0)) ]) in
                 Sequence
-                  (40,
+                  (46,
                     While
-                      (40,
+                      (46,
                         Apply
-                          (40,
+                          (46,
                             Variable
-                              (40, OCaml.Pervasives.le),
+                              (46, OCaml.Pervasives.le),
                             [
                               Apply
-                                (40,
+                                (46,
                                   Variable
-                                    (40,
+                                    (46,
                                       OCaml.Effect.State.read),
                                   [
                                     Variable
-                                      (40,
+                                      (46,
                                         j)
                                   ]);
                               Apply
-                                (40,
+                                (46,
                                   Variable
-                                    (40,
+                                    (46,
                                       OCaml.Effect.State.read),
                                   [
                                     Variable
-                                      (40,
+                                      (46,
                                         y)
                                   ])
                             ]),
                         Sequence
-                          (41,
+                          (47,
                             Apply
-                              (41,
+                              (47,
                                 Variable
-                                  (41,
+                                  (47,
                                     OCaml.Effect.State.write),
                                 [
-                                  Variable (41, z);
+                                  Variable (47, z);
                                   Apply
-                                    (41,
+                                    (47,
                                       Variable
-                                        (41,
+                                        (47,
                                           Z.add),
                                       [
                                         Apply
-                                          (41,
+                                          (47,
                                             Variable
-                                              (41,
+                                              (47,
                                                 OCaml.Effect.State.read),
                                             [
                                               Variable
-                                                (41,
+                                                (47,
                                                   z)
                                             ]);
                                         Constant
-                                          (41,
+                                          (47,
                                             Int(1))
                                       ])
                                 ]),
                             Apply
-                              (42,
+                              (48,
                                 Variable
-                                  (42,
+                                  (48,
                                     OCaml.Effect.State.write),
                                 [
-                                  Variable (42, j);
+                                  Variable (48, j);
                                   Apply
-                                    (42,
+                                    (48,
                                       Variable
-                                        (42,
+                                        (48,
                                           Z.add),
                                       [
                                         Apply
-                                          (42,
+                                          (48,
                                             Variable
-                                              (42,
+                                              (48,
                                                 OCaml.Effect.State.read),
                                             [
                                               Variable
-                                                (42,
+                                                (48,
                                                   j)
                                             ]);
                                         Constant
-                                          (42,
+                                          (48,
                                             Int(1))
                                       ])
                                 ]))),
                     Sequence
-                      (44,
+                      (50,
                         Apply
-                          (44,
+                          (50,
                             Variable
-                              (44,
+                              (50,
                                 OCaml.Effect.State.write),
                             [
-                              Variable (44, y);
+                              Variable (50, y);
                               Apply
-                                (44,
+                                (50,
                                   Variable
-                                    (44,
+                                    (50,
                                       Z.sub),
                                   [
                                     Apply
-                                      (44,
+                                      (50,
                                         Variable
-                                          (44,
+                                          (50,
                                             OCaml.Effect.State.read),
                                         [
                                           Variable
-                                            (44,
+                                            (50,
                                               y)
                                         ]);
                                     Constant
-                                      (44,
+                                      (50,
                                         Int(1))
                                   ])
                             ]),
                         Apply
-                          (45,
+                          (51,
                             Variable
-                              (45,
+                              (51,
                                 OCaml.Effect.State.write),
                             [
-                              Variable (45, i);
+                              Variable (51, i);
                               Apply
-                                (45,
+                                (51,
                                   Variable
-                                    (45,
+                                    (51,
                                       Z.add),
                                   [
                                     Apply
-                                      (45,
+                                      (51,
                                         Variable
-                                          (45,
+                                          (51,
                                             OCaml.Effect.State.read),
                                         [
                                           Variable
-                                            (45,
+                                            (51,
                                               i)
                                         ]);
                                     Constant
-                                      (45,
+                                      (51,
                                         Int(1))
                                   ])
                             ])))),
             Apply
-              (47, Variable (47, OCaml.Effect.State.read),
-                [ Variable (47, z) ])))
+              (53, Variable (53, OCaml.Effect.State.read),
+                [ Variable (53, z) ])))
     ])

--- a/tests/ex43.interface
+++ b/tests/ex43.interface
@@ -29,6 +29,7 @@
         ]
       ],
       [ "Var", "raises", [ [ [ "Counter", "NonTermination", "OCaml.Failure" ] ] ] ],
+      [ "Var", "complex_raises", [ [ [ "Counter", "NonTermination", "OCaml.Failure" ] ] ] ],
       [
         "Var",
         "argument_effects",

--- a/tests/ex43.ml
+++ b/tests/ex43.ml
@@ -31,6 +31,12 @@ let raises (b : bool) : unit =
     failwith "b is true"
   done
 
+let complex_raises (b : bool) : unit =
+  let f a = (a, 15, failwith "b is true") in
+  while b do
+    f true
+  done
+
 let argument_effects (x : int ref) (y : int) =
   let y = ref y in
   let z = ref 0 in

--- a/tests/ex43.monadise
+++ b/tests/ex43.monadise
@@ -1345,6 +1345,170 @@ Value
 Value
   (non_rec, @.,
     [
+      ((complex_raises, [ ], [ (b, Type (bool)) ],
+        Monad ([ Counter; NonTermination; OCaml.Failure ], Type (unit))),
+        LetFun 35
+          (non_rec, @.,
+            [
+              ((f, [ A; B ], [ (a, A) ],
+                Monad
+                  ([ OCaml.Failure ],
+                    (A *
+                      Type
+                        (Z)
+                      *
+                      B))),
+                Bind
+                  (?,
+                    Apply
+                      (35,
+                        Variable
+                          (35,
+                            OCaml.Pervasives.failwith),
+                        [
+                          Constant
+                            (35,
+                              String("b is true"))
+                        ]),
+                    Some
+                      x,
+                    Return
+                      (?,
+                        Tuple
+                          (35,
+                            Variable
+                              (35,
+                                a),
+                            Constant
+                              (35,
+                                Int(15)),
+                            Variable
+                              (?,
+                                x)))))
+            ]) in
+        LetFun 36
+          (rec, @.,
+            [
+              ((while, [ ], [ (counter, Type (nat)) ],
+                Monad
+                  ([
+                    NonTermination;
+                    OCaml.Failure
+                  ], ())),
+                Match
+                  (?,
+                    Variable
+                      (?,
+                        counter),
+                    [
+                      (Constructor
+                        (O),
+                        Lift
+                          (?,
+                            [
+                              NonTermination
+                            ],
+                            [
+                              NonTermination;
+                              OCaml.Failure
+                            ],
+                            Apply
+                              (?,
+                                Variable
+                                  (?,
+                                    not_terminated),
+                                [
+                                  Constructor
+                                    (?,
+                                      tt)
+                                ])));
+                      (Constructor
+                        (S,
+                          counter),
+                        LetVar
+                          ?
+                          check
+                          =
+                          Variable
+                            (36,
+                              b)
+                          in
+                        IfThenElse
+                          (?,
+                            Variable
+                              (?,
+                                check),
+                            Bind
+                              (?,
+                                Lift
+                                  (?,
+                                    [
+                                      OCaml.Failure
+                                    ],
+                                    [
+                                      NonTermination;
+                                      OCaml.Failure
+                                    ],
+                                    Coerce
+                                      (?,
+                                        Apply
+                                          (37,
+                                            Variable
+                                              (37,
+                                                f),
+                                            [
+                                              Constructor
+                                                (37,
+                                                  true)
+                                            ]),
+                                        Monad
+                                          ([
+                                            OCaml.Failure
+                                          ],
+                                            (Type
+                                              (bool)
+                                              *
+                                              Type
+                                                (Z)
+                                              *
+                                              ())))),
+                                None,
+                                Apply
+                                  (?,
+                                    Variable
+                                      (?,
+                                        while),
+                                    [
+                                      Variable
+                                        (?,
+                                          counter)
+                                    ])),
+                            Return
+                              (?,
+                                Constructor
+                                  (?,
+                                    tt))))
+                    ]))
+            ]) in
+        Bind
+          (?,
+            Lift
+              (?, [ Counter ],
+                [ Counter; NonTermination; OCaml.Failure ],
+                Apply
+                  (?, Variable (?, read_counter),
+                    [ Constructor (?, tt) ])), Some counter,
+            Lift
+              (?, [ NonTermination; OCaml.Failure ],
+                [ Counter; NonTermination; OCaml.Failure ],
+                Apply
+                  (?, Variable (?, while), [ Variable (?, counter) ]))))
+    ])
+
+40
+Value
+  (non_rec, @.,
+    [
       ((argument_effects, [ ],
         [ (x, Type (OCaml.Effect.State.t, Type (Z))); (y, Type (Z)) ],
         Monad
@@ -1360,8 +1524,8 @@ Value
                   NonTermination
                 ],
                 Apply
-                  (35, Variable (35, OCaml.Pervasives.ref),
-                    [ Variable (35, y) ])), Some y,
+                  (41, Variable (41, OCaml.Pervasives.ref),
+                    [ Variable (41, y) ])), Some y,
             Bind
               (?,
                 Lift
@@ -1372,8 +1536,8 @@ Value
                       NonTermination
                     ],
                     Apply
-                      (36, Variable (36, OCaml.Pervasives.ref),
-                        [ Constant (36, Int(0)) ])), Some z,
+                      (42, Variable (42, OCaml.Pervasives.ref),
+                        [ Constant (42, Int(0)) ])), Some z,
                 Bind
                   (?,
                     Lift
@@ -1384,14 +1548,14 @@ Value
                           NonTermination
                         ],
                         Apply
-                          (37,
+                          (43,
                             Variable
-                              (37, OCaml.Pervasives.ref),
-                            [ Constant (37, Int(0)) ])),
+                              (43, OCaml.Pervasives.ref),
+                            [ Constant (43, Int(0)) ])),
                     Some i,
                     Bind
                       (?,
-                        LetFun 38
+                        LetFun 44
                           (rec, @.,
                             [
                               ((while, [ ],
@@ -1457,13 +1621,13 @@ Value
                                                 Bind
                                                   (?,
                                                     Apply
-                                                      (38,
+                                                      (44,
                                                         Variable
-                                                          (38,
+                                                          (44,
                                                             OCaml.Effect.State.read),
                                                         [
                                                           Variable
-                                                            (38,
+                                                            (44,
                                                               i)
                                                         ]),
                                                     Some
@@ -1471,13 +1635,13 @@ Value
                                                     Bind
                                                       (?,
                                                         Apply
-                                                          (38,
+                                                          (44,
                                                             Variable
-                                                              (38,
+                                                              (44,
                                                                 OCaml.Effect.State.read),
                                                             [
                                                               Variable
-                                                                (38,
+                                                                (44,
                                                                   x)
                                                             ]),
                                                         Some
@@ -1485,9 +1649,9 @@ Value
                                                         Return
                                                           (?,
                                                             Apply
-                                                              (38,
+                                                              (44,
                                                                 Variable
-                                                                  (38,
+                                                                  (44,
                                                                     OCaml.Pervasives.le),
                                                                 [
                                                                   Variable
@@ -1521,13 +1685,13 @@ Value
                                                               NonTermination
                                                             ],
                                                             Apply
-                                                              (39,
+                                                              (45,
                                                                 Variable
-                                                                  (39,
+                                                                  (45,
                                                                     OCaml.Pervasives.ref),
                                                                 [
                                                                   Constant
-                                                                    (39,
+                                                                    (45,
                                                                       Int(0))
                                                                 ])),
                                                         Some
@@ -1535,7 +1699,7 @@ Value
                                                         Bind
                                                           (?,
                                                             LetFun
-                                                              40
+                                                              46
                                                               (rec,
                                                                 @.,
                                                                 [
@@ -1601,13 +1765,13 @@ Value
                                                                                     Bind
                                                                                       (?,
                                                                                         Apply
-                                                                                          (40,
+                                                                                          (46,
                                                                                             Variable
-                                                                                              (40,
+                                                                                              (46,
                                                                                                 OCaml.Effect.State.read),
                                                                                             [
                                                                                               Variable
-                                                                                                (40,
+                                                                                                (46,
                                                                                                   j)
                                                                                             ]),
                                                                                         Some
@@ -1615,13 +1779,13 @@ Value
                                                                                         Bind
                                                                                           (?,
                                                                                             Apply
-                                                                                              (40,
+                                                                                              (46,
                                                                                                 Variable
-                                                                                                  (40,
+                                                                                                  (46,
                                                                                                     OCaml.Effect.State.read),
                                                                                                 [
                                                                                                   Variable
-                                                                                                    (40,
+                                                                                                    (46,
                                                                                                       y)
                                                                                                 ]),
                                                                                             Some
@@ -1629,9 +1793,9 @@ Value
                                                                                             Return
                                                                                               (?,
                                                                                                 Apply
-                                                                                                  (40,
+                                                                                                  (46,
                                                                                                     Variable
-                                                                                                      (40,
+                                                                                                      (46,
                                                                                                         OCaml.Pervasives.le),
                                                                                                     [
                                                                                                       Variable
@@ -1668,13 +1832,13 @@ Value
                                                                                                     Bind
                                                                                                       (?,
                                                                                                         Apply
-                                                                                                          (41,
+                                                                                                          (47,
                                                                                                             Variable
-                                                                                                              (41,
+                                                                                                              (47,
                                                                                                                 OCaml.Effect.State.read),
                                                                                                             [
                                                                                                               Variable
-                                                                                                                (41,
+                                                                                                                (47,
                                                                                                                   z)
                                                                                                             ]),
                                                                                                         Some
@@ -1682,28 +1846,28 @@ Value
                                                                                                         Return
                                                                                                           (?,
                                                                                                             Apply
-                                                                                                              (41,
+                                                                                                              (47,
                                                                                                                 Variable
-                                                                                                                  (41,
+                                                                                                                  (47,
                                                                                                                     Z.add),
                                                                                                                 [
                                                                                                                   Variable
                                                                                                                     (?,
                                                                                                                       x_1);
                                                                                                                   Constant
-                                                                                                                    (41,
+                                                                                                                    (47,
                                                                                                                       Int(1))
                                                                                                                 ]))),
                                                                                                     Some
                                                                                                       x_1,
                                                                                                     Apply
-                                                                                                      (41,
+                                                                                                      (47,
                                                                                                         Variable
-                                                                                                          (41,
+                                                                                                          (47,
                                                                                                             OCaml.Effect.State.write),
                                                                                                         [
                                                                                                           Variable
-                                                                                                            (41,
+                                                                                                            (47,
                                                                                                               z);
                                                                                                           Variable
                                                                                                             (?,
@@ -1715,13 +1879,13 @@ Value
                                                                                                     Bind
                                                                                                       (?,
                                                                                                         Apply
-                                                                                                          (42,
+                                                                                                          (48,
                                                                                                             Variable
-                                                                                                              (42,
+                                                                                                              (48,
                                                                                                                 OCaml.Effect.State.read),
                                                                                                             [
                                                                                                               Variable
-                                                                                                                (42,
+                                                                                                                (48,
                                                                                                                   j)
                                                                                                             ]),
                                                                                                         Some
@@ -1729,28 +1893,28 @@ Value
                                                                                                         Return
                                                                                                           (?,
                                                                                                             Apply
-                                                                                                              (42,
+                                                                                                              (48,
                                                                                                                 Variable
-                                                                                                                  (42,
+                                                                                                                  (48,
                                                                                                                     Z.add),
                                                                                                                 [
                                                                                                                   Variable
                                                                                                                     (?,
                                                                                                                       x_1);
                                                                                                                   Constant
-                                                                                                                    (42,
+                                                                                                                    (48,
                                                                                                                       Int(1))
                                                                                                                 ]))),
                                                                                                     Some
                                                                                                       x_1,
                                                                                                     Apply
-                                                                                                      (42,
+                                                                                                      (48,
                                                                                                         Variable
-                                                                                                          (42,
+                                                                                                          (48,
                                                                                                             OCaml.Effect.State.write),
                                                                                                         [
                                                                                                           Variable
-                                                                                                            (42,
+                                                                                                            (48,
                                                                                                               j);
                                                                                                           Variable
                                                                                                             (?,
@@ -1843,13 +2007,13 @@ Value
                                                                         Bind
                                                                           (?,
                                                                             Apply
-                                                                              (44,
+                                                                              (50,
                                                                                 Variable
-                                                                                  (44,
+                                                                                  (50,
                                                                                     OCaml.Effect.State.read),
                                                                                 [
                                                                                   Variable
-                                                                                    (44,
+                                                                                    (50,
                                                                                       y)
                                                                                 ]),
                                                                             Some
@@ -1857,28 +2021,28 @@ Value
                                                                             Return
                                                                               (?,
                                                                                 Apply
-                                                                                  (44,
+                                                                                  (50,
                                                                                     Variable
-                                                                                      (44,
+                                                                                      (50,
                                                                                         Z.sub),
                                                                                     [
                                                                                       Variable
                                                                                         (?,
                                                                                           x_1);
                                                                                       Constant
-                                                                                        (44,
+                                                                                        (50,
                                                                                           Int(1))
                                                                                     ]))),
                                                                         Some
                                                                           x_1,
                                                                         Apply
-                                                                          (44,
+                                                                          (50,
                                                                             Variable
-                                                                              (44,
+                                                                              (50,
                                                                                 OCaml.Effect.State.write),
                                                                             [
                                                                               Variable
-                                                                                (44,
+                                                                                (50,
                                                                                   y);
                                                                               Variable
                                                                                 (?,
@@ -1890,13 +2054,13 @@ Value
                                                                         Bind
                                                                           (?,
                                                                             Apply
-                                                                              (45,
+                                                                              (51,
                                                                                 Variable
-                                                                                  (45,
+                                                                                  (51,
                                                                                     OCaml.Effect.State.read),
                                                                                 [
                                                                                   Variable
-                                                                                    (45,
+                                                                                    (51,
                                                                                       i)
                                                                                 ]),
                                                                             Some
@@ -1904,28 +2068,28 @@ Value
                                                                             Return
                                                                               (?,
                                                                                 Apply
-                                                                                  (45,
+                                                                                  (51,
                                                                                     Variable
-                                                                                      (45,
+                                                                                      (51,
                                                                                         Z.add),
                                                                                     [
                                                                                       Variable
                                                                                         (?,
                                                                                           x_1);
                                                                                       Constant
-                                                                                        (45,
+                                                                                        (51,
                                                                                           Int(1))
                                                                                     ]))),
                                                                         Some
                                                                           x_1,
                                                                         Apply
-                                                                          (45,
+                                                                          (51,
                                                                             Variable
-                                                                              (45,
+                                                                              (51,
                                                                                 OCaml.Effect.State.write),
                                                                             [
                                                                               Variable
-                                                                                (45,
+                                                                                (51,
                                                                                   i);
                                                                               Variable
                                                                                 (?,
@@ -1990,9 +2154,9 @@ Value
                               NonTermination
                             ],
                             Apply
-                              (47,
+                              (53,
                                 Variable
-                                  (47,
+                                  (53,
                                     OCaml.Effect.State.read),
-                                [ Variable (47, z) ])))))))
+                                [ Variable (53, z) ])))))))
     ])

--- a/tests/ex43.v
+++ b/tests/ex43.v
@@ -170,6 +170,26 @@ Definition raises (b : bool)
   let! counter := lift [_;_;_] "100" (read_counter tt) in
   lift [_;_;_] "011" (while counter).
 
+Definition complex_raises (b : bool)
+  : M [ Counter; NonTermination; OCaml.Failure ] unit :=
+  let f {A B : Type} (a : A) : M [ OCaml.Failure ] (A * Z * B) :=
+    let! x := OCaml.Pervasives.failwith "b is true" % string in
+    ret (a, 15, x) in
+  let fix while (counter : nat) : M [ NonTermination; OCaml.Failure ] unit :=
+    match counter with
+    | O => lift [_;_] "10" (not_terminated tt)
+    | S counter =>
+      let check := b in
+      if check then
+        let! _ :=
+          lift [_;_] "01" ((f true) : M [ OCaml.Failure ] (bool * Z * unit)) in
+        while counter
+      else
+        ret tt
+    end in
+  let! counter := lift [_;_;_] "100" (read_counter tt) in
+  lift [_;_;_] "011" (while counter).
+
 Definition argument_effects (x : OCaml.Effect.State.t Z) (y : Z)
   : M [ OCaml.Effect.State.state Z; Counter; NonTermination ] Z :=
   let! y := lift [_;_;_] "100" (OCaml.Pervasives.ref y) in


### PR DESCRIPTION
This PR
* lets `for` loops have bodies of non-unit type
* add `unit` wherever there is an under-declared type in for/while loop bodies, using `Exp.t`'s `Coerce` to output it to Coq
* adds tests for the new behaviour, updates test output