### PR TITLE
Unify type and puretype

### DIFF
--- a/src/commonType.ml
+++ b/src/commonType.ml
@@ -1,0 +1,120 @@
+open SmartPrint
+open Yojson.Basic
+
+include Kerneltypes.Type
+type 'a t = 'a Kerneltypes.Type.t'
+
+let rec pp (pp_a : 'a -> SmartPrint.t) (typ : 'a t) : SmartPrint.t =
+  let pp = pp pp_a in
+  match typ with
+  | Variable x -> Name.pp x
+  | Arrow (typ1, typ2) -> nest @@ parens (pp typ1 ^^ !^ "->" ^^ pp typ2)
+  | Tuple typs -> nest @@ parens (separate (space ^^ !^ "*" ^^ space) (List.map pp typs))
+  | Apply (x, typs) ->
+    nest (!^ "Type" ^^ nest (parens (
+      separate (!^ "," ^^ space) (BoundName.pp x :: List.map pp typs))))
+  | Monad (d, typ) -> nest (!^ "Monad" ^^ OCaml.tuple [pp_a d; pp typ])
+
+let rec unify (typ1 : 'a t) (typ2 : 'b t) : 'b t Name.Map.t =
+  let union = Name.Map.union (fun _ typ _ -> Some typ) in
+  match typ1, typ2 with
+  | Monad (_, typ), _ -> unify typ typ2
+  | _, Monad (_, typ) -> unify typ1 typ
+  | Variable x, _ -> Name.Map.singleton x typ2
+  | Arrow (typ1a, typ1b), Arrow (typ2a, typ2b) ->
+    union (unify typ1a typ2a) (unify typ1b typ2b)
+  | Tuple typs1, Tuple typs2 ->
+    List.fold_left2 (fun var_map typ1 typ2 -> union var_map (unify typ1 typ2))
+      Name.Map.empty typs1 typs2
+  | Apply (x1, typs1), Apply (x2, typs2) ->
+    List.fold_left2 (fun var_map typ1 typ2 -> union var_map (unify typ1 typ2))
+      Name.Map.empty typs1 typs2
+  | _, _ -> failwith "Could not unify types"
+
+let rec strip_monads (typ : 'a t) : 'b t =
+  match typ with
+  | Variable x -> Variable x
+  | Arrow (typ1, typ2) -> Arrow (strip_monads typ1, strip_monads typ2)
+  | Tuple typs -> Tuple (List.map strip_monads typs)
+  | Apply (x, typs) -> Apply (x, List.map strip_monads typs)
+  | Monad (x, typ) -> strip_monads typ
+
+let rec map (f : BoundName.t -> BoundName.t) (typ : 'a t) : 'a t =
+  match typ with
+  | Variable x -> Variable x
+  | Arrow (typ_x, typ_y) -> Arrow (map f typ_x, map f typ_y)
+  | Tuple typs -> Tuple (List.map (map f) typs)
+  | Apply (path, typs) -> Apply (f path, List.map (map f) typs)
+  | Monad (x, typ) -> Monad (x, map f typ)
+
+let rec map_vars (f : Name.t -> 'a t) (typ : 'a t) : 'a t =
+  match typ with
+  | Variable x -> f x
+  | Arrow (typ1, typ2) -> Arrow (map_vars f typ1, map_vars f typ2)
+  | Tuple typs -> Tuple (List.map (map_vars f) typs)
+  | Apply (x, typs) -> Apply (x, List.map (map_vars f) typs)
+  | Monad (x, typ) -> Monad (x, map_vars f typ)
+
+let rec has_vars (typ : 'a t) : bool =
+  match typ with
+  | Variable _ -> true
+  | Arrow (typ_x, typ_y) -> has_vars typ_x || has_vars typ_y
+  | Tuple typs -> List.exists has_vars typs
+  | Apply (_, typs) -> List.exists has_vars typs
+  | Monad (x, typ) -> has_vars typ
+
+let rec typ_args (typ : 'a t) : Name.Set.t =
+  match typ with
+  | Variable x -> Name.Set.singleton x
+  | Arrow (typ1, typ2) -> typ_args_of_typs [typ1; typ2]
+  | Tuple typs | Apply (_, typs) -> typ_args_of_typs typs
+  | Monad (_, typ) -> typ_args typ
+
+and typ_args_of_typs (typs : 'a t list) : Name.Set.t =
+  List.fold_left (fun args typ -> Name.Set.union args (typ_args typ))
+    Name.Set.empty typs
+
+let rec to_json (a_to_json : 'a -> json) (typ : 'a t) : json =
+  let to_json = to_json a_to_json in
+  match typ with
+  | Variable x -> `List [`String "Variable"; Name.to_json x]
+  | Arrow (typ_x, typ_y) ->
+    `List [`String "Arrow"; to_json typ_x; to_json typ_y]
+  | Tuple typs -> `List (`String "Tuple" :: List.map to_json typs)
+  | Apply (path, typs) ->
+    `List (`String "Apply" :: BoundName.to_json path :: List.map to_json typs)
+  | Monad (descriptor, typ) ->
+    `List [`String "Monad"; a_to_json descriptor; to_json typ]
+
+let rec of_json (a_of_json : json -> 'a) (json : json) : 'a t =
+  let of_json = of_json a_of_json in
+  match json with
+  | `List [`String "Variable"; x] -> Variable (Name.of_json x)
+  | `List [`String "Arrow"; typ_x; typ_y] ->
+    Arrow (of_json typ_x, of_json typ_y)
+  | `List (`String "Tuple" :: typs) -> Tuple (List.map of_json typs)
+  | `List (`String "Apply" :: path :: typs) ->
+    Apply (BoundName.of_json path, List.map of_json typs)
+  | `List [`String "Monad"; descriptor; typ] ->
+    Monad (a_of_json descriptor, of_json typ)
+  | _ -> failwith "Invalid JSON for Type."
+
+(** Pretty-print a type (inside parenthesis if the [paren] flag is set). *)
+let rec to_coq (a_to_coq : 'a -> SmartPrint.t) (paren : bool) (typ : 'a t)
+  : SmartPrint.t =
+  let to_coq = to_coq a_to_coq in
+  match typ with
+  | Variable x -> Name.to_coq x
+  | Arrow (typ_x, typ_y) ->
+    Pp.parens paren @@ nest (to_coq true typ_x ^^ !^ "->" ^^ to_coq false typ_y)
+  | Tuple typs ->
+    (match typs with
+    | [] -> !^ "unit"
+    | _ ->
+      Pp.parens paren @@ nest @@ separate (space ^^ !^ "*" ^^ space)
+        (List.map (to_coq true) typs))
+  | Apply (path, typs) ->
+    Pp.parens (paren && typs <> []) @@ nest @@ separate space
+      (BoundName.to_coq path :: List.map (to_coq true) typs)
+  | Monad (d, typ) ->
+    Pp.parens paren @@ nest (!^ "M" ^^ a_to_coq d ^^ to_coq true typ)

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -6,7 +6,7 @@ module Value = struct
   type 'a t =
     | Variable of 'a
     | Function of 'a * Effect.PureType.t
-    | Type of Kerneltypes.TypeDefinition.t
+    | Type of Effect.Descriptor.t Kerneltypes.TypeDefinition.t'
     | Descriptor
     | Exception of PathName.t
     | Constructor of PathName.t * int
@@ -346,12 +346,12 @@ module Typ = ValueCarrier(struct
   let assoc (x : PathName.t) (y : PathName.t) (m : Mod.t) : Mod.t =
     { m with Mod.typs = PathName.Map.add x y m.Mod.typs }
 
-  type 'a t = Kerneltypes.TypeDefinition.t
-  type 'a t' = Kerneltypes.TypeDefinition.t
+  type 'a t = Effect.Descriptor.t Kerneltypes.TypeDefinition.t'
+  type 'a t' = Effect.Descriptor.t Kerneltypes.TypeDefinition.t'
 
-  let value (def : Kerneltypes.TypeDefinition.t) : 'a Value.t = Type def
+  let value (def : 'a t) : 'a Value.t = Type def
 
-  let unpack (v : 'a Value.t) : Kerneltypes.TypeDefinition.t =
+  let unpack (v : 'a Value.t) : 'a t' =
     match v with
     | Type def -> def
     | _ -> failwith @@ "Could not interpret " ^ Value.to_string v ^ " as a type."

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -5,7 +5,7 @@ open Utils
 module Value = struct
   type 'a t =
     | Variable of 'a
-    | Function of 'a * Effect.PureType.t
+    | Function of 'a * Effect.Descriptor.t Kerneltypes.Type.t'
     | Type of Effect.Descriptor.t Kerneltypes.TypeDefinition.t'
     | Descriptor
     | Exception of PathName.t
@@ -327,12 +327,12 @@ module Function = ValueCarrier(struct
   let assoc (x : PathName.t) (y : PathName.t) (m : Mod.t) : Mod.t =
     { m with Mod.vars = PathName.Map.add x y m.Mod.vars }
 
-  type 'a t = 'a * Effect.PureType.t
-  type 'a t' = Effect.PureType.t option
+  type 'a t = 'a * Effect.Descriptor.t Kerneltypes.Type.t'
+  type 'a t' = Effect.Descriptor.t Kerneltypes.Type.t' option
 
-  let value ((v, typ) : 'a * Effect.PureType.t) : 'a Value.t = Function (v, typ)
+  let value ((v, typ) : 'a t) : 'a Value.t = Function (v, typ)
 
-  let unpack (v : 'a Value.t) : Effect.PureType.t option =
+  let unpack (v : 'a Value.t) : 'a t' =
     match v with
     | Variable _ -> None
     | Function (_, typ) -> Some typ

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -2,6 +2,37 @@ open SmartPrint
 open Kerneltypes
 open Utils
 
+module Value = struct
+  type 'a t =
+    | Variable of 'a
+    | Function of 'a * Effect.PureType.t
+    | Type of Kerneltypes.TypeDefinition.t
+    | Descriptor
+    | Exception of PathName.t
+    | Constructor of PathName.t * int
+    | Field of PathName.t * int
+
+  let map (f : 'a -> 'b) (v : 'a t) : 'b t =
+    match v with
+    | Variable a -> Variable (f a)
+    | Function (a, typ) -> Function (f a, typ)
+    | Type def -> Type def
+    | Descriptor -> Descriptor
+    | Exception raise_name -> Exception raise_name
+    | Constructor (typ, index) -> Constructor (typ, index)
+    | Field (typ, index) -> Field (typ, index)
+
+  let to_string (v : 'a t) : string =
+    match v with
+    | Variable _ -> "variable"
+    | Function _ -> "function"
+    | Type _ -> "type"
+    | Descriptor -> "descriptor"
+    | Exception _ -> "exception"
+    | Constructor _ -> "constructor"
+    | Field _ -> "field"
+end
+
 type 'a t = {
   values : 'a Value.t PathName.Map.t;
   modules : Mod.t PathName.Map.t;

--- a/src/kerneltypes.ml
+++ b/src/kerneltypes.ml
@@ -1,16 +1,16 @@
 module Type = struct
-  type t =
+  type 'a t' =
     | Variable of Name.t
-    | Arrow of t * t
-    | Tuple of t list
-    | Apply of BoundName.t * t list
-    | Monad of Effect.Descriptor.t * t
+    | Arrow of 'a t' * 'a t'
+    | Tuple of 'a t' list
+    | Apply of BoundName.t * 'a t' list
+    | Monad of 'a * 'a t'
 end
 
 module TypeDefinition = struct
-  type t =
-    | Inductive of CoqName.t * Name.t list * (CoqName.t * Type.t list) list
-    | Record of CoqName.t * Name.t list * (CoqName.t * Type.t) list
-    | Synonym of CoqName.t * Name.t list * Type.t
+  type 'a t' =
+    | Inductive of CoqName.t * Name.t list * (CoqName.t * 'a Type.t' list) list
+    | Record of CoqName.t * Name.t list * (CoqName.t * 'a Type.t') list
+    | Synonym of CoqName.t * Name.t list * 'a Type.t'
     | Abstract of CoqName.t * Name.t list
 end

--- a/src/kerneltypes.ml
+++ b/src/kerneltypes.ml
@@ -14,34 +14,3 @@ module TypeDefinition = struct
     | Synonym of CoqName.t * Name.t list * Type.t
     | Abstract of CoqName.t * Name.t list
 end
-
-module Value = struct
-  type 'a t =
-    | Variable of 'a
-    | Function of 'a * Effect.PureType.t
-    | Type of TypeDefinition.t
-    | Descriptor
-    | Exception of PathName.t
-    | Constructor of PathName.t * int
-    | Field of PathName.t * int
-
-  let map (f : 'a -> 'b) (v : 'a t) : 'b t =
-    match v with
-    | Variable a -> Variable (f a)
-    | Function (a, typ) -> Function (f a, typ)
-    | Type def -> Type def
-    | Descriptor -> Descriptor
-    | Exception raise_name -> Exception raise_name
-    | Constructor (typ, index) -> Constructor (typ, index)
-    | Field (typ, index) -> Field (typ, index)
-
-  let to_string (v : 'a t) : string =
-    match v with
-    | Variable _ -> "variable"
-    | Function _ -> "function"
-    | Type _ -> "type"
-    | Descriptor -> "descriptor"
-    | Exception _ -> "exception"
-    | Constructor _ -> "constructor"
-    | Field _ -> "field"
-end

--- a/src/mod.ml
+++ b/src/mod.ml
@@ -1,7 +1,5 @@
 open Utils
 open SmartPrint
-open Kerneltypes
-open Value
 
 type t = {
   name : CoqName.t option;

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -19,11 +19,11 @@ let env_with_effects (interfaces : (Name.t * string) list)
     Effect.Descriptor.singleton
       (bound_name ["OCaml"; "Effect"; "State"] ["Effect"; "State"] "state")
       [Effect.PureType.Variable i] in
-  let state_type (x : int) : Effect.PureType.t =
+  let state_type (x : int) : Type.t =
     let i = string_of_int x in
-    Effect.PureType.Apply
+    Type.Apply
       (bound_name ["OCaml"; "Effect"; "State"] ["Effect"; "State"] "state",
-      [Effect.PureType.Variable i]) in
+      [Type.Variable i]) in
   let add_exn path base = add_exception_with_effects path base in
   let arrow x y = Effect.eff (Arrow (x, y)) in
   let pure = Effect.pure in
@@ -128,8 +128,7 @@ let env_with_effects (interfaces : (Name.t * string) list)
   |> Var.add ["Effect"; "State"] "global" pure
   |> Function.add ["Effect"; "State"] "read"
     (arrow (typ_d 0) Pure,
-    Effect.PureType.Arrow
-      (state_type 0, Effect.PureType.Variable "0"))
+    Type.Arrow (state_type 0, Type.Variable "0"))
   |> Function.add ["Effect"; "State"] "write"
     (arrow (d []) (Arrow (typ_d 0, Pure)),
     Effect.PureType.Arrow

--- a/src/type.ml
+++ b/src/type.ml
@@ -4,6 +4,7 @@ open SmartPrint
 open Yojson.Basic
 
 include Kerneltypes.Type
+type t = Effect.Descriptor.t t'
 
 let rec pp (typ : t) : SmartPrint.t =
   match typ with

--- a/src/type.ml
+++ b/src/type.ml
@@ -6,16 +6,7 @@ open Yojson.Basic
 include Kerneltypes.Type
 type t = Effect.Descriptor.t t'
 
-let rec pp (typ : t) : SmartPrint.t =
-  match typ with
-  | Variable x -> Name.pp x
-  | Arrow (typ1, typ2) -> nest @@ parens (pp typ1 ^^ !^ "->" ^^ pp typ2)
-  | Tuple typs -> nest @@ parens (separate (space ^^ !^ "*" ^^ space) (List.map pp typs))
-  | Apply (x, typs) ->
-    nest (!^ "Type" ^^ nest (parens (
-      separate (!^ "," ^^ space) (BoundName.pp x :: List.map pp typs))))
-  | Monad (d, typ) -> nest (!^ "Monad" ^^ OCaml.tuple [
-    Effect.Descriptor.pp d; pp typ])
+let pp (typ : t) : SmartPrint.t = CommonType.pp Effect.Descriptor.pp typ
 
 (** Import an OCaml type. Add to the environment all the new free type variables. *)
 let rec of_type_expr_new_typ_vars (env : 'a FullEnvi.t) (loc : Loc.t)
@@ -96,61 +87,19 @@ let is_function (typ : t) : bool =
   | Arrow _ -> true
   | _ -> false
 
-let rec pure_type (typ : t) : Effect.PureType.t =
-  match typ with
-  | Variable x -> Effect.PureType.Variable x
-  | Arrow (typ1, typ2) ->
-    Effect.PureType.Arrow (pure_type typ1, pure_type typ2)
-  | Tuple typs -> Effect.PureType.Tuple (List.map pure_type typs)
-  | Apply (x, typs) -> Effect.PureType.Apply (x, List.map pure_type typs)
-  | Monad (x, typ) -> pure_type typ
+let pure_type (typ : t) : Effect.PureType.t = CommonType.strip_monads typ
 
-let rec of_pure_type (typ : Effect.PureType.t) : t =
-  match typ with
-  | Effect.PureType.Variable x -> Variable x
-  | Effect.PureType.Arrow (typ1, typ2) ->
-    Arrow (of_pure_type typ1, of_pure_type typ2)
-  | Effect.PureType.Tuple typs -> Tuple (List.map of_pure_type typs)
-  | Effect.PureType.Apply (x, typs) -> Apply (x, List.map of_pure_type typs)
+let of_pure_type (typ : t) : Effect.PureType.t = CommonType.strip_monads typ
 
-let rec unify (typ1 : t) (typ2 : t) : t Name.Map.t =
-  let union = Name.Map.union (fun _ typ _ -> Some typ) in
-  match typ1, typ2 with
-  | Variable x, _ -> Name.Map.singleton x typ2
-  | Monad (_, typ), _ -> unify typ typ2
-  | _, Monad (_, typ) -> unify typ1 typ
-  | Arrow (typ1a, typ1b), Arrow (typ2a, typ2b) ->
-    union (unify typ1a typ2a) (unify typ1b typ2b)
-  | Tuple typs1, Tuple typs2 ->
-    List.fold_left2 (fun var_map typ1 typ2 -> union var_map (unify typ1 typ2))
-      Name.Map.empty typs1 typs2
-  | Apply (x1, typs1), Apply (x2, typs2) ->
-    List.fold_left2 (fun var_map typ1 typ2 -> union var_map (unify typ1 typ2))
-      Name.Map.empty typs1 typs2
-  | _, _ -> failwith "Could not unify types"
+let unify (typ1 : t) (typ2 : t) : t Name.Map.t = CommonType.unify typ1 typ2
 
 let unify_pure (ptyp : Effect.PureType.t) (typ : t)
   : Effect.PureType.t Name.Map.t =
-  Name.Map.map pure_type (unify (of_pure_type ptyp) typ)
+  Name.Map.map pure_type (CommonType.unify ptyp typ)
 
-let rec map_vars (f : Name.t -> t) (typ : t) : t =
-  match typ with
-  | Variable x -> f x
-  | Arrow (typ1, typ2) -> Arrow (map_vars f typ1, map_vars f typ2)
-  | Tuple typs -> Tuple (List.map (map_vars f) typs)
-  | Apply (x, typs) -> Apply (x, List.map (map_vars f) typs)
-  | Monad (x, typ) -> Monad (x, map_vars f typ)
+let map_vars (f : Name.t -> t) (typ : t) : t = CommonType.map_vars f typ
 
-let rec typ_args (typ : t) : Name.Set.t =
-  match typ with
-  | Variable x -> Name.Set.singleton x
-  | Arrow (typ1, typ2) -> typ_args_of_typs [typ1; typ2]
-  | Tuple typs | Apply (_, typs) -> typ_args_of_typs typs
-  | Monad (_, typ) -> typ_args typ
-
-and typ_args_of_typs (typs : t list) : Name.Set.t =
-  List.fold_left (fun args typ -> Name.Set.union args (typ_args typ))
-    Name.Set.empty typs
+let typ_args (typ : t) : Name.Set.t = CommonType.typ_args typ
 
 (** In a function's type extract the body's type (up to [n] arguments). *)
 let rec open_type (typ : t) (n : int) : t list * t =
@@ -185,28 +134,10 @@ let allocate_implicits_for_monad (implicit_args : (CoqName.t * 'a) list)
       (implicit_args, Monad (d, typ))
   | _ -> (implicit_args, typ)
 
-let rec to_json (typ : t) : json =
-  match typ with
-  | Variable x -> `List [`String "Variable"; Name.to_json x]
-  | Arrow (typ_x, typ_y) ->
-    `List [`String "Arrow"; to_json typ_x; to_json typ_y]
-  | Tuple typs -> `List (`String "Tuple" :: List.map to_json typs)
-  | Apply (path, typs) ->
-    `List (`String "Apply" :: BoundName.to_json path :: List.map to_json typs)
-  | Monad (descriptor, typ) ->
-    `List [`String "Monad"; Effect.Descriptor.to_json descriptor; to_json typ]
+let to_json (typ : t) : json = CommonType.to_json Effect.Descriptor.to_json typ
 
-let rec of_json (json : json) : t =
-  match json with
-  | `List [`String "Variable"; x] -> Variable (Name.of_json x)
-  | `List [`String "Arrow"; typ_x; typ_y] ->
-    Arrow (of_json typ_x, of_json typ_y)
-  | `List (`String "Tuple" :: typs) -> Tuple (List.map of_json typs)
-  | `List (`String "Apply" :: path :: typs) ->
-    Apply (BoundName.of_json path, List.map of_json typs)
-  | `List [`String "Monad"; descriptor; typ] ->
-    Monad (Effect.Descriptor.of_json descriptor, of_json typ)
-  | _ -> failwith "Invalid JSON for Type."
+let of_json (json : json) : t =
+  CommonType.of_json Effect.Descriptor.of_json json
 
 let monadise (typ : t) (effect : Effect.t) : t =
   let rec aux (typ : t) (effect_typ : Effect.Type.t) : t =
@@ -228,21 +159,5 @@ let monadise (typ : t) (effect : Effect.t) : t =
   else
     Monad (effect.Effect.descriptor, typ)
 
-(** Pretty-print a type (inside parenthesis if the [paren] flag is set). *)
-let rec to_coq (paren : bool) (typ : t) : SmartPrint.t =
-  match typ with
-  | Variable x -> Name.to_coq x
-  | Arrow (typ_x, typ_y) ->
-    Pp.parens paren @@ nest (to_coq true typ_x ^^ !^ "->" ^^ to_coq false typ_y)
-  | Tuple typs ->
-    (match typs with
-    | [] -> !^ "unit"
-    | _ ->
-      Pp.parens paren @@ nest @@ separate (space ^^ !^ "*" ^^ space)
-        (List.map (to_coq true) typs))
-  | Apply (path, typs) ->
-    Pp.parens (paren && typs <> []) @@ nest @@ separate space
-      (BoundName.to_coq path :: List.map (to_coq true) typs)
-  | Monad (d, typ) ->
-    Pp.parens paren @@ nest (
-      !^ "M" ^^ Effect.Descriptor.to_coq d ^^ to_coq true typ)
+let to_coq (paren : bool) (typ : t) : SmartPrint.t =
+  CommonType.to_coq Effect.Descriptor.to_coq paren typ

--- a/src/typeDefinition.ml
+++ b/src/typeDefinition.ml
@@ -5,6 +5,7 @@ open Yojson.Basic
 open Utils
 
 include Kerneltypes.TypeDefinition
+type t = Effect.Descriptor.t t'
 
 let pp (def : t) : SmartPrint.t =
   match def with

--- a/tests/ex18.effects
+++ b/tests/ex18.effects
@@ -6,7 +6,9 @@ Value
     [
       ((plus_one, [ A ], [ (x, A) ], Type (Z)),
         Match
-          ((?, Effect ([ (OCaml.Effect.State.state, Z); r_state ], .)),
+          ((?,
+            Effect
+              ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -14,8 +16,10 @@ Value
                   ((4,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          Z);
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z));
                         r_state
                       ],
                         .)),
@@ -31,8 +35,10 @@ Value
                         ((4,
                           Effect
                             ([
-                              (OCaml.Effect.State.state,
-                                Z);
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z));
                               r_state
                             ],
                               .)),
@@ -43,8 +49,10 @@ Value
                                 ],
                                   .
                                     -[
-                                      (OCaml.Effect.State.state,
-                                        Z)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z))
                                     ]->
                                     .)),
                               OCaml.Effect.State.read),
@@ -53,8 +61,10 @@ Value
                               ((4,
                                 Effect
                                   ([
-                                    (OCaml.Effect.State.state,
-                                      Z);
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (Z));
                                     r_state
                                   ],
                                     .)),
@@ -84,7 +94,7 @@ Value
           ((?,
             Effect
               ([
-                (OCaml.Effect.State.state, string);
+                Type (OCaml.Effect.State.state, Type (string));
                 s_state;
                 OCaml.Failure
               ], .)), Variable ((?, Effect ([ ], .)), x),
@@ -94,8 +104,10 @@ Value
                   ((8,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          string);
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (string));
                         s_state;
                         OCaml.Failure
                       ],
@@ -116,8 +128,10 @@ Value
                         ((8,
                           Effect
                             ([
-                              (OCaml.Effect.State.state,
-                                string);
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (string));
                               s_state
                             ],
                               .)),
@@ -128,8 +142,10 @@ Value
                                 ],
                                   .
                                     -[
-                                      (OCaml.Effect.State.state,
-                                        string)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (string))
                                     ]->
                                     .)),
                               OCaml.Effect.State.read),
@@ -138,8 +154,10 @@ Value
                               ((8,
                                 Effect
                                   ([
-                                    (OCaml.Effect.State.state,
-                                      string);
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (string));
                                     s_state
                                   ],
                                     .)),
@@ -155,7 +173,9 @@ Value
     [
       ((reset, [ A ], [ (x, A) ], Type (unit)),
         Match
-          ((?, Effect ([ (OCaml.Effect.State.state, Z); r_state ], .)),
+          ((?,
+            Effect
+              ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -163,8 +183,10 @@ Value
                   ((11,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          Z);
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z));
                         r_state
                       ],
                         .)),
@@ -177,8 +199,10 @@ Value
                               ->
                               .
                                 -[
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ]->
                                 .)),
                         OCaml.Effect.State.write),
@@ -187,8 +211,10 @@ Value
                         ((11,
                           Effect
                             ([
-                              (OCaml.Effect.State.state,
-                                Z);
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z));
                               r_state
                             ],
                               .)),
@@ -210,7 +236,9 @@ Value
     [
       ((incr, [ A ], [ (x, A) ], Type (unit)),
         Match
-          ((?, Effect ([ (OCaml.Effect.State.state, Z); r_state ], .)),
+          ((?,
+            Effect
+              ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -218,8 +246,10 @@ Value
                   ((14,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          Z);
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z));
                         r_state
                       ],
                         .)),
@@ -232,8 +262,10 @@ Value
                               ->
                               .
                                 -[
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ]->
                                 .)),
                         OCaml.Effect.State.write),
@@ -242,8 +274,10 @@ Value
                         ((14,
                           Effect
                             ([
-                              (OCaml.Effect.State.state,
-                                Z);
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z));
                               r_state
                             ],
                               .)),
@@ -252,8 +286,10 @@ Value
                         ((14,
                           Effect
                             ([
-                              (OCaml.Effect.State.state,
-                                Z);
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z));
                               r_state
                             ],
                               .)),
@@ -269,8 +305,10 @@ Value
                               ((14,
                                 Effect
                                   ([
-                                    (OCaml.Effect.State.state,
-                                      Z);
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (Z));
                                     r_state
                                   ],
                                     .)),
@@ -281,8 +319,10 @@ Value
                                       ],
                                         .
                                           -[
-                                            (OCaml.Effect.State.state,
-                                              Z)
+                                            Type
+                                              (OCaml.Effect.State.state,
+                                                Type
+                                                  (Z))
                                           ]->
                                           .)),
                                     OCaml.Effect.State.read),
@@ -291,8 +331,10 @@ Value
                                     ((14,
                                       Effect
                                         ([
-                                          (OCaml.Effect.State.state,
-                                            Z);
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (Z));
                                           r_state
                                         ],
                                           .)),

--- a/tests/ex18.monadise
+++ b/tests/ex18.monadise
@@ -5,7 +5,8 @@ Value
   (non_rec, @.,
     [
       ((plus_one, [ A ], [ (x, A) ],
-        Monad ([ (OCaml.Effect.State.state, Z); r_state ], Type (Z))),
+        Monad
+          ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], Type (Z))),
         Match
           (?, Variable (?, x),
             [
@@ -22,12 +23,16 @@ Value
                         Lift
                           (?,
                             [
-                              (OCaml.Effect.State.state,
-                                Z)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z))
                             ],
                             [
-                              (OCaml.Effect.State.state,
-                                Z);
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z));
                               r_state
                             ],
                             Apply
@@ -68,7 +73,11 @@ Value
     [
       ((fail, [ A; B ], [ (x, A) ],
         Monad
-          ([ (OCaml.Effect.State.state, string); s_state; OCaml.Failure ], B)),
+          ([
+            Type (OCaml.Effect.State.state, Type (string));
+            s_state;
+            OCaml.Failure
+          ], B)),
         Match
           (?, Variable (?, x),
             [
@@ -78,13 +87,17 @@ Value
                     Lift
                       (?,
                         [
-                          (OCaml.Effect.State.state,
-                            string);
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (string));
                           s_state
                         ],
                         [
-                          (OCaml.Effect.State.state,
-                            string);
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (string));
                           s_state;
                           OCaml.Failure
                         ],
@@ -98,12 +111,16 @@ Value
                             Lift
                               (?,
                                 [
-                                  (OCaml.Effect.State.state,
-                                    string)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (string))
                                 ],
                                 [
-                                  (OCaml.Effect.State.state,
-                                    string);
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (string));
                                   s_state
                                 ],
                                 Apply
@@ -124,8 +141,10 @@ Value
                           OCaml.Failure
                         ],
                         [
-                          (OCaml.Effect.State.state,
-                            string);
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (string));
                           s_state;
                           OCaml.Failure
                         ],
@@ -147,7 +166,9 @@ Value
   (non_rec, @.,
     [
       ((reset, [ A ], [ (x, A) ],
-        Monad ([ (OCaml.Effect.State.state, Z); r_state ], Type (unit))),
+        Monad
+          ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ],
+            Type (unit))),
         Match
           (?, Variable (?, x),
             [
@@ -159,12 +180,16 @@ Value
                     Lift
                       (?,
                         [
-                          (OCaml.Effect.State.state,
-                            Z)
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
                         ],
                         [
-                          (OCaml.Effect.State.state,
-                            Z);
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z));
                           r_state
                         ],
                         Apply
@@ -188,7 +213,9 @@ Value
   (non_rec, @.,
     [
       ((incr, [ A ], [ (x, A) ],
-        Monad ([ (OCaml.Effect.State.state, Z); r_state ], Type (unit))),
+        Monad
+          ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ],
+            Type (unit))),
         Match
           (?, Variable (?, x),
             [
@@ -211,12 +238,16 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      (OCaml.Effect.State.state,
-                                        Z)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z))
                                     ],
                                     [
-                                      (OCaml.Effect.State.state,
-                                        Z);
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z));
                                       r_state
                                     ],
                                     Apply
@@ -251,12 +282,16 @@ Value
                         Lift
                           (?,
                             [
-                              (OCaml.Effect.State.state,
-                                Z)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z))
                             ],
                             [
-                              (OCaml.Effect.State.state,
-                                Z);
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z));
                               r_state
                             ],
                             Apply

--- a/tests/ex39.effects
+++ b/tests/ex39.effects
@@ -5,21 +5,35 @@ Value
   (non_rec, @.,
     [
       ((get_local_ref, [ ], [ (tt (= tt_1), Type (unit)) ], Type (Z)),
-        LetVar (4, Effect ([ (OCaml.Effect.State.state, Z) ], .)) x =
+        LetVar (4, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .))
+          x =
           Apply
-            ((4, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+            ((4, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
               Variable
                 ((4,
                   Effect
-                    ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
-                  OCaml.Pervasives.ref),
+                    ([ ],
+                      .
+                        -[
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
+                        ]-> .)), OCaml.Pervasives.ref),
               [ Constant ((4, Effect ([ ], .)), Int(12)) ]) in
         Apply
-          ((5, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+          ((5, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
             Variable
               ((5,
-                Effect ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
-                OCaml.Effect.State.read),
+                Effect
+                  ([ ],
+                    .
+                      -[
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
+                      ]-> .)), OCaml.Effect.State.read),
             [ Variable ((5, Effect ([ ], .)), x) ]))
     ])
 
@@ -28,19 +42,28 @@ Value
   (non_rec, @.,
     [
       ((set_local_ref, [ ], [ (tt (= tt_1), Type (unit)) ], Type (Z)),
-        LetVar (8, Effect ([ (OCaml.Effect.State.state, Z) ], .)) x =
+        LetVar (8, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .))
+          x =
           Apply
-            ((8, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+            ((8, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
               Variable
                 ((8,
                   Effect
-                    ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
-                  OCaml.Pervasives.ref),
+                    ([ ],
+                      .
+                        -[
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
+                        ]-> .)), OCaml.Pervasives.ref),
               [ Constant ((8, Effect ([ ], .)), Int(12)) ]) in
         Sequence
-          ((9, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+          ((9, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
             Apply
-              ((9, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+              ((9,
+                Effect
+                  ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
                 Variable
                   ((9,
                     Effect
@@ -48,8 +71,10 @@ Value
                         . ->
                           .
                             -[
-                              (OCaml.Effect.State.state,
-                                Z)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z))
                             ]-> .)),
                     OCaml.Effect.State.write),
                 [
@@ -57,13 +82,20 @@ Value
                   Constant ((9, Effect ([ ], .)), Int(15))
                 ]),
             Apply
-              ((10, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+              ((10,
+                Effect
+                  ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
                 Variable
                   ((10,
                     Effect
                       ([ ],
-                        . -[ (OCaml.Effect.State.state, Z) ]->
-                          .)), OCaml.Effect.State.read),
+                        .
+                          -[
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (Z))
+                          ]-> .)), OCaml.Effect.State.read),
                 [ Variable ((10, Effect ([ ], .)), x) ])))
     ])
 
@@ -74,19 +106,29 @@ Value
       ((add_multiple_by_refs, [ ],
         [ (a, Type (Z)); (b, Type (Z)); (c, Type (Z)); (d, Type (Z)) ],
         Type (Z)),
-        LetVar (13, Effect ([ (OCaml.Effect.State.state, Z) ], .)) x =
+        LetVar (13, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .))
+          x =
           Apply
-            ((13, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+            ((13,
+              Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
               Variable
                 ((13,
                   Effect
-                    ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
-                  OCaml.Pervasives.ref),
+                    ([ ],
+                      .
+                        -[
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
+                        ]-> .)), OCaml.Pervasives.ref),
               [ Variable ((13, Effect ([ ], .)), a) ]) in
         Sequence
-          ((14, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+          ((14, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
             Apply
-              ((14, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+              ((14,
+                Effect
+                  ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
                 Variable
                   ((14,
                     Effect
@@ -94,8 +136,10 @@ Value
                         . ->
                           .
                             -[
-                              (OCaml.Effect.State.state,
-                                Z)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z))
                             ]-> .)),
                     OCaml.Effect.State.write),
                 [
@@ -104,8 +148,10 @@ Value
                     ((14,
                       Effect
                         ([
-                          (OCaml.Effect.State.state,
-                            Z)
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
                         ],
                           .)),
                       Variable
@@ -120,8 +166,10 @@ Value
                           ((14,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  Z)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z))
                               ],
                                 .)),
                             Variable
@@ -131,8 +179,10 @@ Value
                                   ],
                                     .
                                       -[
-                                        (OCaml.Effect.State.state,
-                                          Z)
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (Z))
                                       ]->
                                       .)),
                                 OCaml.Effect.State.read),
@@ -154,24 +204,41 @@ Value
                             b)
                       ])
                 ]),
-            LetVar (15, Effect ([ (OCaml.Effect.State.state, Z) ], .)) y =
+            LetVar
+              (15,
+                Effect
+                  ([ Type (OCaml.Effect.State.state, Type (Z)) ], .))
+              y =
               Apply
-                ((15, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+                ((15,
+                  Effect
+                    ([ Type (OCaml.Effect.State.state, Type (Z)) ],
+                      .)),
                   Variable
                     ((15,
                       Effect
                         ([ ],
                           .
                             -[
-                              (OCaml.Effect.State.state,
-                                Z)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z))
                             ]-> .)), OCaml.Pervasives.ref),
                   [ Variable ((15, Effect ([ ], .)), c) ]) in
             Sequence
-              ((16, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+              ((16,
+                Effect
+                  ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
                 Apply
                   ((16,
-                    Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+                    Effect
+                      ([
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
+                      ], .)),
                     Variable
                       ((16,
                         Effect
@@ -179,8 +246,10 @@ Value
                             . ->
                               .
                                 -[
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ]-> .)),
                         OCaml.Effect.State.write),
                     [
@@ -189,8 +258,10 @@ Value
                         ((16,
                           Effect
                             ([
-                              (OCaml.Effect.State.state,
-                                Z)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z))
                             ],
                               .)),
                           Variable
@@ -205,8 +276,10 @@ Value
                               ((16,
                                 Effect
                                   ([
-                                    (OCaml.Effect.State.state,
-                                      Z)
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (Z))
                                   ],
                                     .)),
                                 Variable
@@ -216,8 +289,10 @@ Value
                                       ],
                                         .
                                           -[
-                                            (OCaml.Effect.State.state,
-                                              Z)
+                                            Type
+                                              (OCaml.Effect.State.state,
+                                                Type
+                                                  (Z))
                                           ]->
                                           .)),
                                     OCaml.Effect.State.read),
@@ -240,20 +315,33 @@ Value
                           ])
                     ]),
                 LetVar
-                  (17, Effect ([ (OCaml.Effect.State.state, Z) ], .))
-                  z =
+                  (17,
+                    Effect
+                      ([
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
+                      ], .)) z =
                   Apply
                     ((17,
                       Effect
-                        ([ (OCaml.Effect.State.state, Z) ], .)),
+                        ([
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
+                        ], .)),
                       Variable
                         ((17,
                           Effect
                             ([ ],
                               .
                                 -[
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ]-> .)),
                           OCaml.Pervasives.ref),
                       [
@@ -261,8 +349,10 @@ Value
                           ((17,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  Z)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z))
                               ],
                                 .)),
                             Variable
@@ -277,8 +367,10 @@ Value
                                 ((17,
                                   Effect
                                     ([
-                                      (OCaml.Effect.State.state,
-                                        Z)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z))
                                     ],
                                       .)),
                                   Variable
@@ -288,8 +380,10 @@ Value
                                         ],
                                           .
                                             -[
-                                              (OCaml.Effect.State.state,
-                                                Z)
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (Z))
                                             ]->
                                             .)),
                                       OCaml.Effect.State.read),
@@ -306,8 +400,10 @@ Value
                                 ((17,
                                   Effect
                                     ([
-                                      (OCaml.Effect.State.state,
-                                        Z)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z))
                                     ],
                                       .)),
                                   Variable
@@ -317,8 +413,10 @@ Value
                                         ],
                                           .
                                             -[
-                                              (OCaml.Effect.State.state,
-                                                Z)
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (Z))
                                             ]->
                                             .)),
                                       OCaml.Effect.State.read),
@@ -335,15 +433,23 @@ Value
                       ]) in
                 Apply
                   ((18,
-                    Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+                    Effect
+                      ([
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
+                      ], .)),
                     Variable
                       ((18,
                         Effect
                           ([ ],
                             .
                               -[
-                                (OCaml.Effect.State.state,
-                                  Z)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z))
                               ]-> .)),
                         OCaml.Effect.State.read),
                     [ Variable ((18, Effect ([ ], .)), z) ]))))
@@ -356,13 +462,19 @@ Value
       ((set_ref, [ ], [ (x, Type (OCaml.Effect.State.t, Type (Z))) ],
         Type (unit)),
         Apply
-          ((21, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+          ((21, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
             Variable
               ((21,
                 Effect
                   ([ ],
-                    . -> . -[ (OCaml.Effect.State.state, Z) ]-> .)),
-                OCaml.Effect.State.write),
+                    . ->
+                      .
+                        -[
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
+                        ]-> .)), OCaml.Effect.State.write),
             [
               Variable ((21, Effect ([ ], .)), x);
               Constant ((21, Effect ([ ], .)), Int(15))
@@ -375,11 +487,18 @@ Value
     [
       ((get_ref, [ ], [ (x, Type (OCaml.Effect.State.t, Type (Z))) ], Type (Z)),
         Apply
-          ((24, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+          ((24, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
             Variable
               ((24,
-                Effect ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
-                OCaml.Effect.State.read),
+                Effect
+                  ([ ],
+                    .
+                      -[
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
+                      ]-> .)), OCaml.Effect.State.read),
             [ Variable ((24, Effect ([ ], .)), x) ]))
     ])
 
@@ -390,21 +509,29 @@ Value
       ((update_ref, [ ], [ (x, Type (OCaml.Effect.State.t, Type (Z))) ],
         Type (unit)),
         Apply
-          ((27, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+          ((27, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
             Variable
               ((27,
                 Effect
                   ([ ],
-                    . -> . -[ (OCaml.Effect.State.state, Z) ]-> .)),
-                OCaml.Effect.State.write),
+                    . ->
+                      .
+                        -[
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
+                        ]-> .)), OCaml.Effect.State.write),
             [
               Variable ((27, Effect ([ ], .)), x);
               Apply
                 ((27,
                   Effect
                     ([
-                      (OCaml.Effect.State.state,
-                        Z)
+                      Type
+                        (OCaml.Effect.State.state,
+                          Type
+                            (Z))
                     ], .)),
                   Variable
                     ((27,
@@ -418,8 +545,10 @@ Value
                       ((27,
                         Effect
                           ([
-                            (OCaml.Effect.State.state,
-                              Z)
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (Z))
                           ],
                             .)),
                         Variable
@@ -429,8 +558,10 @@ Value
                               ],
                                 .
                                   -[
-                                    (OCaml.Effect.State.state,
-                                      Z)
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (Z))
                                   ]->
                                   .)),
                             OCaml.Effect.State.read),
@@ -461,11 +592,18 @@ Value
       ((new_ref, [ ], [ (x, Type (unit)) ],
         Type (OCaml.Effect.State.t, Type (Z))),
         Apply
-          ((30, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+          ((30, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
             Variable
               ((30,
-                Effect ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
-                OCaml.Pervasives.ref),
+                Effect
+                  ([ ],
+                    .
+                      -[
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
+                      ]-> .)), OCaml.Pervasives.ref),
             [ Constant ((30, Effect ([ ], .)), Int(15)) ]))
     ])
 
@@ -477,18 +615,29 @@ Value
     [
       ((set_r, [ ], [ (x, Type (unit)) ], Type (unit)),
         Apply
-          ((34, Effect ([ (OCaml.Effect.State.state, Z); r_state ], .)),
+          ((34,
+            Effect
+              ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], .)),
             Variable
               ((34,
-                Effect ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
-                set_ref),
+                Effect
+                  ([ ],
+                    .
+                      -[
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
+                      ]-> .)), set_ref),
             [
               Variable
                 ((34,
                   Effect
                     ([
-                      (OCaml.Effect.State.state,
-                        Z);
+                      Type
+                        (OCaml.Effect.State.state,
+                          Type
+                            (Z));
                       r_state
                     ], .)),
                   r)
@@ -501,18 +650,29 @@ Value
     [
       ((get_r, [ ], [ (x, Type (unit)) ], Type (Z)),
         Apply
-          ((36, Effect ([ (OCaml.Effect.State.state, Z); r_state ], .)),
+          ((36,
+            Effect
+              ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], .)),
             Variable
               ((36,
-                Effect ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
-                get_ref),
+                Effect
+                  ([ ],
+                    .
+                      -[
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
+                      ]-> .)), get_ref),
             [
               Variable
                 ((36,
                   Effect
                     ([
-                      (OCaml.Effect.State.state,
-                        Z);
+                      Type
+                        (OCaml.Effect.State.state,
+                          Type
+                            (Z));
                       r_state
                     ], .)),
                   r)
@@ -524,62 +684,97 @@ Value
   (non_rec, @.,
     [
       ((r_add_15, [ ], [ (x, Type (unit)) ], Type (Z)),
-        LetVar (39, Effect ([ (OCaml.Effect.State.state, Z); r_state ], .)) i
-          =
+        LetVar
+          (39,
+            Effect
+              ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], .))
+          i =
           Apply
-            ((39, Effect ([ (OCaml.Effect.State.state, Z); r_state ], .)),
+            ((39,
+              Effect
+                ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ],
+                  .)),
               Variable
                 ((39,
                   Effect
                     ([ ],
                       .
                         -[
-                          (OCaml.Effect.State.state, Z);
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z));
                           r_state
                         ]-> .)), get_r),
               [ Constructor ((39, Effect ([ ], .)), tt) ]) in
         Sequence
-          ((40, Effect ([ (OCaml.Effect.State.state, Z); r_state ], .)),
+          ((40,
+            Effect
+              ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], .)),
             Apply
               ((40,
-                Effect ([ (OCaml.Effect.State.state, Z); r_state ], .)),
+                Effect
+                  ([
+                    Type (OCaml.Effect.State.state, Type (Z));
+                    r_state
+                  ], .)),
                 Variable
                   ((40,
                     Effect
                       ([ ],
                         .
                           -[
-                            (OCaml.Effect.State.state, Z);
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (Z));
                             r_state
                           ]-> .)), set_r),
                 [ Constructor ((40, Effect ([ ], .)), tt) ]),
             LetVar
               (41,
-                Effect ([ (OCaml.Effect.State.state, Z); r_state ], .))
-              j =
+                Effect
+                  ([
+                    Type (OCaml.Effect.State.state, Type (Z));
+                    r_state
+                  ], .)) j =
               Apply
                 ((41,
                   Effect
-                    ([ (OCaml.Effect.State.state, Z); r_state ], .)),
+                    ([
+                      Type (OCaml.Effect.State.state, Type (Z));
+                      r_state
+                    ], .)),
                   Variable
                     ((41,
                       Effect
                         ([ ],
                           .
                             -[
-                              (OCaml.Effect.State.state,
-                                Z);
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z));
                               r_state
                             ]-> .)), get_r),
                   [ Constructor ((41, Effect ([ ], .)), tt) ]) in
             Sequence
               ((42,
-                Effect ([ (OCaml.Effect.State.state, Z); r_state ], .)),
+                Effect
+                  ([
+                    Type (OCaml.Effect.State.state, Type (Z));
+                    r_state
+                  ], .)),
                 Apply
                   ((42,
                     Effect
-                      ([ (OCaml.Effect.State.state, Z); r_state ],
-                        .)),
+                      ([
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z));
+                        r_state
+                      ], .)),
                     Variable
                       ((42,
                         Effect
@@ -587,8 +782,10 @@ Value
                             . ->
                               .
                                 -[
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ]-> .)),
                         OCaml.Effect.State.write),
                     [
@@ -596,8 +793,10 @@ Value
                         ((42,
                           Effect
                             ([
-                              (OCaml.Effect.State.state,
-                                Z);
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z));
                               r_state
                             ],
                               .)),
@@ -635,16 +834,23 @@ Value
                 Apply
                   ((43,
                     Effect
-                      ([ (OCaml.Effect.State.state, Z); r_state ],
-                        .)),
+                      ([
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z));
+                        r_state
+                      ], .)),
                     Variable
                       ((43,
                         Effect
                           ([ ],
                             .
                               -[
-                                (OCaml.Effect.State.state,
-                                  Z)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z))
                               ]-> .)),
                         OCaml.Effect.State.read),
                     [
@@ -652,8 +858,10 @@ Value
                         ((43,
                           Effect
                             ([
-                              (OCaml.Effect.State.state,
-                                Z);
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z));
                               r_state
                             ],
                               .)),
@@ -671,46 +879,59 @@ Value
           (46,
             Effect
               ([
-                (OCaml.Effect.State.state, Z);
-                (OCaml.Effect.State.state, bool);
-                (OCaml.Effect.State.state, string);
+                Type (OCaml.Effect.State.state, Type (Z));
+                Type (OCaml.Effect.State.state, Type (bool));
+                Type (OCaml.Effect.State.state, Type (string));
                 r_state
               ], .)) b =
           Apply
-            ((46, Effect ([ (OCaml.Effect.State.state, bool) ], .)),
+            ((46,
+              Effect
+                ([ Type (OCaml.Effect.State.state, Type (bool)) ], .)),
               Variable
                 ((46,
                   Effect
                     ([ ],
-                      . -[ (OCaml.Effect.State.state, bool) ]->
-                        .)), OCaml.Pervasives.ref),
+                      .
+                        -[
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (bool))
+                        ]-> .)), OCaml.Pervasives.ref),
               [ Constructor ((46, Effect ([ ], .)), true) ]) in
         LetVar
           (47,
             Effect
               ([
-                (OCaml.Effect.State.state, Z);
-                (OCaml.Effect.State.state, bool);
-                (OCaml.Effect.State.state, string);
+                Type (OCaml.Effect.State.state, Type (Z));
+                Type (OCaml.Effect.State.state, Type (bool));
+                Type (OCaml.Effect.State.state, Type (string));
                 r_state
               ], .)) str =
           Apply
-            ((47, Effect ([ (OCaml.Effect.State.state, string) ], .)),
+            ((47,
+              Effect
+                ([ Type (OCaml.Effect.State.state, Type (string)) ], .)),
               Variable
                 ((47,
                   Effect
                     ([ ],
                       .
-                        -[ (OCaml.Effect.State.state, string) ]->
-                        .)), OCaml.Pervasives.ref),
+                        -[
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (string))
+                        ]-> .)), OCaml.Pervasives.ref),
               [ Constant ((47, Effect ([ ], .)), String("")) ]) in
         LetFun
           (48,
             Effect
               ([
-                (OCaml.Effect.State.state, Z);
-                (OCaml.Effect.State.state, bool);
-                (OCaml.Effect.State.state, string);
+                Type (OCaml.Effect.State.state, Type (Z));
+                Type (OCaml.Effect.State.state, Type (bool));
+                Type (OCaml.Effect.State.state, Type (string));
                 r_state
               ], .))
           (non_rec, @.,
@@ -720,10 +941,14 @@ Value
                   ((?,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          bool);
-                        (OCaml.Effect.State.state,
-                          string)
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (bool));
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (string))
                       ],
                         .)),
                     Variable
@@ -740,18 +965,24 @@ Value
                           ((49,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  bool);
-                                (OCaml.Effect.State.state,
-                                  string)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (bool));
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (string))
                               ],
                                 .)),
                             Apply
                               ((49,
                                 Effect
                                   ([
-                                    (OCaml.Effect.State.state,
-                                      bool)
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (bool))
                                   ],
                                     .)),
                                 Variable
@@ -763,8 +994,10 @@ Value
                                           ->
                                           .
                                             -[
-                                              (OCaml.Effect.State.state,
-                                                bool)
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (bool))
                                             ]->
                                             .)),
                                     OCaml.Effect.State.write),
@@ -780,8 +1013,10 @@ Value
                                     ((49,
                                       Effect
                                         ([
-                                          (OCaml.Effect.State.state,
-                                            bool)
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (bool))
                                         ],
                                           .)),
                                       Variable
@@ -791,8 +1026,10 @@ Value
                                             ],
                                               .
                                                 -[
-                                                  (OCaml.Effect.State.state,
-                                                    bool)
+                                                  Type
+                                                    (OCaml.Effect.State.state,
+                                                      Type
+                                                        (bool))
                                                 ]->
                                                 .)),
                                           OCaml.Effect.State.read),
@@ -810,8 +1047,10 @@ Value
                               ((50,
                                 Effect
                                   ([
-                                    (OCaml.Effect.State.state,
-                                      string)
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (string))
                                   ],
                                     .)),
                                 Variable
@@ -823,8 +1062,10 @@ Value
                                           ->
                                           .
                                             -[
-                                              (OCaml.Effect.State.state,
-                                                string)
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (string))
                                             ]->
                                             .)),
                                     OCaml.Effect.State.write),
@@ -840,8 +1081,10 @@ Value
                                     ((50,
                                       Effect
                                         ([
-                                          (OCaml.Effect.State.state,
-                                            string)
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (string))
                                         ],
                                           .)),
                                       Variable
@@ -863,8 +1106,10 @@ Value
                                           ((50,
                                             Effect
                                               ([
-                                                (OCaml.Effect.State.state,
-                                                  string)
+                                                Type
+                                                  (OCaml.Effect.State.state,
+                                                    Type
+                                                      (string))
                                               ],
                                                 .)),
                                             Variable
@@ -874,8 +1119,10 @@ Value
                                                   ],
                                                     .
                                                       -[
-                                                        (OCaml.Effect.State.state,
-                                                          string)
+                                                        Type
+                                                          (OCaml.Effect.State.state,
+                                                            Type
+                                                              (string))
                                                       ]->
                                                       .)),
                                                 OCaml.Effect.State.read),
@@ -896,17 +1143,17 @@ Value
           ((51,
             Effect
               ([
-                (OCaml.Effect.State.state, Z);
-                (OCaml.Effect.State.state, bool);
-                (OCaml.Effect.State.state, string);
+                Type (OCaml.Effect.State.state, Type (Z));
+                Type (OCaml.Effect.State.state, Type (bool));
+                Type (OCaml.Effect.State.state, Type (string));
                 r_state
               ], .)),
             Apply
               ((51,
                 Effect
                   ([
-                    (OCaml.Effect.State.state, bool);
-                    (OCaml.Effect.State.state, string)
+                    Type (OCaml.Effect.State.state, Type (bool));
+                    Type (OCaml.Effect.State.state, Type (string))
                   ], .)),
                 Variable
                   ((51,
@@ -914,27 +1161,37 @@ Value
                       ([ ],
                         .
                           -[
-                            (OCaml.Effect.State.state,
-                              bool);
-                            (OCaml.Effect.State.state,
-                              string)
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (bool));
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (string))
                           ]-> .)), update),
                 [ Constructor ((51, Effect ([ ], .)), tt) ]),
             Sequence
               ((52,
                 Effect
                   ([
-                    (OCaml.Effect.State.state, Z);
-                    (OCaml.Effect.State.state, bool);
-                    (OCaml.Effect.State.state, string);
+                    Type (OCaml.Effect.State.state, Type (Z));
+                    Type (OCaml.Effect.State.state, Type (bool));
+                    Type (OCaml.Effect.State.state, Type (string));
                     r_state
                   ], .)),
                 Apply
                   ((52,
                     Effect
                       ([
-                        (OCaml.Effect.State.state, bool);
-                        (OCaml.Effect.State.state, string)
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (bool));
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (string))
                       ], .)),
                     Variable
                       ((52,
@@ -942,29 +1199,46 @@ Value
                           ([ ],
                             .
                               -[
-                                (OCaml.Effect.State.state,
-                                  bool);
-                                (OCaml.Effect.State.state,
-                                  string)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (bool));
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (string))
                               ]-> .)), update),
                     [ Constructor ((52, Effect ([ ], .)), tt) ]),
                 Sequence
                   ((53,
                     Effect
                       ([
-                        (OCaml.Effect.State.state, Z);
-                        (OCaml.Effect.State.state, bool);
-                        (OCaml.Effect.State.state, string);
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z));
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (bool));
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (string));
                         r_state
                       ], .)),
                     Apply
                       ((53,
                         Effect
                           ([
-                            (OCaml.Effect.State.state,
-                              bool);
-                            (OCaml.Effect.State.state,
-                              string)
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (bool));
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (string))
                           ], .)),
                         Variable
                           ((53,
@@ -972,10 +1246,14 @@ Value
                               ([ ],
                                 .
                                   -[
-                                    (OCaml.Effect.State.state,
-                                      bool);
-                                    (OCaml.Effect.State.state,
-                                      string)
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (bool));
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (string))
                                   ]-> .)), update),
                         [
                           Constructor
@@ -990,19 +1268,28 @@ Value
                       ((54,
                         Effect
                           ([
-                            (OCaml.Effect.State.state, Z);
-                            (OCaml.Effect.State.state,
-                              bool);
-                            (OCaml.Effect.State.state,
-                              string);
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (Z));
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (bool));
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (string));
                             r_state
                           ], .)),
                         Apply
                           ((54,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  bool)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (bool))
                               ], .)),
                             Variable
                               ((54,
@@ -1010,8 +1297,10 @@ Value
                                   ([ ],
                                     .
                                       -[
-                                        (OCaml.Effect.State.state,
-                                          bool)
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (bool))
                                       ]-> .)),
                                 OCaml.Effect.State.read),
                             [
@@ -1027,8 +1316,10 @@ Value
                           ((54,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  string)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (string))
                               ], .)),
                             Variable
                               ((54,
@@ -1036,8 +1327,10 @@ Value
                                   ([ ],
                                     .
                                       -[
-                                        (OCaml.Effect.State.state,
-                                          string)
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (string))
                                       ]-> .)),
                                 OCaml.Effect.State.read),
                             [
@@ -1053,8 +1346,10 @@ Value
                           ((54,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  Z);
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z));
                                 r_state
                               ], .)),
                             Variable
@@ -1063,8 +1358,10 @@ Value
                                   ([ ],
                                     .
                                       -[
-                                        (OCaml.Effect.State.state,
-                                          Z)
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (Z))
                                       ]-> .)),
                                 OCaml.Effect.State.read),
                             [
@@ -1072,8 +1369,10 @@ Value
                                 ((54,
                                   Effect
                                     ([
-                                      (OCaml.Effect.State.state,
-                                        Z);
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z));
                                       r_state
                                     ],
                                       .)),
@@ -1091,8 +1390,8 @@ Value
           ((?,
             Effect
               ([
-                (OCaml.Effect.State.state, Z);
-                (OCaml.Effect.State.state, (list, Z));
+                Type (OCaml.Effect.State.state, Type (Z));
+                Type (OCaml.Effect.State.state, Type (list, Type (Z)));
                 r_state
               ], .)), Variable ((?, Effect ([ ], .)), x),
             [
@@ -1101,11 +1400,16 @@ Value
                   (57,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          Z);
-                        (OCaml.Effect.State.state,
-                          (list,
-                            Z));
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z));
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (list,
+                                Type
+                                  (Z)));
                         r_state
                       ],
                         .))
@@ -1132,16 +1436,20 @@ Value
                           ((58,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  Z)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z))
                               ],
                                 .)),
                             Apply
                               ((58,
                                 Effect
                                   ([
-                                    (OCaml.Effect.State.state,
-                                      Z)
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (Z))
                                   ],
                                     .)),
                                 Variable
@@ -1153,8 +1461,10 @@ Value
                                           ->
                                           .
                                             -[
-                                              (OCaml.Effect.State.state,
-                                                Z)
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (Z))
                                             ]->
                                             .)),
                                     OCaml.Effect.State.write),
@@ -1187,11 +1497,16 @@ Value
                   (60,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          Z);
-                        (OCaml.Effect.State.state,
-                          (list,
-                            Z));
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z));
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (list,
+                                Type
+                                  (Z)));
                         r_state
                       ],
                         .))
@@ -1200,14 +1515,18 @@ Value
                     ((60,
                       Effect
                         ([
-                          (OCaml.Effect.State.state,
-                            Z);
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z));
                           r_state
                         ],
                           .
                             -[
-                              (OCaml.Effect.State.state,
-                                Z)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z))
                             ]->
                             .)),
                       Variable
@@ -1219,8 +1538,10 @@ Value
                                 ->
                                 .
                                   -[
-                                    (OCaml.Effect.State.state,
-                                      Z)
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (Z))
                                   ]->
                                   .)),
                           f1),
@@ -1229,8 +1550,10 @@ Value
                           ((60,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  Z);
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z));
                                 r_state
                               ],
                                 .)),
@@ -1241,11 +1564,16 @@ Value
                   (61,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          Z);
-                        (OCaml.Effect.State.state,
-                          (list,
-                            Z))
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z));
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (list,
+                                Type
+                                  (Z)))
                       ],
                         .))
                   f1_test =
@@ -1253,8 +1581,10 @@ Value
                     ((61,
                       Effect
                         ([
-                          (OCaml.Effect.State.state,
-                            Z)
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
                         ],
                           .)),
                       Variable
@@ -1264,8 +1594,10 @@ Value
                             ],
                               .
                                 -[
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ]->
                                 .)),
                           f1_test),
@@ -1283,11 +1615,16 @@ Value
                   (62,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          Z);
-                        (OCaml.Effect.State.state,
-                          (list,
-                            Z))
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z));
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (list,
+                                Type
+                                  (Z)))
                       ],
                         .))
                   (non_rec, @.,
@@ -1317,11 +1654,16 @@ Value
                           ((63,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  Z);
-                                (OCaml.Effect.State.state,
-                                  (list,
-                                    Z))
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z));
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (list,
+                                        Type
+                                          (Z)))
                               ],
                                 .)),
                             Variable
@@ -1331,8 +1673,10 @@ Value
                                   ],
                                     .
                                       -[
-                                        (OCaml.Effect.State.state,
-                                          Z)
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (Z))
                                       ]->
                                       .)),
                                 OCaml.Pervasives.ref),
@@ -1341,9 +1685,12 @@ Value
                                 ((63,
                                   Effect
                                     ([
-                                      (OCaml.Effect.State.state,
-                                        (list,
-                                          Z))
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (list,
+                                              Type
+                                                (Z)))
                                     ],
                                       .)),
                                   Variable
@@ -1358,9 +1705,12 @@ Value
                                       ((63,
                                         Effect
                                           ([
-                                            (OCaml.Effect.State.state,
-                                              (list,
-                                                Z))
+                                            Type
+                                              (OCaml.Effect.State.state,
+                                                Type
+                                                  (list,
+                                                    Type
+                                                      (Z)))
                                           ],
                                             .)),
                                         Variable
@@ -1375,9 +1725,12 @@ Value
                                             ((63,
                                               Effect
                                                 ([
-                                                  (OCaml.Effect.State.state,
-                                                    (list,
-                                                      Z))
+                                                  Type
+                                                    (OCaml.Effect.State.state,
+                                                      Type
+                                                        (list,
+                                                          Type
+                                                            (Z)))
                                                 ],
                                                   .)),
                                               Variable
@@ -1387,9 +1740,12 @@ Value
                                                     ],
                                                       .
                                                         -[
-                                                          (OCaml.Effect.State.state,
-                                                            (list,
-                                                              Z))
+                                                          Type
+                                                            (OCaml.Effect.State.state,
+                                                              Type
+                                                                (list,
+                                                                  Type
+                                                                    (Z)))
                                                         ]->
                                                         .)),
                                                   OCaml.Effect.State.read),
@@ -1433,11 +1789,16 @@ Value
                   (64,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          Z);
-                        (OCaml.Effect.State.state,
-                          (list,
-                            Z))
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z));
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (list,
+                                Type
+                                  (Z)))
                       ],
                         .))
                   f2_test =
@@ -1445,17 +1806,25 @@ Value
                     ((64,
                       Effect
                         ([
-                          (OCaml.Effect.State.state,
-                            (list,
-                              Z))
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (list,
+                                  Type
+                                    (Z)))
                         ],
                           .
                             -[
-                              (OCaml.Effect.State.state,
-                                Z);
-                              (OCaml.Effect.State.state,
-                                (list,
-                                  Z))
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z));
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (list,
+                                      Type
+                                        (Z)))
                             ]->
                             .)),
                       Variable
@@ -1467,11 +1836,16 @@ Value
                                 ->
                                 .
                                   -[
-                                    (OCaml.Effect.State.state,
-                                      Z);
-                                    (OCaml.Effect.State.state,
-                                      (list,
-                                        Z))
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (Z));
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (list,
+                                            Type
+                                              (Z)))
                                   ]->
                                   .)),
                           f2),
@@ -1480,9 +1854,12 @@ Value
                           ((64,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  (list,
-                                    Z))
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (list,
+                                        Type
+                                          (Z)))
                               ],
                                 .)),
                             Variable
@@ -1492,9 +1869,12 @@ Value
                                   ],
                                     .
                                       -[
-                                        (OCaml.Effect.State.state,
-                                          (list,
-                                            Z))
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (list,
+                                                Type
+                                                  (Z)))
                                       ]->
                                       .)),
                                 OCaml.Pervasives.ref),
@@ -1555,11 +1935,16 @@ Value
                   (65,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          Z);
-                        (OCaml.Effect.State.state,
-                          (list,
-                            Z))
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z));
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (list,
+                                Type
+                                  (Z)))
                       ],
                         .))
                   f2_test =
@@ -1567,11 +1952,16 @@ Value
                     ((65,
                       Effect
                         ([
-                          (OCaml.Effect.State.state,
-                            Z);
-                          (OCaml.Effect.State.state,
-                            (list,
-                              Z))
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z));
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (list,
+                                  Type
+                                    (Z)))
                         ],
                           .)),
                       Variable
@@ -1581,11 +1971,16 @@ Value
                             ],
                               .
                                 -[
-                                  (OCaml.Effect.State.state,
-                                    Z);
-                                  (OCaml.Effect.State.state,
-                                    (list,
-                                      Z))
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z));
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (list,
+                                          Type
+                                            (Z)))
                                 ]->
                                 .)),
                           f2_test),
@@ -1631,8 +2026,10 @@ Value
                   ((66,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          Z)
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
                       ],
                         .)),
                     Variable
@@ -1644,8 +2041,10 @@ Value
                               ->
                               .
                                 -[
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ]->
                                 .)),
                         f1),
@@ -1661,8 +2060,10 @@ Value
                         ((66,
                           Effect
                             ([
-                              (OCaml.Effect.State.state,
-                                Z)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z))
                             ],
                               .)),
                           Variable
@@ -1672,8 +2073,10 @@ Value
                                 ],
                                   .
                                     -[
-                                      (OCaml.Effect.State.state,
-                                        Z)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z))
                                     ]->
                                     .)),
                               OCaml.Effect.State.read),
@@ -1697,7 +2100,7 @@ Value
       ((multiple_returns_test, [ ], [ (x, Type (unit)) ],
         (Type (Z) * Type (OCaml.Effect.State.t, Type (Z)))),
         Match
-          ((?, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+          ((?, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (tt),
@@ -1705,8 +2108,10 @@ Value
                   (69,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          Z)
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
                       ],
                         .))
                   (non_rec, @.,
@@ -1740,26 +2145,34 @@ Value
                           ((70,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  Z)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z))
                               ],
                                 .
                                   -[
-                                    (OCaml.Effect.State.state,
-                                      Z)
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (Z))
                                   ]->
                                   .
                                     -[
-                                      (OCaml.Effect.State.state,
-                                        Z)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z))
                                     ]->
                                     .)),
                             Apply
                               ((70,
                                 Effect
                                   ([
-                                    (OCaml.Effect.State.state,
-                                      Z)
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (Z))
                                   ],
                                     .)),
                                 Variable
@@ -1771,8 +2184,10 @@ Value
                                           ->
                                           .
                                             -[
-                                              (OCaml.Effect.State.state,
-                                                Z)
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (Z))
                                             ]->
                                             .)),
                                     OCaml.Effect.State.write),
@@ -1799,13 +2214,17 @@ Value
                                   ],
                                     .
                                       -[
-                                        (OCaml.Effect.State.state,
-                                          Z)
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (Z))
                                       ]->
                                       .
                                         -[
-                                          (OCaml.Effect.State.state,
-                                            Z)
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (Z))
                                         ]->
                                         .)),
                                 z,
@@ -1813,21 +2232,27 @@ Value
                                   ((71,
                                     Effect
                                       ([
-                                        (OCaml.Effect.State.state,
-                                          Z)
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (Z))
                                       ],
                                         .
                                           -[
-                                            (OCaml.Effect.State.state,
-                                              Z)
+                                            Type
+                                              (OCaml.Effect.State.state,
+                                                Type
+                                                  (Z))
                                           ]->
                                           .)),
                                     Apply
                                       ((72,
                                         Effect
                                           ([
-                                            (OCaml.Effect.State.state,
-                                              Z)
+                                            Type
+                                              (OCaml.Effect.State.state,
+                                                Type
+                                                  (Z))
                                           ],
                                             .)),
                                         Variable
@@ -1839,8 +2264,10 @@ Value
                                                   ->
                                                   .
                                                     -[
-                                                      (OCaml.Effect.State.state,
-                                                        Z)
+                                                      Type
+                                                        (OCaml.Effect.State.state,
+                                                          Type
+                                                            (Z))
                                                     ]->
                                                     .)),
                                             OCaml.Effect.State.write),
@@ -1856,8 +2283,10 @@ Value
                                             ((72,
                                               Effect
                                                 ([
-                                                  (OCaml.Effect.State.state,
-                                                    Z)
+                                                  Type
+                                                    (OCaml.Effect.State.state,
+                                                      Type
+                                                        (Z))
                                                 ],
                                                   .)),
                                               Variable
@@ -1872,8 +2301,10 @@ Value
                                                   ((72,
                                                     Effect
                                                       ([
-                                                        (OCaml.Effect.State.state,
-                                                          Z)
+                                                        Type
+                                                          (OCaml.Effect.State.state,
+                                                            Type
+                                                              (Z))
                                                       ],
                                                         .)),
                                                     Variable
@@ -1883,8 +2314,10 @@ Value
                                                           ],
                                                             .
                                                               -[
-                                                                (OCaml.Effect.State.state,
-                                                                  Z)
+                                                                Type
+                                                                  (OCaml.Effect.State.state,
+                                                                    Type
+                                                                      (Z))
                                                               ]->
                                                               .)),
                                                         OCaml.Effect.State.read),
@@ -1913,8 +2346,10 @@ Value
                                           ],
                                             .
                                               -[
-                                                (OCaml.Effect.State.state,
-                                                  Z)
+                                                Type
+                                                  (OCaml.Effect.State.state,
+                                                    Type
+                                                      (Z))
                                               ]->
                                               .)),
                                         w,
@@ -1922,8 +2357,10 @@ Value
                                           (73,
                                             Effect
                                               ([
-                                                (OCaml.Effect.State.state,
-                                                  Z)
+                                                Type
+                                                  (OCaml.Effect.State.state,
+                                                    Type
+                                                      (Z))
                                               ],
                                                 .))
                                           tmp
@@ -1932,8 +2369,10 @@ Value
                                             ((74,
                                               Effect
                                                 ([
-                                                  (OCaml.Effect.State.state,
-                                                    Z)
+                                                  Type
+                                                    (OCaml.Effect.State.state,
+                                                      Type
+                                                        (Z))
                                                 ],
                                                   .)),
                                               Variable
@@ -1943,8 +2382,10 @@ Value
                                                     ],
                                                       .
                                                         -[
-                                                          (OCaml.Effect.State.state,
-                                                            Z)
+                                                          Type
+                                                            (OCaml.Effect.State.state,
+                                                              Type
+                                                                (Z))
                                                         ]->
                                                         .)),
                                                   OCaml.Effect.State.read),
@@ -1962,16 +2403,20 @@ Value
                                           ((75,
                                             Effect
                                               ([
-                                                (OCaml.Effect.State.state,
-                                                  Z)
+                                                Type
+                                                  (OCaml.Effect.State.state,
+                                                    Type
+                                                      (Z))
                                               ],
                                                 .)),
                                             Apply
                                               ((75,
                                                 Effect
                                                   ([
-                                                    (OCaml.Effect.State.state,
-                                                      Z)
+                                                    Type
+                                                      (OCaml.Effect.State.state,
+                                                        Type
+                                                          (Z))
                                                   ],
                                                     .)),
                                                 Variable
@@ -1983,8 +2428,10 @@ Value
                                                           ->
                                                           .
                                                             -[
-                                                              (OCaml.Effect.State.state,
-                                                                Z)
+                                                              Type
+                                                                (OCaml.Effect.State.state,
+                                                                  Type
+                                                                    (Z))
                                                             ]->
                                                             .)),
                                                     OCaml.Effect.State.write),
@@ -2000,8 +2447,10 @@ Value
                                                     ((75,
                                                       Effect
                                                         ([
-                                                          (OCaml.Effect.State.state,
-                                                            Z)
+                                                          Type
+                                                            (OCaml.Effect.State.state,
+                                                              Type
+                                                                (Z))
                                                         ],
                                                           .)),
                                                       Variable
@@ -2023,8 +2472,10 @@ Value
                                                           ((75,
                                                             Effect
                                                               ([
-                                                                (OCaml.Effect.State.state,
-                                                                  Z)
+                                                                Type
+                                                                  (OCaml.Effect.State.state,
+                                                                    Type
+                                                                      (Z))
                                                               ],
                                                                 .)),
                                                             Variable
@@ -2034,8 +2485,10 @@ Value
                                                                   ],
                                                                     .
                                                                       -[
-                                                                        (OCaml.Effect.State.state,
-                                                                          Z)
+                                                                        Type
+                                                                          (OCaml.Effect.State.state,
+                                                                            Type
+                                                                              (Z))
                                                                       ]->
                                                                       .)),
                                                                 OCaml.Effect.State.read),
@@ -2054,16 +2507,20 @@ Value
                                               ((76,
                                                 Effect
                                                   ([
-                                                    (OCaml.Effect.State.state,
-                                                      Z)
+                                                    Type
+                                                      (OCaml.Effect.State.state,
+                                                        Type
+                                                          (Z))
                                                   ],
                                                     .)),
                                                 Apply
                                                   ((76,
                                                     Effect
                                                       ([
-                                                        (OCaml.Effect.State.state,
-                                                          Z)
+                                                        Type
+                                                          (OCaml.Effect.State.state,
+                                                            Type
+                                                              (Z))
                                                       ],
                                                         .)),
                                                     Variable
@@ -2075,8 +2532,10 @@ Value
                                                               ->
                                                               .
                                                                 -[
-                                                                  (OCaml.Effect.State.state,
-                                                                    Z)
+                                                                  Type
+                                                                    (OCaml.Effect.State.state,
+                                                                      Type
+                                                                        (Z))
                                                                 ]->
                                                                 .)),
                                                         OCaml.Effect.State.write),
@@ -2109,8 +2568,10 @@ Value
                   (80,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          Z)
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
                       ],
                         .))
                   s =
@@ -2118,8 +2579,10 @@ Value
                     ((80,
                       Effect
                         ([
-                          (OCaml.Effect.State.state,
-                            Z)
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
                         ],
                           .)),
                       Variable
@@ -2129,8 +2592,10 @@ Value
                             ],
                               .
                                 -[
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ]->
                                 .)),
                           OCaml.Pervasives.ref),
@@ -2148,8 +2613,10 @@ Value
                   (81,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          Z)
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
                       ],
                         .))
                   f1 =
@@ -2157,23 +2624,31 @@ Value
                     ((81,
                       Effect
                         ([
-                          (OCaml.Effect.State.state,
-                            Z)
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
                         ],
                           .
                             -[
-                              (OCaml.Effect.State.state,
-                                Z)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z))
                             ]->
                             .
                               -[
-                                (OCaml.Effect.State.state,
-                                  Z)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z))
                               ]->
                               .
                                 -[
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ]->
                                 .)),
                       Variable
@@ -2185,18 +2660,24 @@ Value
                                 ->
                                 .
                                   -[
-                                    (OCaml.Effect.State.state,
-                                      Z)
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (Z))
                                   ]->
                                   .
                                     -[
-                                      (OCaml.Effect.State.state,
-                                        Z)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z))
                                     ]->
                                     .
                                       -[
-                                        (OCaml.Effect.State.state,
-                                          Z)
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (Z))
                                       ]->
                                       .)),
                           f),
@@ -2205,8 +2686,10 @@ Value
                           ((81,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  Z)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z))
                               ],
                                 .)),
                             Variable
@@ -2216,8 +2699,10 @@ Value
                                   ],
                                     .
                                       -[
-                                        (OCaml.Effect.State.state,
-                                          Z)
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (Z))
                                       ]->
                                       .)),
                                 OCaml.Pervasives.ref),
@@ -2236,8 +2721,10 @@ Value
                   (82,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          Z)
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
                       ],
                         .))
                   f2 =
@@ -2245,18 +2732,24 @@ Value
                     ((82,
                       Effect
                         ([
-                          (OCaml.Effect.State.state,
-                            Z)
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
                         ],
                           .
                             -[
-                              (OCaml.Effect.State.state,
-                                Z)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z))
                             ]->
                             .
                               -[
-                                (OCaml.Effect.State.state,
-                                  Z)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z))
                               ]->
                               .)),
                       Variable
@@ -2266,18 +2759,24 @@ Value
                             ],
                               .
                                 -[
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ]->
                                 .
                                   -[
-                                    (OCaml.Effect.State.state,
-                                      Z)
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (Z))
                                   ]->
                                   .
                                     -[
-                                      (OCaml.Effect.State.state,
-                                        Z)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z))
                                     ]->
                                     .)),
                           f1),
@@ -2295,8 +2794,10 @@ Value
                   (83,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          Z)
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
                       ],
                         .))
                   f3 =
@@ -2304,13 +2805,17 @@ Value
                     ((83,
                       Effect
                         ([
-                          (OCaml.Effect.State.state,
-                            Z)
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
                         ],
                           .
                             -[
-                              (OCaml.Effect.State.state,
-                                Z)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z))
                             ]->
                             .)),
                       Variable
@@ -2320,13 +2825,17 @@ Value
                             ],
                               .
                                 -[
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ]->
                                 .
                                   -[
-                                    (OCaml.Effect.State.state,
-                                      Z)
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (Z))
                                   ]->
                                   .)),
                           f2),
@@ -2344,8 +2853,10 @@ Value
                   (84,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          Z)
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
                       ],
                         .))
                   f4 =
@@ -2353,8 +2864,10 @@ Value
                     ((84,
                       Effect
                         ([
-                          (OCaml.Effect.State.state,
-                            Z)
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
                         ],
                           .)),
                       Variable
@@ -2364,8 +2877,10 @@ Value
                             ],
                               .
                                 -[
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ]->
                                 .)),
                           f3),
@@ -2383,16 +2898,20 @@ Value
                   ((85,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          Z)
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
                       ],
                         .)),
                     Apply
                       ((85,
                         Effect
                           ([
-                            (OCaml.Effect.State.state,
-                              Z)
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (Z))
                           ],
                             .)),
                         Variable
@@ -2402,8 +2921,10 @@ Value
                               ],
                                 .
                                   -[
-                                    (OCaml.Effect.State.state,
-                                      Z)
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (Z))
                                   ]->
                                   .)),
                             OCaml.Effect.State.read),
@@ -2441,11 +2962,11 @@ Value
           ((88,
             Effect
               ([
-                (OCaml.Effect.State.state, A);
-                (OCaml.Effect.State.state, B)
+                Type (OCaml.Effect.State.state, A);
+                Type (OCaml.Effect.State.state, B)
               ], .)),
             Apply
-              ((88, Effect ([ (OCaml.Effect.State.state, A) ], .)),
+              ((88, Effect ([ Type (OCaml.Effect.State.state, A) ], .)),
                 Variable
                   ((88,
                     Effect
@@ -2453,8 +2974,9 @@ Value
                         . ->
                           .
                             -[
-                              (OCaml.Effect.State.state,
-                                A)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  A)
                             ]-> .)),
                     OCaml.Effect.State.write),
                 [
@@ -2462,7 +2984,7 @@ Value
                   Variable ((88, Effect ([ ], .)), a)
                 ]),
             Apply
-              ((89, Effect ([ (OCaml.Effect.State.state, B) ], .)),
+              ((89, Effect ([ Type (OCaml.Effect.State.state, B) ], .)),
                 Variable
                   ((89,
                     Effect
@@ -2470,8 +2992,9 @@ Value
                         . ->
                           .
                             -[
-                              (OCaml.Effect.State.state,
-                                B)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  B)
                             ]-> .)),
                     OCaml.Effect.State.write),
                 [
@@ -2487,7 +3010,7 @@ Value
       ((resolves_test1, [ A ],
         [ (x, Type (OCaml.Effect.State.t, A)); (a, A); (b, A) ], Type (unit)),
         Apply
-          ((92, Effect ([ (OCaml.Effect.State.state, A) ], .)),
+          ((92, Effect ([ Type (OCaml.Effect.State.state, A) ], .)),
             Variable
               ((92,
                 Effect
@@ -2497,10 +3020,12 @@ Value
                         . ->
                           .
                             -[
-                              (OCaml.Effect.State.state,
-                                A);
-                              (OCaml.Effect.State.state,
-                                A)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  A);
+                              Type
+                                (OCaml.Effect.State.state,
+                                  A)
                             ]-> .)), type_vars_test),
             [
               Variable ((92, Effect ([ ], .)), x);
@@ -2525,8 +3050,8 @@ Value
           ((95,
             Effect
               ([
-                (OCaml.Effect.State.state, A);
-                (OCaml.Effect.State.state, Z)
+                Type (OCaml.Effect.State.state, A);
+                Type (OCaml.Effect.State.state, Type (Z))
               ], .)),
             Variable
               ((95,
@@ -2537,10 +3062,13 @@ Value
                         . ->
                           .
                             -[
-                              (OCaml.Effect.State.state,
-                                Z);
-                              (OCaml.Effect.State.state,
-                                A)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z));
+                              Type
+                                (OCaml.Effect.State.state,
+                                  A)
                             ]-> .)), type_vars_test),
             [
               Variable ((95, Effect ([ ], .)), x);
@@ -2562,7 +3090,7 @@ Value
           (b, Type (Z))
         ], Type (unit)),
         Apply
-          ((98, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+          ((98, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
             Variable
               ((98,
                 Effect
@@ -2572,10 +3100,14 @@ Value
                         . ->
                           .
                             -[
-                              (OCaml.Effect.State.state,
-                                Z);
-                              (OCaml.Effect.State.state,
-                                Z)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z));
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z))
                             ]-> .)), type_vars_test),
             [
               Variable ((98, Effect ([ ], .)), x);

--- a/tests/ex39.monadise
+++ b/tests/ex39.monadise
@@ -5,7 +5,7 @@ Value
   (non_rec, @.,
     [
       ((get_local_ref, [ ], [ (tt (= tt_1), Type (unit)) ],
-        Monad ([ (OCaml.Effect.State.state, Z) ], Type (Z))),
+        Monad ([ Type (OCaml.Effect.State.state, Type (Z)) ], Type (Z))),
         Bind
           (?,
             Apply
@@ -21,7 +21,7 @@ Value
   (non_rec, @.,
     [
       ((set_local_ref, [ ], [ (tt (= tt_1), Type (unit)) ],
-        Monad ([ (OCaml.Effect.State.state, Z) ], Type (Z))),
+        Monad ([ Type (OCaml.Effect.State.state, Type (Z)) ], Type (Z))),
         Bind
           (?,
             Apply
@@ -44,7 +44,7 @@ Value
     [
       ((add_multiple_by_refs, [ ],
         [ (a, Type (Z)); (b, Type (Z)); (c, Type (Z)); (d, Type (Z)) ],
-        Monad ([ (OCaml.Effect.State.state, Z) ], Type (Z))),
+        Monad ([ Type (OCaml.Effect.State.state, Type (Z)) ], Type (Z))),
         Bind
           (?,
             Apply
@@ -193,7 +193,7 @@ Value
   (non_rec, @.,
     [
       ((set_ref, [ ], [ (x, Type (OCaml.Effect.State.t, Type (Z))) ],
-        Monad ([ (OCaml.Effect.State.state, Z) ], Type (unit))),
+        Monad ([ Type (OCaml.Effect.State.state, Type (Z)) ], Type (unit))),
         Apply
           (21, Variable (21, OCaml.Effect.State.write),
             [ Variable (21, x); Constant (21, Int(15)) ]))
@@ -204,7 +204,7 @@ Value
   (non_rec, @.,
     [
       ((get_ref, [ ], [ (x, Type (OCaml.Effect.State.t, Type (Z))) ],
-        Monad ([ (OCaml.Effect.State.state, Z) ], Type (Z))),
+        Monad ([ Type (OCaml.Effect.State.state, Type (Z)) ], Type (Z))),
         Apply
           (24, Variable (24, OCaml.Effect.State.read), [ Variable (24, x) ]))
     ])
@@ -214,7 +214,7 @@ Value
   (non_rec, @.,
     [
       ((update_ref, [ ], [ (x, Type (OCaml.Effect.State.t, Type (Z))) ],
-        Monad ([ (OCaml.Effect.State.state, Z) ], Type (unit))),
+        Monad ([ Type (OCaml.Effect.State.state, Type (Z)) ], Type (unit))),
         Bind
           (?,
             Bind
@@ -241,7 +241,7 @@ Value
     [
       ((new_ref, [ ], [ (x, Type (unit)) ],
         Monad
-          ([ (OCaml.Effect.State.state, Z) ],
+          ([ Type (OCaml.Effect.State.state, Type (Z)) ],
             Type (OCaml.Effect.State.t, Type (Z)))),
         Apply
           (30, Variable (30, OCaml.Pervasives.ref),
@@ -255,12 +255,14 @@ Value
   (non_rec, @.,
     [
       ((set_r, [ ], [ (x, Type (unit)) ],
-        Monad ([ (OCaml.Effect.State.state, Z); r_state ], Type (unit))),
+        Monad
+          ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ],
+            Type (unit))),
         Bind
           (?, Variable (34, r), Some x_1,
             Lift
-              (?, [ (OCaml.Effect.State.state, Z) ],
-                [ (OCaml.Effect.State.state, Z); r_state ],
+              (?, [ Type (OCaml.Effect.State.state, Type (Z)) ],
+                [ Type (OCaml.Effect.State.state, Type (Z)); r_state ],
                 Apply
                   (34, Variable (34, set_ref), [ Variable (?, x_1) ]))))
     ])
@@ -270,12 +272,13 @@ Value
   (non_rec, @.,
     [
       ((get_r, [ ], [ (x, Type (unit)) ],
-        Monad ([ (OCaml.Effect.State.state, Z); r_state ], Type (Z))),
+        Monad
+          ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], Type (Z))),
         Bind
           (?, Variable (36, r), Some x_1,
             Lift
-              (?, [ (OCaml.Effect.State.state, Z) ],
-                [ (OCaml.Effect.State.state, Z); r_state ],
+              (?, [ Type (OCaml.Effect.State.state, Type (Z)) ],
+                [ Type (OCaml.Effect.State.state, Type (Z)); r_state ],
                 Apply
                   (36, Variable (36, get_ref), [ Variable (?, x_1) ]))))
     ])
@@ -285,7 +288,8 @@ Value
   (non_rec, @.,
     [
       ((r_add_15, [ ], [ (x, Type (unit)) ],
-        Monad ([ (OCaml.Effect.State.state, Z); r_state ], Type (Z))),
+        Monad
+          ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], Type (Z))),
         Bind
           (?, Apply (39, Variable (39, get_r), [ Constructor (39, tt) ]),
             Some i,
@@ -306,12 +310,16 @@ Value
                             Lift
                               (?,
                                 [
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ],
                                 [
-                                  (OCaml.Effect.State.state,
-                                    Z);
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z));
                                   r_state
                                 ],
                                 Apply
@@ -342,12 +350,16 @@ Value
                             Lift
                               (?,
                                 [
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ],
                                 [
-                                  (OCaml.Effect.State.state,
-                                    Z);
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z));
                                   r_state
                                 ],
                                 Apply
@@ -369,19 +381,19 @@ Value
       ((mixed_type, [ ], [ (es_in, list Effect.t); (x, Type (unit)) ],
         Monad
           ([
-            (OCaml.Effect.State.state, Z);
-            (OCaml.Effect.State.state, bool);
-            (OCaml.Effect.State.state, string);
+            Type (OCaml.Effect.State.state, Type (Z));
+            Type (OCaml.Effect.State.state, Type (bool));
+            Type (OCaml.Effect.State.state, Type (string));
             r_state
           ], (Type (bool) * Type (string) * Type (Z)))),
         Bind
           (?,
             Lift
-              (?, [ (OCaml.Effect.State.state, bool) ],
+              (?, [ Type (OCaml.Effect.State.state, Type (bool)) ],
                 [
-                  (OCaml.Effect.State.state, Z);
-                  (OCaml.Effect.State.state, bool);
-                  (OCaml.Effect.State.state, string);
+                  Type (OCaml.Effect.State.state, Type (Z));
+                  Type (OCaml.Effect.State.state, Type (bool));
+                  Type (OCaml.Effect.State.state, Type (string));
                   r_state
                 ],
                 Apply
@@ -390,11 +402,23 @@ Value
             Bind
               (?,
                 Lift
-                  (?, [ (OCaml.Effect.State.state, string) ],
+                  (?,
                     [
-                      (OCaml.Effect.State.state, Z);
-                      (OCaml.Effect.State.state, bool);
-                      (OCaml.Effect.State.state, string);
+                      Type
+                        (OCaml.Effect.State.state,
+                          Type
+                            (string))
+                    ],
+                    [
+                      Type (OCaml.Effect.State.state, Type (Z));
+                      Type
+                        (OCaml.Effect.State.state,
+                          Type
+                            (bool));
+                      Type
+                        (OCaml.Effect.State.state,
+                          Type
+                            (string));
                       r_state
                     ],
                     Apply
@@ -407,10 +431,14 @@ Value
                       ((update, [ ], [ (x_1, Type (unit)) ],
                         Monad
                           ([
-                            (OCaml.Effect.State.state,
-                              bool);
-                            (OCaml.Effect.State.state,
-                              string)
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (bool));
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (string))
                           ],
                             Type
                               (unit))),
@@ -427,14 +455,20 @@ Value
                                     Lift
                                       (?,
                                         [
-                                          (OCaml.Effect.State.state,
-                                            bool)
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (bool))
                                         ],
                                         [
-                                          (OCaml.Effect.State.state,
-                                            bool);
-                                          (OCaml.Effect.State.state,
-                                            string)
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (bool));
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (string))
                                         ],
                                         Bind
                                           (?,
@@ -467,14 +501,20 @@ Value
                                     Lift
                                       (?,
                                         [
-                                          (OCaml.Effect.State.state,
-                                            string)
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (string))
                                         ],
                                         [
-                                          (OCaml.Effect.State.state,
-                                            bool);
-                                          (OCaml.Effect.State.state,
-                                            string)
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (bool));
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (string))
                                         ],
                                         Bind
                                           (?,
@@ -529,13 +569,28 @@ Value
                     Lift
                       (?,
                         [
-                          (OCaml.Effect.State.state, bool);
-                          (OCaml.Effect.State.state, string)
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (bool));
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (string))
                         ],
                         [
-                          (OCaml.Effect.State.state, Z);
-                          (OCaml.Effect.State.state, bool);
-                          (OCaml.Effect.State.state, string);
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z));
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (bool));
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (string));
                           r_state
                         ],
                         Apply
@@ -547,18 +602,28 @@ Value
                         Lift
                           (?,
                             [
-                              (OCaml.Effect.State.state,
-                                bool);
-                              (OCaml.Effect.State.state,
-                                string)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (bool));
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (string))
                             ],
                             [
-                              (OCaml.Effect.State.state,
-                                Z);
-                              (OCaml.Effect.State.state,
-                                bool);
-                              (OCaml.Effect.State.state,
-                                string);
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z));
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (bool));
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (string));
                               r_state
                             ],
                             Apply
@@ -574,18 +639,28 @@ Value
                             Lift
                               (?,
                                 [
-                                  (OCaml.Effect.State.state,
-                                    bool);
-                                  (OCaml.Effect.State.state,
-                                    string)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (bool));
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (string))
                                 ],
                                 [
-                                  (OCaml.Effect.State.state,
-                                    Z);
-                                  (OCaml.Effect.State.state,
-                                    bool);
-                                  (OCaml.Effect.State.state,
-                                    string);
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z));
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (bool));
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (string));
                                   r_state
                                 ],
                                 Apply
@@ -603,16 +678,24 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      (OCaml.Effect.State.state,
-                                        bool)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (bool))
                                     ],
                                     [
-                                      (OCaml.Effect.State.state,
-                                        Z);
-                                      (OCaml.Effect.State.state,
-                                        bool);
-                                      (OCaml.Effect.State.state,
-                                        string);
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z));
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (bool));
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (string));
                                       r_state
                                     ],
                                     Apply
@@ -631,16 +714,24 @@ Value
                                     Lift
                                       (?,
                                         [
-                                          (OCaml.Effect.State.state,
-                                            string)
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (string))
                                         ],
                                         [
-                                          (OCaml.Effect.State.state,
-                                            Z);
-                                          (OCaml.Effect.State.state,
-                                            bool);
-                                          (OCaml.Effect.State.state,
-                                            string);
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (Z));
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (bool));
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (string));
                                           r_state
                                         ],
                                         Apply
@@ -659,17 +750,25 @@ Value
                                         Lift
                                           (?,
                                             [
-                                              (OCaml.Effect.State.state,
-                                                Z);
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (Z));
                                               r_state
                                             ],
                                             [
-                                              (OCaml.Effect.State.state,
-                                                Z);
-                                              (OCaml.Effect.State.state,
-                                                bool);
-                                              (OCaml.Effect.State.state,
-                                                string);
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (Z));
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (bool));
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (string));
                                               r_state
                                             ],
                                             Bind
@@ -682,12 +781,16 @@ Value
                                                 Lift
                                                   (?,
                                                     [
-                                                      (OCaml.Effect.State.state,
-                                                        Z)
+                                                      Type
+                                                        (OCaml.Effect.State.state,
+                                                          Type
+                                                            (Z))
                                                     ],
                                                     [
-                                                      (OCaml.Effect.State.state,
-                                                        Z);
+                                                      Type
+                                                        (OCaml.Effect.State.state,
+                                                          Type
+                                                            (Z));
                                                       r_state
                                                     ],
                                                     Apply
@@ -724,8 +827,8 @@ Value
       ((partials_test, [ ], [ (es_in, list Effect.t); (x, Type (unit)) ],
         Monad
           ([
-            (OCaml.Effect.State.state, Z);
-            (OCaml.Effect.State.state, (list, Z));
+            Type (OCaml.Effect.State.state, Type (Z));
+            Type (OCaml.Effect.State.state, Type (list, Type (Z)));
             r_state
           ], Type (OCaml.Effect.State.t, Type (Z)))),
         Match
@@ -750,8 +853,10 @@ Value
                         ],
                         Monad
                           ([
-                            (OCaml.Effect.State.state,
-                              Z)
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (Z))
                           ],
                             Type
                               (OCaml.Effect.State.t,
@@ -785,16 +890,23 @@ Value
                     Lift
                       (?,
                         [
-                          (OCaml.Effect.State.state,
-                            Z);
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z));
                           r_state
                         ],
                         [
-                          (OCaml.Effect.State.state,
-                            Z);
-                          (OCaml.Effect.State.state,
-                            (list,
-                              Z));
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z));
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (list,
+                                  Type
+                                    (Z)));
                           r_state
                         ],
                         Bind
@@ -821,18 +933,28 @@ Value
                     Lift
                       (?,
                         [
-                          (OCaml.Effect.State.state,
-                            Z);
-                          (OCaml.Effect.State.state,
-                            (list,
-                              Z))
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z));
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (list,
+                                  Type
+                                    (Z)))
                         ],
                         [
-                          (OCaml.Effect.State.state,
-                            Z);
-                          (OCaml.Effect.State.state,
-                            (list,
-                              Z));
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z));
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (list,
+                                  Type
+                                    (Z)));
                           r_state
                         ],
                         Bind
@@ -840,15 +962,22 @@ Value
                             Lift
                               (?,
                                 [
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ],
                                 [
-                                  (OCaml.Effect.State.state,
-                                    Z);
-                                  (OCaml.Effect.State.state,
-                                    (list,
-                                      Z))
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z));
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (list,
+                                          Type
+                                            (Z)))
                                 ],
                                 Apply
                                   (61,
@@ -886,11 +1015,16 @@ Value
                                     ],
                                     Monad
                                       ([
-                                        (OCaml.Effect.State.state,
-                                          Z);
-                                        (OCaml.Effect.State.state,
-                                          (list,
-                                            Z))
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (Z));
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (list,
+                                                Type
+                                                  (Z)))
                                       ],
                                         Type
                                           (OCaml.Effect.State.t,
@@ -901,16 +1035,24 @@ Value
                                         Lift
                                           (?,
                                             [
-                                              (OCaml.Effect.State.state,
-                                                (list,
-                                                  Z))
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (list,
+                                                      Type
+                                                        (Z)))
                                             ],
                                             [
-                                              (OCaml.Effect.State.state,
-                                                Z);
-                                              (OCaml.Effect.State.state,
-                                                (list,
-                                                  Z))
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (Z));
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (list,
+                                                      Type
+                                                        (Z)))
                                             ],
                                             Bind
                                               (?,
@@ -969,15 +1111,22 @@ Value
                                         Lift
                                           (?,
                                             [
-                                              (OCaml.Effect.State.state,
-                                                Z)
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (Z))
                                             ],
                                             [
-                                              (OCaml.Effect.State.state,
-                                                Z);
-                                              (OCaml.Effect.State.state,
-                                                (list,
-                                                  Z))
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (Z));
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (list,
+                                                      Type
+                                                        (Z)))
                                             ],
                                             Apply
                                               (63,
@@ -996,16 +1145,24 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      (OCaml.Effect.State.state,
-                                        (list,
-                                          Z))
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (list,
+                                              Type
+                                                (Z)))
                                     ],
                                     [
-                                      (OCaml.Effect.State.state,
-                                        Z);
-                                      (OCaml.Effect.State.state,
-                                        (list,
-                                          Z))
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z));
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (list,
+                                              Type
+                                                (Z)))
                                     ],
                                     Bind
                                       (?,
@@ -1082,15 +1239,22 @@ Value
                                     Lift
                                       (?,
                                         [
-                                          (OCaml.Effect.State.state,
-                                            Z)
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (Z))
                                         ],
                                         [
-                                          (OCaml.Effect.State.state,
-                                            Z);
-                                          (OCaml.Effect.State.state,
-                                            (list,
-                                              Z))
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (Z));
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (list,
+                                                  Type
+                                                    (Z)))
                                         ],
                                         Bind
                                           (?,
@@ -1128,7 +1292,7 @@ Value
     [
       ((multiple_returns_test, [ ], [ (x, Type (unit)) ],
         Monad
-          ([ (OCaml.Effect.State.state, Z) ],
+          ([ Type (OCaml.Effect.State.state, Type (Z)) ],
             (Type (Z) * Type (OCaml.Effect.State.t, Type (Z))))),
         Match
           (?, Variable (?, x),
@@ -1152,16 +1316,20 @@ Value
                         ],
                         Monad
                           ([
-                            (OCaml.Effect.State.state,
-                              Z)
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (Z))
                           ],
                             (Type
                               (Z)
                               ->
                               Monad
                                 ([
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ],
                                   (Type
                                     (OCaml.Effect.State.t,
@@ -1170,8 +1338,10 @@ Value
                                     ->
                                     Monad
                                       ([
-                                        (OCaml.Effect.State.state,
-                                          Z)
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (Z))
                                       ],
                                         Type
                                           (OCaml.Effect.State.t,
@@ -1464,25 +1634,27 @@ Value
           (b, B)
         ],
         Monad
-          ([ (OCaml.Effect.State.state, A); (OCaml.Effect.State.state, B) ],
-            Type (unit))),
+          ([
+            Type (OCaml.Effect.State.state, A);
+            Type (OCaml.Effect.State.state, B)
+          ], Type (unit))),
         Bind
           (?,
             Lift
-              (?, [ (OCaml.Effect.State.state, A) ],
+              (?, [ Type (OCaml.Effect.State.state, A) ],
                 [
-                  (OCaml.Effect.State.state, A);
-                  (OCaml.Effect.State.state, B)
+                  Type (OCaml.Effect.State.state, A);
+                  Type (OCaml.Effect.State.state, B)
                 ],
                 Apply
                   (88, Variable (88, OCaml.Effect.State.write),
                     [ Variable (88, x); Variable (88, a) ])),
             None,
             Lift
-              (?, [ (OCaml.Effect.State.state, B) ],
+              (?, [ Type (OCaml.Effect.State.state, B) ],
                 [
-                  (OCaml.Effect.State.state, A);
-                  (OCaml.Effect.State.state, B)
+                  Type (OCaml.Effect.State.state, A);
+                  Type (OCaml.Effect.State.state, B)
                 ],
                 Apply
                   (89, Variable (89, OCaml.Effect.State.write),
@@ -1495,13 +1667,13 @@ Value
     [
       ((resolves_test1, [ A ],
         [ (x, Type (OCaml.Effect.State.t, A)); (a, A); (b, A) ],
-        Monad ([ (OCaml.Effect.State.state, A) ], Type (unit))),
+        Monad ([ Type (OCaml.Effect.State.state, A) ], Type (unit))),
         Lift
           (?,
             [
-              (OCaml.Effect.State.state, A);
-              (OCaml.Effect.State.state, A)
-            ], [ (OCaml.Effect.State.state, A) ],
+              Type (OCaml.Effect.State.state, A);
+              Type (OCaml.Effect.State.state, A)
+            ], [ Type (OCaml.Effect.State.state, A) ],
             Apply
               (92, Variable (92, type_vars_test),
                 [
@@ -1525,17 +1697,19 @@ Value
           (b, A)
         ],
         Monad
-          ([ (OCaml.Effect.State.state, A); (OCaml.Effect.State.state, Z) ],
-            Type (unit))),
+          ([
+            Type (OCaml.Effect.State.state, A);
+            Type (OCaml.Effect.State.state, Type (Z))
+          ], Type (unit))),
         Lift
           (?,
             [
-              (OCaml.Effect.State.state, Z);
-              (OCaml.Effect.State.state, A)
+              Type (OCaml.Effect.State.state, Type (Z));
+              Type (OCaml.Effect.State.state, A)
             ],
             [
-              (OCaml.Effect.State.state, A);
-              (OCaml.Effect.State.state, Z)
+              Type (OCaml.Effect.State.state, A);
+              Type (OCaml.Effect.State.state, Type (Z))
             ],
             Apply
               (95, Variable (95, type_vars_test),
@@ -1557,13 +1731,13 @@ Value
           (y, Type (OCaml.Effect.State.t, Type (Z)));
           (a, Type (Z));
           (b, Type (Z))
-        ], Monad ([ (OCaml.Effect.State.state, Z) ], Type (unit))),
+        ], Monad ([ Type (OCaml.Effect.State.state, Type (Z)) ], Type (unit))),
         Lift
           (?,
             [
-              (OCaml.Effect.State.state, Z);
-              (OCaml.Effect.State.state, Z)
-            ], [ (OCaml.Effect.State.state, Z) ],
+              Type (OCaml.Effect.State.state, Type (Z));
+              Type (OCaml.Effect.State.state, Type (Z))
+            ], [ Type (OCaml.Effect.State.state, Type (Z)) ],
             Apply
               (98, Variable (98, type_vars_test),
                 [

--- a/tests/ex40.effects
+++ b/tests/ex40.effects
@@ -6,7 +6,9 @@ Value
     [
       ((b, [ ], [ (x, Type (unit)) ], Type (OCaml.Effect.State.t, Type (Z))),
         Match
-          ((?, Effect ([ (OCaml.Effect.State.state, Z); a_state ], .)),
+          ((?,
+            Effect
+              ([ Type (OCaml.Effect.State.state, Type (Z)); a_state ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (tt),
@@ -14,8 +16,10 @@ Value
                   ((4,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          Z);
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z));
                         a_state
                       ],
                         .)),
@@ -34,16 +38,22 @@ Value
     [
       ((c, [ ], [ (x, Type (unit)) ], Type (OCaml.Effect.State.t, Type (string))),
         Match
-          ((?, Effect ([ (OCaml.Effect.State.state, string); a_state_1 ], .)),
-            Variable ((?, Effect ([ ], .)), x),
+          ((?,
+            Effect
+              ([
+                Type (OCaml.Effect.State.state, Type (string));
+                a_state_1
+              ], .)), Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (tt),
                 Variable
                   ((6,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          string);
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (string));
                         a_state_1
                       ],
                         .)),

--- a/tests/ex40.monadise
+++ b/tests/ex40.monadise
@@ -6,7 +6,7 @@ Value
     [
       ((b, [ ], [ (x, Type (unit)) ],
         Monad
-          ([ (OCaml.Effect.State.state, Z); a_state ],
+          ([ Type (OCaml.Effect.State.state, Type (Z)); a_state ],
             Type (OCaml.Effect.State.t, Type (Z)))),
         Match (?, Variable (?, x), [ (Constructor (tt), Variable (4, a)) ]))
     ])
@@ -19,7 +19,7 @@ Value
     [
       ((c, [ ], [ (x, Type (unit)) ],
         Monad
-          ([ (OCaml.Effect.State.state, string); a_state_1 ],
+          ([ Type (OCaml.Effect.State.state, Type (string)); a_state_1 ],
             Type (OCaml.Effect.State.t, Type (string)))),
         Match (?, Variable (?, x), [ (Constructor (tt), Variable (6, a_1)) ]))
     ])

--- a/tests/ex42.effects
+++ b/tests/ex42.effects
@@ -3,23 +3,39 @@ Value
   (non_rec, @.,
     [
       ((x, [ ], [ (a, Type (Z)); (b, Type (Z)) ], Type (Z)),
-        LetVar (3, Effect ([ (OCaml.Effect.State.state, Z) ], .)) y =
+        LetVar (3, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .))
+          y =
           Apply
-            ((3, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+            ((3, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
               Variable
                 ((3,
                   Effect
-                    ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
-                  OCaml.Pervasives.ref),
+                    ([ ],
+                      .
+                        -[
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
+                        ]-> .)), OCaml.Pervasives.ref),
               [ Constant ((3, Effect ([ ], .)), Int(0)) ]) in
         Sequence
-          ((4, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+          ((4, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
             For
-              ((4, Effect ([ (OCaml.Effect.State.state, Z) ], .)), i,
-                true, Variable ((4, Effect ([ ], .)), a),
+              ((4,
+                Effect
+                  ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
+                i, true, Variable ((4, Effect ([ ], .)), a),
                 Variable ((4, Effect ([ ], .)), b),
                 Apply
-                  ((5, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+                  ((5,
+                    Effect
+                      ([
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
+                      ], .)),
                     Variable
                       ((5,
                         Effect
@@ -27,8 +43,10 @@ Value
                             . ->
                               .
                                 -[
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ]-> .)),
                         OCaml.Effect.State.write),
                     [
@@ -37,8 +55,10 @@ Value
                         ((5,
                           Effect
                             ([
-                              (OCaml.Effect.State.state,
-                                Z)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z))
                             ],
                               .)),
                           Variable
@@ -53,8 +73,10 @@ Value
                               ((5,
                                 Effect
                                   ([
-                                    (OCaml.Effect.State.state,
-                                      Z)
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (Z))
                                   ],
                                     .)),
                                 Variable
@@ -64,8 +86,10 @@ Value
                                       ],
                                         .
                                           -[
-                                            (OCaml.Effect.State.state,
-                                              Z)
+                                            Type
+                                              (OCaml.Effect.State.state,
+                                                Type
+                                                  (Z))
                                           ]->
                                           .)),
                                     OCaml.Effect.State.read),
@@ -88,13 +112,20 @@ Value
                           ])
                     ])),
             Apply
-              ((7, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+              ((7,
+                Effect
+                  ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
                 Variable
                   ((7,
                     Effect
                       ([ ],
-                        . -[ (OCaml.Effect.State.state, Z) ]->
-                          .)), OCaml.Effect.State.read),
+                        .
+                          -[
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (Z))
+                          ]-> .)), OCaml.Effect.State.read),
                 [ Variable ((7, Effect ([ ], .)), y) ])))
     ])
 
@@ -103,44 +134,87 @@ Value
   (non_rec, @.,
     [
       ((nested, [ ], [ (x, Type (Z)); (y, Type (Z)) ], Type (list, Type (bool))),
-        LetVar (10, Effect ([ (OCaml.Effect.State.state, (list, bool)) ], .))
-          a =
+        LetVar
+          (10,
+            Effect
+              ([
+                Type
+                  (OCaml.Effect.State.state,
+                    Type
+                      (list,
+                        Type
+                          (bool)))
+              ], .)) a =
           Apply
-            ((10, Effect ([ (OCaml.Effect.State.state, (list, bool)) ], .)),
+            ((10,
+              Effect
+                ([
+                  Type
+                    (OCaml.Effect.State.state,
+                      Type
+                        (list,
+                          Type
+                            (bool)))
+                ], .)),
               Variable
                 ((10,
                   Effect
                     ([ ],
                       .
                         -[
-                          (OCaml.Effect.State.state,
-                            (list,
-                              bool))
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (list,
+                                  Type
+                                    (bool)))
                         ]-> .)), OCaml.Pervasives.ref),
               [ Constructor ((10, Effect ([ ], .)), []) ]) in
         Sequence
-          ((11, Effect ([ (OCaml.Effect.State.state, (list, bool)) ], .)),
+          ((11,
+            Effect
+              ([
+                Type
+                  (OCaml.Effect.State.state,
+                    Type
+                      (list,
+                        Type
+                          (bool)))
+              ], .)),
             For
               ((11,
                 Effect
-                  ([ (OCaml.Effect.State.state, (list, bool)) ], .)),
-                i, true, Constant ((11, Effect ([ ], .)), Int(0)),
+                  ([
+                    Type
+                      (OCaml.Effect.State.state,
+                        Type
+                          (list,
+                            Type
+                              (bool)))
+                  ], .)), i, true,
+                Constant ((11, Effect ([ ], .)), Int(0)),
                 Variable ((11, Effect ([ ], .)), x),
                 Sequence
                   ((12,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          (list,
-                            bool))
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (list,
+                                Type
+                                  (bool)))
                       ], .)),
                     For
                       ((12,
                         Effect
                           ([
-                            (OCaml.Effect.State.state,
-                              (list,
-                                bool))
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (list,
+                                    Type
+                                      (bool)))
                           ], .)), j, true,
                         Constant
                           ((12, Effect ([ ], .)), Int(0)),
@@ -149,9 +223,12 @@ Value
                           ((13,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  (list,
-                                    bool))
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (list,
+                                        Type
+                                          (bool)))
                               ], .)),
                             Variable
                               ((13,
@@ -160,9 +237,12 @@ Value
                                     . ->
                                       .
                                         -[
-                                          (OCaml.Effect.State.state,
-                                            (list,
-                                              bool))
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (list,
+                                                  Type
+                                                    (bool)))
                                         ]-> .)),
                                 OCaml.Effect.State.write),
                             [
@@ -177,9 +257,12 @@ Value
                                 ((13,
                                   Effect
                                     ([
-                                      (OCaml.Effect.State.state,
-                                        (list,
-                                          bool))
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (list,
+                                              Type
+                                                (bool)))
                                     ],
                                       .)),
                                   cons,
@@ -194,9 +277,12 @@ Value
                                     ((13,
                                       Effect
                                         ([
-                                          (OCaml.Effect.State.state,
-                                            (list,
-                                              bool))
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (list,
+                                                  Type
+                                                    (bool)))
                                         ],
                                           .)),
                                       Variable
@@ -206,9 +292,12 @@ Value
                                             ],
                                               .
                                                 -[
-                                                  (OCaml.Effect.State.state,
-                                                    (list,
-                                                      bool))
+                                                  Type
+                                                    (OCaml.Effect.State.state,
+                                                      Type
+                                                        (list,
+                                                          Type
+                                                            (bool)))
                                                 ]->
                                                 .)),
                                           OCaml.Effect.State.read),
@@ -226,9 +315,12 @@ Value
                       ((15,
                         Effect
                           ([
-                            (OCaml.Effect.State.state,
-                              (list,
-                                bool))
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (list,
+                                    Type
+                                      (bool)))
                           ], .)),
                         Variable
                           ((15,
@@ -237,9 +329,12 @@ Value
                                 . ->
                                   .
                                     -[
-                                      (OCaml.Effect.State.state,
-                                        (list,
-                                          bool))
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (list,
+                                              Type
+                                                (bool)))
                                     ]-> .)),
                             OCaml.Effect.State.write),
                         [
@@ -254,9 +349,12 @@ Value
                             ((15,
                               Effect
                                 ([
-                                  (OCaml.Effect.State.state,
-                                    (list,
-                                      bool))
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (list,
+                                          Type
+                                            (bool)))
                                 ],
                                   .)),
                               cons,
@@ -271,9 +369,12 @@ Value
                                 ((15,
                                   Effect
                                     ([
-                                      (OCaml.Effect.State.state,
-                                        (list,
-                                          bool))
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (list,
+                                              Type
+                                                (bool)))
                                     ],
                                       .)),
                                   Variable
@@ -283,9 +384,12 @@ Value
                                         ],
                                           .
                                             -[
-                                              (OCaml.Effect.State.state,
-                                                (list,
-                                                  bool))
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (list,
+                                                      Type
+                                                        (bool)))
                                             ]->
                                             .)),
                                       OCaml.Effect.State.read),
@@ -302,16 +406,26 @@ Value
             Apply
               ((17,
                 Effect
-                  ([ (OCaml.Effect.State.state, (list, bool)) ], .)),
+                  ([
+                    Type
+                      (OCaml.Effect.State.state,
+                        Type
+                          (list,
+                            Type
+                              (bool)))
+                  ], .)),
                 Variable
                   ((17,
                     Effect
                       ([ ],
                         .
                           -[
-                            (OCaml.Effect.State.state,
-                              (list,
-                                bool))
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (list,
+                                    Type
+                                      (bool)))
                           ]-> .)), OCaml.Effect.State.read),
                 [ Variable ((17, Effect ([ ], .)), a) ])))
     ])
@@ -425,59 +539,97 @@ Value
       ((argument_effects, [ ],
         [ (x, Type (OCaml.Effect.State.t, Type (Z))); (y, Type (Z)) ],
         Type (Z)),
-        LetVar (31, Effect ([ (OCaml.Effect.State.state, Z) ], .)) y =
+        LetVar (31, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .))
+          y =
           Apply
-            ((31, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+            ((31,
+              Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
               Variable
                 ((31,
                   Effect
-                    ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
-                  OCaml.Pervasives.ref),
+                    ([ ],
+                      .
+                        -[
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
+                        ]-> .)), OCaml.Pervasives.ref),
               [ Variable ((31, Effect ([ ], .)), y) ]) in
-        LetVar (32, Effect ([ (OCaml.Effect.State.state, Z) ], .)) z =
+        LetVar (32, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .))
+          z =
           Apply
-            ((32, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+            ((32,
+              Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
               Variable
                 ((32,
                   Effect
-                    ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
-                  OCaml.Pervasives.ref),
+                    ([ ],
+                      .
+                        -[
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
+                        ]-> .)), OCaml.Pervasives.ref),
               [ Constant ((32, Effect ([ ], .)), Int(0)) ]) in
         Sequence
-          ((33, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+          ((33, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
             For
-              ((33, Effect ([ (OCaml.Effect.State.state, Z) ], .)), i,
-                true, Constant ((33, Effect ([ ], .)), Int(0)),
+              ((33,
+                Effect
+                  ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
+                i, true, Constant ((33, Effect ([ ], .)), Int(0)),
                 Apply
                   ((33,
-                    Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+                    Effect
+                      ([
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
+                      ], .)),
                     Variable
                       ((33,
                         Effect
                           ([ ],
                             .
                               -[
-                                (OCaml.Effect.State.state,
-                                  Z)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z))
                               ]-> .)),
                         OCaml.Effect.State.read),
                     [ Variable ((33, Effect ([ ], .)), x) ]),
                 Sequence
                   ((34,
-                    Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+                    Effect
+                      ([
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
+                      ], .)),
                     For
                       ((34,
                         Effect
-                          ([ (OCaml.Effect.State.state, Z) ],
-                            .)), j, true,
+                          ([
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (Z))
+                          ], .)), j, true,
                         Constant
                           ((34, Effect ([ ], .)), Int(0)),
                         Apply
                           ((34,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  Z)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z))
                               ], .)),
                             Variable
                               ((34,
@@ -485,8 +637,10 @@ Value
                                   ([ ],
                                     .
                                       -[
-                                        (OCaml.Effect.State.state,
-                                          Z)
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (Z))
                                       ]-> .)),
                                 OCaml.Effect.State.read),
                             [
@@ -502,8 +656,10 @@ Value
                           ((35,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  Z)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z))
                               ], .)),
                             Variable
                               ((35,
@@ -512,8 +668,10 @@ Value
                                     . ->
                                       .
                                         -[
-                                          (OCaml.Effect.State.state,
-                                            Z)
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (Z))
                                         ]-> .)),
                                 OCaml.Effect.State.write),
                             [
@@ -528,8 +686,10 @@ Value
                                 ((35,
                                   Effect
                                     ([
-                                      (OCaml.Effect.State.state,
-                                        Z)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z))
                                     ],
                                       .)),
                                   Variable
@@ -544,8 +704,10 @@ Value
                                       ((35,
                                         Effect
                                           ([
-                                            (OCaml.Effect.State.state,
-                                              Z)
+                                            Type
+                                              (OCaml.Effect.State.state,
+                                                Type
+                                                  (Z))
                                           ],
                                             .)),
                                         Variable
@@ -555,8 +717,10 @@ Value
                                               ],
                                                 .
                                                   -[
-                                                    (OCaml.Effect.State.state,
-                                                      Z)
+                                                    Type
+                                                      (OCaml.Effect.State.state,
+                                                        Type
+                                                          (Z))
                                                   ]->
                                                   .)),
                                             OCaml.Effect.State.read),
@@ -581,8 +745,12 @@ Value
                     Apply
                       ((37,
                         Effect
-                          ([ (OCaml.Effect.State.state, Z) ],
-                            .)),
+                          ([
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (Z))
+                          ], .)),
                         Variable
                           ((37,
                             Effect
@@ -590,8 +758,10 @@ Value
                                 . ->
                                   .
                                     -[
-                                      (OCaml.Effect.State.state,
-                                        Z)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z))
                                     ]-> .)),
                             OCaml.Effect.State.write),
                         [
@@ -606,8 +776,10 @@ Value
                             ((37,
                               Effect
                                 ([
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ],
                                   .)),
                               Variable
@@ -622,8 +794,10 @@ Value
                                   ((37,
                                     Effect
                                       ([
-                                        (OCaml.Effect.State.state,
-                                          Z)
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (Z))
                                       ],
                                         .)),
                                     Variable
@@ -633,8 +807,10 @@ Value
                                           ],
                                             .
                                               -[
-                                                (OCaml.Effect.State.state,
-                                                  Z)
+                                                Type
+                                                  (OCaml.Effect.State.state,
+                                                    Type
+                                                      (Z))
                                               ]->
                                               .)),
                                         OCaml.Effect.State.read),
@@ -657,12 +833,19 @@ Value
                               ])
                         ]))),
             Apply
-              ((39, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+              ((39,
+                Effect
+                  ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
                 Variable
                   ((39,
                     Effect
                       ([ ],
-                        . -[ (OCaml.Effect.State.state, Z) ]->
-                          .)), OCaml.Effect.State.read),
+                        .
+                          -[
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (Z))
+                          ]-> .)), OCaml.Effect.State.read),
                 [ Variable ((39, Effect ([ ], .)), z) ])))
     ])

--- a/tests/ex42.monadise
+++ b/tests/ex42.monadise
@@ -3,7 +3,7 @@ Value
   (non_rec, @.,
     [
       ((x, [ ], [ (a, Type (Z)); (b, Type (Z)) ],
-        Monad ([ (OCaml.Effect.State.state, Z) ], Type (Z))),
+        Monad ([ Type (OCaml.Effect.State.state, Type (Z)) ], Type (Z))),
         Bind
           (?,
             Apply
@@ -76,7 +76,7 @@ Value
     [
       ((nested, [ ], [ (x, Type (Z)); (y, Type (Z)) ],
         Monad
-          ([ (OCaml.Effect.State.state, (list, bool)) ],
+          ([ Type (OCaml.Effect.State.state, Type (list, Type (bool))) ],
             Type (list, Type (bool)))),
         Bind
           (?,
@@ -317,7 +317,7 @@ Value
     [
       ((argument_effects, [ ],
         [ (x, Type (OCaml.Effect.State.t, Type (Z))); (y, Type (Z)) ],
-        Monad ([ (OCaml.Effect.State.state, Z) ], Type (Z))),
+        Monad ([ Type (OCaml.Effect.State.state, Type (Z)) ], Type (Z))),
         Bind
           (?,
             Apply

--- a/tests/ex43.effects
+++ b/tests/ex43.effects
@@ -8,44 +8,72 @@ Value
         LetVar
           (3,
             Effect
-              ([ (OCaml.Effect.State.state, Z); Counter; NonTermination ],
-                .)) y =
+              ([
+                Type (OCaml.Effect.State.state, Type (Z));
+                Counter;
+                NonTermination
+              ], .)) y =
           Apply
-            ((3, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+            ((3, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
               Variable
                 ((3,
                   Effect
-                    ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
-                  OCaml.Pervasives.ref),
+                    ([ ],
+                      .
+                        -[
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
+                        ]-> .)), OCaml.Pervasives.ref),
               [ Constant ((3, Effect ([ ], .)), Int(0)) ]) in
         LetVar
           (4,
             Effect
-              ([ (OCaml.Effect.State.state, Z); Counter; NonTermination ],
-                .)) c =
+              ([
+                Type (OCaml.Effect.State.state, Type (Z));
+                Counter;
+                NonTermination
+              ], .)) c =
           Apply
-            ((4, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+            ((4, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
               Variable
                 ((4,
                   Effect
-                    ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
-                  OCaml.Pervasives.ref),
+                    ([ ],
+                      .
+                        -[
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
+                        ]-> .)), OCaml.Pervasives.ref),
               [ Constant ((4, Effect ([ ], .)), Int(0)) ]) in
         Sequence
           ((5,
             Effect
-              ([ (OCaml.Effect.State.state, Z); Counter; NonTermination ],
-                .)),
+              ([
+                Type (OCaml.Effect.State.state, Type (Z));
+                Counter;
+                NonTermination
+              ], .)),
             While
               ((5,
                 Effect
                   ([
-                    (OCaml.Effect.State.state, Z);
+                    Type (OCaml.Effect.State.state, Type (Z));
                     Counter;
                     NonTermination
                   ], .)),
                 Apply
-                  ((5, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+                  ((5,
+                    Effect
+                      ([
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
+                      ], .)),
                     Variable
                       ((5, Effect ([ ], .)), OCaml.Pervasives.le),
                     [
@@ -53,8 +81,10 @@ Value
                         ((5,
                           Effect
                             ([
-                              (OCaml.Effect.State.state,
-                                Z)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z))
                             ],
                               .)),
                           Variable
@@ -69,8 +99,10 @@ Value
                               ((5,
                                 Effect
                                   ([
-                                    (OCaml.Effect.State.state,
-                                      Z)
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (Z))
                                   ],
                                     .)),
                                 Variable
@@ -80,8 +112,10 @@ Value
                                       ],
                                         .
                                           -[
-                                            (OCaml.Effect.State.state,
-                                              Z)
+                                            Type
+                                              (OCaml.Effect.State.state,
+                                                Type
+                                                  (Z))
                                           ]->
                                           .)),
                                     OCaml.Effect.State.read),
@@ -105,12 +139,23 @@ Value
                       Variable ((5, Effect ([ ], .)), a)
                     ]),
                 Sequence
-                  ((6, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+                  ((6,
+                    Effect
+                      ([
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
+                      ], .)),
                     Apply
                       ((6,
                         Effect
-                          ([ (OCaml.Effect.State.state, Z) ],
-                            .)),
+                          ([
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (Z))
+                          ], .)),
                         Variable
                           ((6,
                             Effect
@@ -118,8 +163,10 @@ Value
                                 . ->
                                   .
                                     -[
-                                      (OCaml.Effect.State.state,
-                                        Z)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z))
                                     ]-> .)),
                             OCaml.Effect.State.write),
                         [
@@ -128,8 +175,10 @@ Value
                             ((6,
                               Effect
                                 ([
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ],
                                   .)),
                               Variable
@@ -144,8 +193,10 @@ Value
                                   ((6,
                                     Effect
                                       ([
-                                        (OCaml.Effect.State.state,
-                                          Z)
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (Z))
                                       ],
                                         .)),
                                     Variable
@@ -155,8 +206,10 @@ Value
                                           ],
                                             .
                                               -[
-                                                (OCaml.Effect.State.state,
-                                                  Z)
+                                                Type
+                                                  (OCaml.Effect.State.state,
+                                                    Type
+                                                      (Z))
                                               ]->
                                               .)),
                                         OCaml.Effect.State.read),
@@ -181,8 +234,12 @@ Value
                     Apply
                       ((7,
                         Effect
-                          ([ (OCaml.Effect.State.state, Z) ],
-                            .)),
+                          ([
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (Z))
+                          ], .)),
                         Variable
                           ((7,
                             Effect
@@ -190,8 +247,10 @@ Value
                                 . ->
                                   .
                                     -[
-                                      (OCaml.Effect.State.state,
-                                        Z)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z))
                                     ]-> .)),
                             OCaml.Effect.State.write),
                         [
@@ -200,8 +259,10 @@ Value
                             ((7,
                               Effect
                                 ([
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ],
                                   .)),
                               Variable
@@ -216,8 +277,10 @@ Value
                                   ((7,
                                     Effect
                                       ([
-                                        (OCaml.Effect.State.state,
-                                          Z)
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (Z))
                                       ],
                                         .)),
                                     Variable
@@ -227,8 +290,10 @@ Value
                                           ],
                                             .
                                               -[
-                                                (OCaml.Effect.State.state,
-                                                  Z)
+                                                Type
+                                                  (OCaml.Effect.State.state,
+                                                    Type
+                                                      (Z))
                                               ]->
                                               .)),
                                         OCaml.Effect.State.read),
@@ -251,13 +316,20 @@ Value
                               ])
                         ]))),
             Apply
-              ((9, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+              ((9,
+                Effect
+                  ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
                 Variable
                   ((9,
                     Effect
                       ([ ],
-                        . -[ (OCaml.Effect.State.state, Z) ]->
-                          .)), OCaml.Effect.State.read),
+                        .
+                          -[
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (Z))
+                          ]-> .)), OCaml.Effect.State.read),
                 [ Variable ((9, Effect ([ ], .)), c) ])))
     ])
 
@@ -270,12 +342,17 @@ Value
           ((?,
             Effect
               ([
-                (OCaml.Effect.State.state, (list, Z));
-                (OCaml.Effect.State.state,
-                  (list,
-                    (OCaml.Effect.State.t,
+                Type (OCaml.Effect.State.state, Type (list, Type (Z)));
+                Type
+                  (OCaml.Effect.State.state,
+                    Type
                       (list,
-                        Z))));
+                        Type
+                          (OCaml.Effect.State.t,
+                            Type
+                              (list,
+                                Type
+                                  (Z)))));
                 Counter;
                 NonTermination
               ], .)), Variable ((?, Effect ([ ], .)), x),
@@ -285,14 +362,22 @@ Value
                   (12,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          (list,
-                            Z));
-                        (OCaml.Effect.State.state,
-                          (list,
-                            (OCaml.Effect.State.t,
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
                               (list,
-                                Z))));
+                                Type
+                                  (Z)));
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (list,
+                                Type
+                                  (OCaml.Effect.State.t,
+                                    Type
+                                      (list,
+                                        Type
+                                          (Z)))));
                         Counter;
                         NonTermination
                       ],
@@ -302,14 +387,22 @@ Value
                     ((12,
                       Effect
                         ([
-                          (OCaml.Effect.State.state,
-                            (list,
-                              Z));
-                          (OCaml.Effect.State.state,
-                            (list,
-                              (OCaml.Effect.State.t,
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
                                 (list,
-                                  Z))))
+                                  Type
+                                    (Z)));
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (list,
+                                  Type
+                                    (OCaml.Effect.State.t,
+                                      Type
+                                        (list,
+                                          Type
+                                            (Z)))))
                         ],
                           .)),
                       Variable
@@ -319,11 +412,16 @@ Value
                             ],
                               .
                                 -[
-                                  (OCaml.Effect.State.state,
-                                    (list,
-                                      (OCaml.Effect.State.t,
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
                                         (list,
-                                          Z))))
+                                          Type
+                                            (OCaml.Effect.State.t,
+                                              Type
+                                                (list,
+                                                  Type
+                                                    (Z)))))
                                 ]->
                                 .)),
                           OCaml.Pervasives.ref),
@@ -332,9 +430,12 @@ Value
                           ((12,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  (list,
-                                    Z))
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (list,
+                                        Type
+                                          (Z)))
                               ],
                                 .)),
                             cons,
@@ -342,9 +443,12 @@ Value
                               ((12,
                                 Effect
                                   ([
-                                    (OCaml.Effect.State.state,
-                                      (list,
-                                        Z))
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (list,
+                                            Type
+                                              (Z)))
                                   ],
                                     .)),
                                 Variable
@@ -354,9 +458,12 @@ Value
                                       ],
                                         .
                                           -[
-                                            (OCaml.Effect.State.state,
-                                              (list,
-                                                Z))
+                                            Type
+                                              (OCaml.Effect.State.state,
+                                                Type
+                                                  (list,
+                                                    Type
+                                                      (Z)))
                                           ]->
                                           .)),
                                     OCaml.Pervasives.ref),
@@ -401,9 +508,12 @@ Value
                               ((12,
                                 Effect
                                   ([
-                                    (OCaml.Effect.State.state,
-                                      (list,
-                                        Z))
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (list,
+                                            Type
+                                              (Z)))
                                   ],
                                     .)),
                                 cons,
@@ -411,9 +521,12 @@ Value
                                   ((12,
                                     Effect
                                       ([
-                                        (OCaml.Effect.State.state,
-                                          (list,
-                                            Z))
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (list,
+                                                Type
+                                                  (Z)))
                                       ],
                                         .)),
                                     Variable
@@ -423,9 +536,12 @@ Value
                                           ],
                                             .
                                               -[
-                                                (OCaml.Effect.State.state,
-                                                  (list,
-                                                    Z))
+                                                Type
+                                                  (OCaml.Effect.State.state,
+                                                    Type
+                                                      (list,
+                                                        Type
+                                                          (Z)))
                                               ]->
                                               .)),
                                         OCaml.Pervasives.ref),
@@ -484,9 +600,12 @@ Value
                                   ((12,
                                     Effect
                                       ([
-                                        (OCaml.Effect.State.state,
-                                          (list,
-                                            Z))
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (list,
+                                                Type
+                                                  (Z)))
                                       ],
                                         .)),
                                     cons,
@@ -494,9 +613,12 @@ Value
                                       ((12,
                                         Effect
                                           ([
-                                            (OCaml.Effect.State.state,
-                                              (list,
-                                                Z))
+                                            Type
+                                              (OCaml.Effect.State.state,
+                                                Type
+                                                  (list,
+                                                    Type
+                                                      (Z)))
                                           ],
                                             .)),
                                         Variable
@@ -506,9 +628,12 @@ Value
                                               ],
                                                 .
                                                   -[
-                                                    (OCaml.Effect.State.state,
-                                                      (list,
-                                                        Z))
+                                                    Type
+                                                      (OCaml.Effect.State.state,
+                                                        Type
+                                                          (list,
+                                                            Type
+                                                              (Z)))
                                                   ]->
                                                   .)),
                                             OCaml.Pervasives.ref),
@@ -562,14 +687,22 @@ Value
                   (13,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          (list,
-                            Z));
-                        (OCaml.Effect.State.state,
-                          (list,
-                            (OCaml.Effect.State.t,
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
                               (list,
-                                Z))));
+                                Type
+                                  (Z)));
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (list,
+                                Type
+                                  (OCaml.Effect.State.t,
+                                    Type
+                                      (list,
+                                        Type
+                                          (Z)))));
                         Counter;
                         NonTermination
                       ],
@@ -579,9 +712,12 @@ Value
                     ((13,
                       Effect
                         ([
-                          (OCaml.Effect.State.state,
-                            (list,
-                              Z))
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (list,
+                                  Type
+                                    (Z)))
                         ],
                           .)),
                       Variable
@@ -591,9 +727,12 @@ Value
                             ],
                               .
                                 -[
-                                  (OCaml.Effect.State.state,
-                                    (list,
-                                      Z))
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (list,
+                                          Type
+                                            (Z)))
                                 ]->
                                 .)),
                           OCaml.Pervasives.ref),
@@ -611,14 +750,22 @@ Value
                   ((14,
                     Effect
                       ([
-                        (OCaml.Effect.State.state,
-                          (list,
-                            Z));
-                        (OCaml.Effect.State.state,
-                          (list,
-                            (OCaml.Effect.State.t,
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
                               (list,
-                                Z))));
+                                Type
+                                  (Z)));
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (list,
+                                Type
+                                  (OCaml.Effect.State.t,
+                                    Type
+                                      (list,
+                                        Type
+                                          (Z)))));
                         Counter;
                         NonTermination
                       ],
@@ -627,14 +774,22 @@ Value
                       ((14,
                         Effect
                           ([
-                            (OCaml.Effect.State.state,
-                              (list,
-                                Z));
-                            (OCaml.Effect.State.state,
-                              (list,
-                                (OCaml.Effect.State.t,
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
                                   (list,
-                                    Z))));
+                                    Type
+                                      (Z)));
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (list,
+                                    Type
+                                      (OCaml.Effect.State.t,
+                                        Type
+                                          (list,
+                                            Type
+                                              (Z)))));
                             Counter;
                             NonTermination
                           ],
@@ -643,11 +798,16 @@ Value
                           ((14,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  (list,
-                                    (OCaml.Effect.State.t,
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
                                       (list,
-                                        Z))))
+                                        Type
+                                          (OCaml.Effect.State.t,
+                                            Type
+                                              (list,
+                                                Type
+                                                  (Z)))))
                               ],
                                 .)),
                             Variable
@@ -662,11 +822,16 @@ Value
                                 ((14,
                                   Effect
                                     ([
-                                      (OCaml.Effect.State.state,
-                                        (list,
-                                          (OCaml.Effect.State.t,
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
                                             (list,
-                                              Z))))
+                                              Type
+                                                (OCaml.Effect.State.t,
+                                                  Type
+                                                    (list,
+                                                      Type
+                                                        (Z)))))
                                     ],
                                       .)),
                                   Variable
@@ -681,11 +846,16 @@ Value
                                       ((14,
                                         Effect
                                           ([
-                                            (OCaml.Effect.State.state,
-                                              (list,
-                                                (OCaml.Effect.State.t,
+                                            Type
+                                              (OCaml.Effect.State.state,
+                                                Type
                                                   (list,
-                                                    Z))))
+                                                    Type
+                                                      (OCaml.Effect.State.t,
+                                                        Type
+                                                          (list,
+                                                            Type
+                                                              (Z)))))
                                           ],
                                             .)),
                                         Variable
@@ -695,11 +865,16 @@ Value
                                               ],
                                                 .
                                                   -[
-                                                    (OCaml.Effect.State.state,
-                                                      (list,
-                                                        (OCaml.Effect.State.t,
+                                                    Type
+                                                      (OCaml.Effect.State.state,
+                                                        Type
                                                           (list,
-                                                            Z))))
+                                                            Type
+                                                              (OCaml.Effect.State.t,
+                                                                Type
+                                                                  (list,
+                                                                    Type
+                                                                      (Z)))))
                                                   ]->
                                                   .)),
                                             OCaml.Effect.State.read),
@@ -725,14 +900,22 @@ Value
                           ((15,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  (list,
-                                    Z));
-                                (OCaml.Effect.State.state,
-                                  (list,
-                                    (OCaml.Effect.State.t,
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
                                       (list,
-                                        Z))));
+                                        Type
+                                          (Z)));
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (list,
+                                        Type
+                                          (OCaml.Effect.State.t,
+                                            Type
+                                              (list,
+                                                Type
+                                                  (Z)))));
                                 Counter;
                                 NonTermination
                               ],
@@ -741,11 +924,16 @@ Value
                               ((15,
                                 Effect
                                   ([
-                                    (OCaml.Effect.State.state,
-                                      (list,
-                                        (OCaml.Effect.State.t,
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
                                           (list,
-                                            Z))))
+                                            Type
+                                              (OCaml.Effect.State.t,
+                                                Type
+                                                  (list,
+                                                    Type
+                                                      (Z)))))
                                   ],
                                     .)),
                                 Variable
@@ -755,11 +943,16 @@ Value
                                       ],
                                         .
                                           -[
-                                            (OCaml.Effect.State.state,
-                                              (list,
-                                                (OCaml.Effect.State.t,
+                                            Type
+                                              (OCaml.Effect.State.state,
+                                                Type
                                                   (list,
-                                                    Z))))
+                                                    Type
+                                                      (OCaml.Effect.State.t,
+                                                        Type
+                                                          (list,
+                                                            Type
+                                                              (Z)))))
                                           ]->
                                           .)),
                                     OCaml.Effect.State.read),
@@ -790,14 +983,22 @@ Value
                                   ((18,
                                     Effect
                                       ([
-                                        (OCaml.Effect.State.state,
-                                          (list,
-                                            Z));
-                                        (OCaml.Effect.State.state,
-                                          (list,
-                                            (OCaml.Effect.State.t,
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
                                               (list,
-                                                Z))));
+                                                Type
+                                                  (Z)));
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (list,
+                                                Type
+                                                  (OCaml.Effect.State.t,
+                                                    Type
+                                                      (list,
+                                                        Type
+                                                          (Z)))));
                                         Counter;
                                         NonTermination
                                       ],
@@ -806,9 +1007,12 @@ Value
                                       ((18,
                                         Effect
                                           ([
-                                            (OCaml.Effect.State.state,
-                                              (list,
-                                                Z));
+                                            Type
+                                              (OCaml.Effect.State.state,
+                                                Type
+                                                  (list,
+                                                    Type
+                                                      (Z)));
                                             Counter;
                                             NonTermination
                                           ],
@@ -817,9 +1021,12 @@ Value
                                           ((18,
                                             Effect
                                               ([
-                                                (OCaml.Effect.State.state,
-                                                  (list,
-                                                    Z))
+                                                Type
+                                                  (OCaml.Effect.State.state,
+                                                    Type
+                                                      (list,
+                                                        Type
+                                                          (Z)))
                                               ],
                                                 .)),
                                             Variable
@@ -834,9 +1041,12 @@ Value
                                                 ((18,
                                                   Effect
                                                     ([
-                                                      (OCaml.Effect.State.state,
-                                                        (list,
-                                                          Z))
+                                                      Type
+                                                        (OCaml.Effect.State.state,
+                                                          Type
+                                                            (list,
+                                                              Type
+                                                                (Z)))
                                                     ],
                                                       .)),
                                                   Variable
@@ -851,9 +1061,12 @@ Value
                                                       ((18,
                                                         Effect
                                                           ([
-                                                            (OCaml.Effect.State.state,
-                                                              (list,
-                                                                Z))
+                                                            Type
+                                                              (OCaml.Effect.State.state,
+                                                                Type
+                                                                  (list,
+                                                                    Type
+                                                                      (Z)))
                                                           ],
                                                             .)),
                                                         Variable
@@ -863,9 +1076,12 @@ Value
                                                               ],
                                                                 .
                                                                   -[
-                                                                    (OCaml.Effect.State.state,
-                                                                      (list,
-                                                                        Z))
+                                                                    Type
+                                                                      (OCaml.Effect.State.state,
+                                                                        Type
+                                                                          (list,
+                                                                            Type
+                                                                              (Z)))
                                                                   ]->
                                                                   .)),
                                                             OCaml.Effect.State.read),
@@ -891,18 +1107,24 @@ Value
                                           ((19,
                                             Effect
                                               ([
-                                                (OCaml.Effect.State.state,
-                                                  (list,
-                                                    Z))
+                                                Type
+                                                  (OCaml.Effect.State.state,
+                                                    Type
+                                                      (list,
+                                                        Type
+                                                          (Z)))
                                               ],
                                                 .)),
                                             Apply
                                               ((19,
                                                 Effect
                                                   ([
-                                                    (OCaml.Effect.State.state,
-                                                      (list,
-                                                        Z))
+                                                    Type
+                                                      (OCaml.Effect.State.state,
+                                                        Type
+                                                          (list,
+                                                            Type
+                                                              (Z)))
                                                   ],
                                                     .)),
                                                 Variable
@@ -912,9 +1134,12 @@ Value
                                                       ],
                                                         .
                                                           -[
-                                                            (OCaml.Effect.State.state,
-                                                              (list,
-                                                                Z))
+                                                            Type
+                                                              (OCaml.Effect.State.state,
+                                                                Type
+                                                                  (list,
+                                                                    Type
+                                                                      (Z)))
                                                           ]->
                                                           .)),
                                                     OCaml.Effect.State.read),
@@ -945,18 +1170,24 @@ Value
                                                   ((22,
                                                     Effect
                                                       ([
-                                                        (OCaml.Effect.State.state,
-                                                          (list,
-                                                            Z))
+                                                        Type
+                                                          (OCaml.Effect.State.state,
+                                                            Type
+                                                              (list,
+                                                                Type
+                                                                  (Z)))
                                                       ],
                                                         .)),
                                                     Apply
                                                       ((22,
                                                         Effect
                                                           ([
-                                                            (OCaml.Effect.State.state,
-                                                              (list,
-                                                                Z))
+                                                            Type
+                                                              (OCaml.Effect.State.state,
+                                                                Type
+                                                                  (list,
+                                                                    Type
+                                                                      (Z)))
                                                           ],
                                                             .)),
                                                         Variable
@@ -968,9 +1199,12 @@ Value
                                                                   ->
                                                                   .
                                                                     -[
-                                                                      (OCaml.Effect.State.state,
-                                                                        (list,
-                                                                          Z))
+                                                                      Type
+                                                                        (OCaml.Effect.State.state,
+                                                                          Type
+                                                                            (list,
+                                                                              Type
+                                                                                (Z)))
                                                                     ]->
                                                                     .)),
                                                             OCaml.Effect.State.write),
@@ -986,9 +1220,12 @@ Value
                                                             ((22,
                                                               Effect
                                                                 ([
-                                                                  (OCaml.Effect.State.state,
-                                                                    (list,
-                                                                      Z))
+                                                                  Type
+                                                                    (OCaml.Effect.State.state,
+                                                                      Type
+                                                                        (list,
+                                                                          Type
+                                                                            (Z)))
                                                                 ],
                                                                   .)),
                                                               cons,
@@ -1003,9 +1240,12 @@ Value
                                                                 ((22,
                                                                   Effect
                                                                     ([
-                                                                      (OCaml.Effect.State.state,
-                                                                        (list,
-                                                                          Z))
+                                                                      Type
+                                                                        (OCaml.Effect.State.state,
+                                                                          Type
+                                                                            (list,
+                                                                              Type
+                                                                                (Z)))
                                                                     ],
                                                                       .)),
                                                                   Variable
@@ -1015,9 +1255,12 @@ Value
                                                                         ],
                                                                           .
                                                                             -[
-                                                                              (OCaml.Effect.State.state,
-                                                                                (list,
-                                                                                  Z))
+                                                                              Type
+                                                                                (OCaml.Effect.State.state,
+                                                                                  Type
+                                                                                    (list,
+                                                                                      Type
+                                                                                        (Z)))
                                                                             ]->
                                                                             .)),
                                                                       OCaml.Effect.State.read),
@@ -1035,9 +1278,12 @@ Value
                                                       ((23,
                                                         Effect
                                                           ([
-                                                            (OCaml.Effect.State.state,
-                                                              (list,
-                                                                Z))
+                                                            Type
+                                                              (OCaml.Effect.State.state,
+                                                                Type
+                                                                  (list,
+                                                                    Type
+                                                                      (Z)))
                                                           ],
                                                             .)),
                                                         Variable
@@ -1049,9 +1295,12 @@ Value
                                                                   ->
                                                                   .
                                                                     -[
-                                                                      (OCaml.Effect.State.state,
-                                                                        (list,
-                                                                          Z))
+                                                                      Type
+                                                                        (OCaml.Effect.State.state,
+                                                                          Type
+                                                                            (list,
+                                                                              Type
+                                                                                (Z)))
                                                                     ]->
                                                                     .)),
                                                             OCaml.Effect.State.write),
@@ -1076,11 +1325,16 @@ Value
                                       ((25,
                                         Effect
                                           ([
-                                            (OCaml.Effect.State.state,
-                                              (list,
-                                                (OCaml.Effect.State.t,
+                                            Type
+                                              (OCaml.Effect.State.state,
+                                                Type
                                                   (list,
-                                                    Z))))
+                                                    Type
+                                                      (OCaml.Effect.State.t,
+                                                        Type
+                                                          (list,
+                                                            Type
+                                                              (Z)))))
                                           ],
                                             .)),
                                         Variable
@@ -1092,11 +1346,16 @@ Value
                                                   ->
                                                   .
                                                     -[
-                                                      (OCaml.Effect.State.state,
-                                                        (list,
-                                                          (OCaml.Effect.State.t,
+                                                      Type
+                                                        (OCaml.Effect.State.state,
+                                                          Type
                                                             (list,
-                                                              Z))))
+                                                              Type
+                                                                (OCaml.Effect.State.t,
+                                                                  Type
+                                                                    (list,
+                                                                      Type
+                                                                        (Z)))))
                                                     ]->
                                                     .)),
                                             OCaml.Effect.State.write),
@@ -1121,9 +1380,12 @@ Value
                       ((27,
                         Effect
                           ([
-                            (OCaml.Effect.State.state,
-                              (list,
-                                Z))
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (list,
+                                    Type
+                                      (Z)))
                           ],
                             .)),
                         Variable
@@ -1133,9 +1395,12 @@ Value
                               ],
                                 .
                                   -[
-                                    (OCaml.Effect.State.state,
-                                      (list,
-                                        Z))
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (list,
+                                            Type
+                                              (Z)))
                                   ]->
                                   .)),
                             OCaml.Effect.State.read),
@@ -1261,58 +1526,97 @@ Value
         LetVar
           (41,
             Effect
-              ([ (OCaml.Effect.State.state, Z); Counter; NonTermination ],
-                .)) y =
+              ([
+                Type (OCaml.Effect.State.state, Type (Z));
+                Counter;
+                NonTermination
+              ], .)) y =
           Apply
-            ((41, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+            ((41,
+              Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
               Variable
                 ((41,
                   Effect
-                    ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
-                  OCaml.Pervasives.ref),
+                    ([ ],
+                      .
+                        -[
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
+                        ]-> .)), OCaml.Pervasives.ref),
               [ Variable ((41, Effect ([ ], .)), y) ]) in
         LetVar
           (42,
             Effect
-              ([ (OCaml.Effect.State.state, Z); Counter; NonTermination ],
-                .)) z =
+              ([
+                Type (OCaml.Effect.State.state, Type (Z));
+                Counter;
+                NonTermination
+              ], .)) z =
           Apply
-            ((42, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+            ((42,
+              Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
               Variable
                 ((42,
                   Effect
-                    ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
-                  OCaml.Pervasives.ref),
+                    ([ ],
+                      .
+                        -[
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
+                        ]-> .)), OCaml.Pervasives.ref),
               [ Constant ((42, Effect ([ ], .)), Int(0)) ]) in
         LetVar
           (43,
             Effect
-              ([ (OCaml.Effect.State.state, Z); Counter; NonTermination ],
-                .)) i =
+              ([
+                Type (OCaml.Effect.State.state, Type (Z));
+                Counter;
+                NonTermination
+              ], .)) i =
           Apply
-            ((43, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+            ((43,
+              Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
               Variable
                 ((43,
                   Effect
-                    ([ ], . -[ (OCaml.Effect.State.state, Z) ]-> .)),
-                  OCaml.Pervasives.ref),
+                    ([ ],
+                      .
+                        -[
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
+                        ]-> .)), OCaml.Pervasives.ref),
               [ Constant ((43, Effect ([ ], .)), Int(0)) ]) in
         Sequence
           ((44,
             Effect
-              ([ (OCaml.Effect.State.state, Z); Counter; NonTermination ],
-                .)),
+              ([
+                Type (OCaml.Effect.State.state, Type (Z));
+                Counter;
+                NonTermination
+              ], .)),
             While
               ((44,
                 Effect
                   ([
-                    (OCaml.Effect.State.state, Z);
+                    Type (OCaml.Effect.State.state, Type (Z));
                     Counter;
                     NonTermination
                   ], .)),
                 Apply
                   ((44,
-                    Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+                    Effect
+                      ([
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z))
+                      ], .)),
                     Variable
                       ((44, Effect ([ ], .)),
                         OCaml.Pervasives.le),
@@ -1321,8 +1625,10 @@ Value
                         ((44,
                           Effect
                             ([
-                              (OCaml.Effect.State.state,
-                                Z)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z))
                             ],
                               .)),
                           Variable
@@ -1332,8 +1638,10 @@ Value
                                 ],
                                   .
                                     -[
-                                      (OCaml.Effect.State.state,
-                                        Z)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z))
                                     ]->
                                     .)),
                               OCaml.Effect.State.read),
@@ -1350,8 +1658,10 @@ Value
                         ((44,
                           Effect
                             ([
-                              (OCaml.Effect.State.state,
-                                Z)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z))
                             ],
                               .)),
                           Variable
@@ -1361,8 +1671,10 @@ Value
                                 ],
                                   .
                                     -[
-                                      (OCaml.Effect.State.state,
-                                        Z)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z))
                                     ]->
                                     .)),
                               OCaml.Effect.State.read),
@@ -1380,22 +1692,32 @@ Value
                   (45,
                     Effect
                       ([
-                        (OCaml.Effect.State.state, Z);
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z));
                         Counter;
                         NonTermination
                       ], .)) j =
                   Apply
                     ((45,
                       Effect
-                        ([ (OCaml.Effect.State.state, Z) ], .)),
+                        ([
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
+                        ], .)),
                       Variable
                         ((45,
                           Effect
                             ([ ],
                               .
                                 -[
-                                  (OCaml.Effect.State.state,
-                                    Z)
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
                                 ]-> .)),
                           OCaml.Pervasives.ref),
                       [
@@ -1411,7 +1733,10 @@ Value
                   ((46,
                     Effect
                       ([
-                        (OCaml.Effect.State.state, Z);
+                        Type
+                          (OCaml.Effect.State.state,
+                            Type
+                              (Z));
                         Counter;
                         NonTermination
                       ], .)),
@@ -1419,7 +1744,10 @@ Value
                       ((46,
                         Effect
                           ([
-                            (OCaml.Effect.State.state, Z);
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (Z));
                             Counter;
                             NonTermination
                           ], .)),
@@ -1427,8 +1755,10 @@ Value
                           ((46,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  Z)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z))
                               ], .)),
                             Variable
                               ((46, Effect ([ ], .)),
@@ -1438,8 +1768,10 @@ Value
                                 ((46,
                                   Effect
                                     ([
-                                      (OCaml.Effect.State.state,
-                                        Z)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z))
                                     ],
                                       .)),
                                   Variable
@@ -1449,8 +1781,10 @@ Value
                                         ],
                                           .
                                             -[
-                                              (OCaml.Effect.State.state,
-                                                Z)
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (Z))
                                             ]->
                                             .)),
                                       OCaml.Effect.State.read),
@@ -1467,8 +1801,10 @@ Value
                                 ((46,
                                   Effect
                                     ([
-                                      (OCaml.Effect.State.state,
-                                        Z)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z))
                                     ],
                                       .)),
                                   Variable
@@ -1478,8 +1814,10 @@ Value
                                         ],
                                           .
                                             -[
-                                              (OCaml.Effect.State.state,
-                                                Z)
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (Z))
                                             ]->
                                             .)),
                                       OCaml.Effect.State.read),
@@ -1497,15 +1835,19 @@ Value
                           ((47,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  Z)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z))
                               ], .)),
                             Apply
                               ((47,
                                 Effect
                                   ([
-                                    (OCaml.Effect.State.state,
-                                      Z)
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (Z))
                                   ], .)),
                                 Variable
                                   ((47,
@@ -1514,8 +1856,10 @@ Value
                                         . ->
                                           .
                                             -[
-                                              (OCaml.Effect.State.state,
-                                                Z)
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (Z))
                                             ]->
                                             .)),
                                     OCaml.Effect.State.write),
@@ -1531,8 +1875,10 @@ Value
                                     ((47,
                                       Effect
                                         ([
-                                          (OCaml.Effect.State.state,
-                                            Z)
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (Z))
                                         ],
                                           .)),
                                       Variable
@@ -1547,8 +1893,10 @@ Value
                                           ((47,
                                             Effect
                                               ([
-                                                (OCaml.Effect.State.state,
-                                                  Z)
+                                                Type
+                                                  (OCaml.Effect.State.state,
+                                                    Type
+                                                      (Z))
                                               ],
                                                 .)),
                                             Variable
@@ -1558,8 +1906,10 @@ Value
                                                   ],
                                                     .
                                                       -[
-                                                        (OCaml.Effect.State.state,
-                                                          Z)
+                                                        Type
+                                                          (OCaml.Effect.State.state,
+                                                            Type
+                                                              (Z))
                                                       ]->
                                                       .)),
                                                 OCaml.Effect.State.read),
@@ -1585,8 +1935,10 @@ Value
                               ((48,
                                 Effect
                                   ([
-                                    (OCaml.Effect.State.state,
-                                      Z)
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (Z))
                                   ], .)),
                                 Variable
                                   ((48,
@@ -1595,8 +1947,10 @@ Value
                                         . ->
                                           .
                                             -[
-                                              (OCaml.Effect.State.state,
-                                                Z)
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (Z))
                                             ]->
                                             .)),
                                     OCaml.Effect.State.write),
@@ -1612,8 +1966,10 @@ Value
                                     ((48,
                                       Effect
                                         ([
-                                          (OCaml.Effect.State.state,
-                                            Z)
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (Z))
                                         ],
                                           .)),
                                       Variable
@@ -1628,8 +1984,10 @@ Value
                                           ((48,
                                             Effect
                                               ([
-                                                (OCaml.Effect.State.state,
-                                                  Z)
+                                                Type
+                                                  (OCaml.Effect.State.state,
+                                                    Type
+                                                      (Z))
                                               ],
                                                 .)),
                                             Variable
@@ -1639,8 +1997,10 @@ Value
                                                   ],
                                                     .
                                                       -[
-                                                        (OCaml.Effect.State.state,
-                                                          Z)
+                                                        Type
+                                                          (OCaml.Effect.State.state,
+                                                            Type
+                                                              (Z))
                                                       ]->
                                                       .)),
                                                 OCaml.Effect.State.read),
@@ -1665,14 +2025,20 @@ Value
                     Sequence
                       ((50,
                         Effect
-                          ([ (OCaml.Effect.State.state, Z) ],
-                            .)),
+                          ([
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (Z))
+                          ], .)),
                         Apply
                           ((50,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  Z)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z))
                               ], .)),
                             Variable
                               ((50,
@@ -1681,8 +2047,10 @@ Value
                                     . ->
                                       .
                                         -[
-                                          (OCaml.Effect.State.state,
-                                            Z)
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (Z))
                                         ]-> .)),
                                 OCaml.Effect.State.write),
                             [
@@ -1697,8 +2065,10 @@ Value
                                 ((50,
                                   Effect
                                     ([
-                                      (OCaml.Effect.State.state,
-                                        Z)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z))
                                     ],
                                       .)),
                                   Variable
@@ -1713,8 +2083,10 @@ Value
                                       ((50,
                                         Effect
                                           ([
-                                            (OCaml.Effect.State.state,
-                                              Z)
+                                            Type
+                                              (OCaml.Effect.State.state,
+                                                Type
+                                                  (Z))
                                           ],
                                             .)),
                                         Variable
@@ -1724,8 +2096,10 @@ Value
                                               ],
                                                 .
                                                   -[
-                                                    (OCaml.Effect.State.state,
-                                                      Z)
+                                                    Type
+                                                      (OCaml.Effect.State.state,
+                                                        Type
+                                                          (Z))
                                                   ]->
                                                   .)),
                                             OCaml.Effect.State.read),
@@ -1751,8 +2125,10 @@ Value
                           ((51,
                             Effect
                               ([
-                                (OCaml.Effect.State.state,
-                                  Z)
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z))
                               ], .)),
                             Variable
                               ((51,
@@ -1761,8 +2137,10 @@ Value
                                     . ->
                                       .
                                         -[
-                                          (OCaml.Effect.State.state,
-                                            Z)
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (Z))
                                         ]-> .)),
                                 OCaml.Effect.State.write),
                             [
@@ -1777,8 +2155,10 @@ Value
                                 ((51,
                                   Effect
                                     ([
-                                      (OCaml.Effect.State.state,
-                                        Z)
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (Z))
                                     ],
                                       .)),
                                   Variable
@@ -1793,8 +2173,10 @@ Value
                                       ((51,
                                         Effect
                                           ([
-                                            (OCaml.Effect.State.state,
-                                              Z)
+                                            Type
+                                              (OCaml.Effect.State.state,
+                                                Type
+                                                  (Z))
                                           ],
                                             .)),
                                         Variable
@@ -1804,8 +2186,10 @@ Value
                                               ],
                                                 .
                                                   -[
-                                                    (OCaml.Effect.State.state,
-                                                      Z)
+                                                    Type
+                                                      (OCaml.Effect.State.state,
+                                                        Type
+                                                          (Z))
                                                   ]->
                                                   .)),
                                             OCaml.Effect.State.read),
@@ -1828,12 +2212,19 @@ Value
                                   ])
                             ])))),
             Apply
-              ((53, Effect ([ (OCaml.Effect.State.state, Z) ], .)),
+              ((53,
+                Effect
+                  ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
                 Variable
                   ((53,
                     Effect
                       ([ ],
-                        . -[ (OCaml.Effect.State.state, Z) ]->
-                          .)), OCaml.Effect.State.read),
+                        .
+                          -[
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (Z))
+                          ]-> .)), OCaml.Effect.State.read),
                 [ Variable ((53, Effect ([ ], .)), z) ])))
     ])

--- a/tests/ex43.monadise
+++ b/tests/ex43.monadise
@@ -6,14 +6,17 @@ Value
     [
       ((slow_div, [ ], [ (a, Type (Z)); (b, Type (Z)) ],
         Monad
-          ([ (OCaml.Effect.State.state, Z); Counter; NonTermination ],
-            Type (Z))),
+          ([
+            Type (OCaml.Effect.State.state, Type (Z));
+            Counter;
+            NonTermination
+          ], Type (Z))),
         Bind
           (?,
             Lift
-              (?, [ (OCaml.Effect.State.state, Z) ],
+              (?, [ Type (OCaml.Effect.State.state, Type (Z)) ],
                 [
-                  (OCaml.Effect.State.state, Z);
+                  Type (OCaml.Effect.State.state, Type (Z));
                   Counter;
                   NonTermination
                 ],
@@ -23,9 +26,9 @@ Value
             Bind
               (?,
                 Lift
-                  (?, [ (OCaml.Effect.State.state, Z) ],
+                  (?, [ Type (OCaml.Effect.State.state, Type (Z)) ],
                     [
-                      (OCaml.Effect.State.state, Z);
+                      Type (OCaml.Effect.State.state, Type (Z));
                       Counter;
                       NonTermination
                     ],
@@ -45,8 +48,10 @@ Value
                             ],
                             Monad
                               ([
-                                (OCaml.Effect.State.state,
-                                  Z);
+                                Type
+                                  (OCaml.Effect.State.state,
+                                    Type
+                                      (Z));
                                 NonTermination
                               ],
                                 ())),
@@ -64,8 +69,10 @@ Value
                                           NonTermination
                                         ],
                                         [
-                                          (OCaml.Effect.State.state,
-                                            Z);
+                                          Type
+                                            (OCaml.Effect.State.state,
+                                              Type
+                                                (Z));
                                           NonTermination
                                         ],
                                         Apply
@@ -86,12 +93,16 @@ Value
                                         Lift
                                           (?,
                                             [
-                                              (OCaml.Effect.State.state,
-                                                Z)
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (Z))
                                             ],
                                             [
-                                              (OCaml.Effect.State.state,
-                                                Z);
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (Z));
                                               NonTermination
                                             ],
                                             Bind
@@ -154,12 +165,16 @@ Value
                                                 Lift
                                                   (?,
                                                     [
-                                                      (OCaml.Effect.State.state,
-                                                        Z)
+                                                      Type
+                                                        (OCaml.Effect.State.state,
+                                                          Type
+                                                            (Z))
                                                     ],
                                                     [
-                                                      (OCaml.Effect.State.state,
-                                                        Z);
+                                                      Type
+                                                        (OCaml.Effect.State.state,
+                                                          Type
+                                                            (Z));
                                                       NonTermination
                                                     ],
                                                     Bind
@@ -280,8 +295,10 @@ Value
                         Lift
                           (?, [ Counter ],
                             [
-                              (OCaml.Effect.State.state,
-                                Z);
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z));
                               Counter;
                               NonTermination
                             ],
@@ -294,13 +311,17 @@ Value
                         Lift
                           (?,
                             [
-                              (OCaml.Effect.State.state,
-                                Z);
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z));
                               NonTermination
                             ],
                             [
-                              (OCaml.Effect.State.state,
-                                Z);
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z));
                               Counter;
                               NonTermination
                             ],
@@ -312,9 +333,18 @@ Value
                                       counter)
                                 ]))), None,
                     Lift
-                      (?, [ (OCaml.Effect.State.state, Z) ],
+                      (?,
                         [
-                          (OCaml.Effect.State.state, Z);
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
+                        ],
+                        [
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z));
                           Counter;
                           NonTermination
                         ],
@@ -333,9 +363,17 @@ Value
       ((nested, [ ], [ (es_in, list Effect.t); (x, Type (unit)) ],
         Monad
           ([
-            (OCaml.Effect.State.state, (list, Z));
-            (OCaml.Effect.State.state,
-              (list, (OCaml.Effect.State.t, (list, Z))));
+            Type (OCaml.Effect.State.state, Type (list, Type (Z)));
+            Type
+              (OCaml.Effect.State.state,
+                Type
+                  (list,
+                    Type
+                      (OCaml.Effect.State.t,
+                        Type
+                          (list,
+                            Type
+                              (Z)))));
             Counter;
             NonTermination
           ], Type (list, Type (Z)))),
@@ -348,24 +386,40 @@ Value
                     Lift
                       (?,
                         [
-                          (OCaml.Effect.State.state,
-                            (list,
-                              Z));
-                          (OCaml.Effect.State.state,
-                            (list,
-                              (OCaml.Effect.State.t,
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
                                 (list,
-                                  Z))))
+                                  Type
+                                    (Z)));
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (list,
+                                  Type
+                                    (OCaml.Effect.State.t,
+                                      Type
+                                        (list,
+                                          Type
+                                            (Z)))))
                         ],
                         [
-                          (OCaml.Effect.State.state,
-                            (list,
-                              Z));
-                          (OCaml.Effect.State.state,
-                            (list,
-                              (OCaml.Effect.State.t,
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
                                 (list,
-                                  Z))));
+                                  Type
+                                    (Z)));
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (list,
+                                  Type
+                                    (OCaml.Effect.State.t,
+                                      Type
+                                        (list,
+                                          Type
+                                            (Z)))));
                           Counter;
                           NonTermination
                         ],
@@ -374,19 +428,30 @@ Value
                             Lift
                               (?,
                                 [
-                                  (OCaml.Effect.State.state,
-                                    (list,
-                                      Z))
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (list,
+                                          Type
+                                            (Z)))
                                 ],
                                 [
-                                  (OCaml.Effect.State.state,
-                                    (list,
-                                      Z));
-                                  (OCaml.Effect.State.state,
-                                    (list,
-                                      (OCaml.Effect.State.t,
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
                                         (list,
-                                          Z))))
+                                          Type
+                                            (Z)));
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (list,
+                                          Type
+                                            (OCaml.Effect.State.t,
+                                              Type
+                                                (list,
+                                                  Type
+                                                    (Z)))))
                                 ],
                                 Bind
                                   (?,
@@ -518,21 +583,34 @@ Value
                             Lift
                               (?,
                                 [
-                                  (OCaml.Effect.State.state,
-                                    (list,
-                                      (OCaml.Effect.State.t,
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
                                         (list,
-                                          Z))))
+                                          Type
+                                            (OCaml.Effect.State.t,
+                                              Type
+                                                (list,
+                                                  Type
+                                                    (Z)))))
                                 ],
                                 [
-                                  (OCaml.Effect.State.state,
-                                    (list,
-                                      Z));
-                                  (OCaml.Effect.State.state,
-                                    (list,
-                                      (OCaml.Effect.State.t,
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
                                         (list,
-                                          Z))))
+                                          Type
+                                            (Z)));
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (list,
+                                          Type
+                                            (OCaml.Effect.State.t,
+                                              Type
+                                                (list,
+                                                  Type
+                                                    (Z)))))
                                 ],
                                 Apply
                                   (12,
@@ -551,19 +629,30 @@ Value
                         Lift
                           (?,
                             [
-                              (OCaml.Effect.State.state,
-                                (list,
-                                  Z))
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (list,
+                                      Type
+                                        (Z)))
                             ],
                             [
-                              (OCaml.Effect.State.state,
-                                (list,
-                                  Z));
-                              (OCaml.Effect.State.state,
-                                (list,
-                                  (OCaml.Effect.State.t,
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
                                     (list,
-                                      Z))));
+                                      Type
+                                        (Z)));
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (list,
+                                      Type
+                                        (OCaml.Effect.State.t,
+                                          Type
+                                            (list,
+                                              Type
+                                                (Z)))));
                               Counter;
                               NonTermination
                             ],
@@ -596,14 +685,22 @@ Value
                                     ],
                                     Monad
                                       ([
-                                        (OCaml.Effect.State.state,
-                                          (list,
-                                            Z));
-                                        (OCaml.Effect.State.state,
-                                          (list,
-                                            (OCaml.Effect.State.t,
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
                                               (list,
-                                                Z))));
+                                                Type
+                                                  (Z)));
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (list,
+                                                Type
+                                                  (OCaml.Effect.State.t,
+                                                    Type
+                                                      (list,
+                                                        Type
+                                                          (Z)))));
                                         Counter;
                                         NonTermination
                                       ],
@@ -622,14 +719,22 @@ Value
                                                   NonTermination
                                                 ],
                                                 [
-                                                  (OCaml.Effect.State.state,
-                                                    (list,
-                                                      Z));
-                                                  (OCaml.Effect.State.state,
-                                                    (list,
-                                                      (OCaml.Effect.State.t,
+                                                  Type
+                                                    (OCaml.Effect.State.state,
+                                                      Type
                                                         (list,
-                                                          Z))));
+                                                          Type
+                                                            (Z)));
+                                                  Type
+                                                    (OCaml.Effect.State.state,
+                                                      Type
+                                                        (list,
+                                                          Type
+                                                            (OCaml.Effect.State.t,
+                                                              Type
+                                                                (list,
+                                                                  Type
+                                                                    (Z)))));
                                                   Counter;
                                                   NonTermination
                                                 ],
@@ -651,21 +756,34 @@ Value
                                                 Lift
                                                   (?,
                                                     [
-                                                      (OCaml.Effect.State.state,
-                                                        (list,
-                                                          (OCaml.Effect.State.t,
+                                                      Type
+                                                        (OCaml.Effect.State.state,
+                                                          Type
                                                             (list,
-                                                              Z))))
+                                                              Type
+                                                                (OCaml.Effect.State.t,
+                                                                  Type
+                                                                    (list,
+                                                                      Type
+                                                                        (Z)))))
                                                     ],
                                                     [
-                                                      (OCaml.Effect.State.state,
-                                                        (list,
-                                                          Z));
-                                                      (OCaml.Effect.State.state,
-                                                        (list,
-                                                          (OCaml.Effect.State.t,
+                                                      Type
+                                                        (OCaml.Effect.State.state,
+                                                          Type
                                                             (list,
-                                                              Z))));
+                                                              Type
+                                                                (Z)));
+                                                      Type
+                                                        (OCaml.Effect.State.state,
+                                                          Type
+                                                            (list,
+                                                              Type
+                                                                (OCaml.Effect.State.t,
+                                                                  Type
+                                                                    (list,
+                                                                      Type
+                                                                        (Z)))));
                                                       Counter;
                                                       NonTermination
                                                     ],
@@ -728,21 +846,34 @@ Value
                                                             Lift
                                                               (?,
                                                                 [
-                                                                  (OCaml.Effect.State.state,
-                                                                    (list,
-                                                                      (OCaml.Effect.State.t,
+                                                                  Type
+                                                                    (OCaml.Effect.State.state,
+                                                                      Type
                                                                         (list,
-                                                                          Z))))
+                                                                          Type
+                                                                            (OCaml.Effect.State.t,
+                                                                              Type
+                                                                                (list,
+                                                                                  Type
+                                                                                    (Z)))))
                                                                 ],
                                                                 [
-                                                                  (OCaml.Effect.State.state,
-                                                                    (list,
-                                                                      Z));
-                                                                  (OCaml.Effect.State.state,
-                                                                    (list,
-                                                                      (OCaml.Effect.State.t,
+                                                                  Type
+                                                                    (OCaml.Effect.State.state,
+                                                                      Type
                                                                         (list,
-                                                                          Z))));
+                                                                          Type
+                                                                            (Z)));
+                                                                  Type
+                                                                    (OCaml.Effect.State.state,
+                                                                      Type
+                                                                        (list,
+                                                                          Type
+                                                                            (OCaml.Effect.State.t,
+                                                                              Type
+                                                                                (list,
+                                                                                  Type
+                                                                                    (Z)))));
                                                                   Counter;
                                                                   NonTermination
                                                                 ],
@@ -780,21 +911,32 @@ Value
                                                                         Lift
                                                                           (?,
                                                                             [
-                                                                              (OCaml.Effect.State.state,
-                                                                                (list,
-                                                                                  Z));
+                                                                              Type
+                                                                                (OCaml.Effect.State.state,
+                                                                                  Type
+                                                                                    (list,
+                                                                                      Type
+                                                                                        (Z)));
                                                                               Counter;
                                                                               NonTermination
                                                                             ],
                                                                             [
-                                                                              (OCaml.Effect.State.state,
-                                                                                (list,
-                                                                                  Z));
-                                                                              (OCaml.Effect.State.state,
-                                                                                (list,
-                                                                                  (OCaml.Effect.State.t,
+                                                                              Type
+                                                                                (OCaml.Effect.State.state,
+                                                                                  Type
                                                                                     (list,
-                                                                                      Z))));
+                                                                                      Type
+                                                                                        (Z)));
+                                                                              Type
+                                                                                (OCaml.Effect.State.state,
+                                                                                  Type
+                                                                                    (list,
+                                                                                      Type
+                                                                                        (OCaml.Effect.State.t,
+                                                                                          Type
+                                                                                            (list,
+                                                                                              Type
+                                                                                                (Z)))));
                                                                               Counter;
                                                                               NonTermination
                                                                             ],
@@ -813,9 +955,12 @@ Value
                                                                                     ],
                                                                                     Monad
                                                                                       ([
-                                                                                        (OCaml.Effect.State.state,
-                                                                                          (list,
-                                                                                            Z));
+                                                                                        Type
+                                                                                          (OCaml.Effect.State.state,
+                                                                                            Type
+                                                                                              (list,
+                                                                                                Type
+                                                                                                  (Z)));
                                                                                         NonTermination
                                                                                       ],
                                                                                         ())),
@@ -833,9 +978,12 @@ Value
                                                                                                   NonTermination
                                                                                                 ],
                                                                                                 [
-                                                                                                  (OCaml.Effect.State.state,
-                                                                                                    (list,
-                                                                                                      Z));
+                                                                                                  Type
+                                                                                                    (OCaml.Effect.State.state,
+                                                                                                      Type
+                                                                                                        (list,
+                                                                                                          Type
+                                                                                                            (Z)));
                                                                                                   NonTermination
                                                                                                 ],
                                                                                                 Apply
@@ -856,14 +1004,20 @@ Value
                                                                                                 Lift
                                                                                                   (?,
                                                                                                     [
-                                                                                                      (OCaml.Effect.State.state,
-                                                                                                        (list,
-                                                                                                          Z))
+                                                                                                      Type
+                                                                                                        (OCaml.Effect.State.state,
+                                                                                                          Type
+                                                                                                            (list,
+                                                                                                              Type
+                                                                                                                (Z)))
                                                                                                     ],
                                                                                                     [
-                                                                                                      (OCaml.Effect.State.state,
-                                                                                                        (list,
-                                                                                                          Z));
+                                                                                                      Type
+                                                                                                        (OCaml.Effect.State.state,
+                                                                                                          Type
+                                                                                                            (list,
+                                                                                                              Type
+                                                                                                                (Z)));
                                                                                                       NonTermination
                                                                                                     ],
                                                                                                     Bind
@@ -923,14 +1077,20 @@ Value
                                                                                                         Lift
                                                                                                           (?,
                                                                                                             [
-                                                                                                              (OCaml.Effect.State.state,
-                                                                                                                (list,
-                                                                                                                  Z))
+                                                                                                              Type
+                                                                                                                (OCaml.Effect.State.state,
+                                                                                                                  Type
+                                                                                                                    (list,
+                                                                                                                      Type
+                                                                                                                        (Z)))
                                                                                                             ],
                                                                                                             [
-                                                                                                              (OCaml.Effect.State.state,
-                                                                                                                (list,
-                                                                                                                  Z));
+                                                                                                              Type
+                                                                                                                (OCaml.Effect.State.state,
+                                                                                                                  Type
+                                                                                                                    (list,
+                                                                                                                      Type
+                                                                                                                        (Z)));
                                                                                                               NonTermination
                                                                                                             ],
                                                                                                             Bind
@@ -1050,9 +1210,12 @@ Value
                                                                                       Counter
                                                                                     ],
                                                                                     [
-                                                                                      (OCaml.Effect.State.state,
-                                                                                        (list,
-                                                                                          Z));
+                                                                                      Type
+                                                                                        (OCaml.Effect.State.state,
+                                                                                          Type
+                                                                                            (list,
+                                                                                              Type
+                                                                                                (Z)));
                                                                                       Counter;
                                                                                       NonTermination
                                                                                     ],
@@ -1071,15 +1234,21 @@ Value
                                                                                 Lift
                                                                                   (?,
                                                                                     [
-                                                                                      (OCaml.Effect.State.state,
-                                                                                        (list,
-                                                                                          Z));
+                                                                                      Type
+                                                                                        (OCaml.Effect.State.state,
+                                                                                          Type
+                                                                                            (list,
+                                                                                              Type
+                                                                                                (Z)));
                                                                                       NonTermination
                                                                                     ],
                                                                                     [
-                                                                                      (OCaml.Effect.State.state,
-                                                                                        (list,
-                                                                                          Z));
+                                                                                      Type
+                                                                                        (OCaml.Effect.State.state,
+                                                                                          Type
+                                                                                            (list,
+                                                                                              Type
+                                                                                                (Z)));
                                                                                       Counter;
                                                                                       NonTermination
                                                                                     ],
@@ -1097,21 +1266,34 @@ Value
                                                                         Lift
                                                                           (?,
                                                                             [
-                                                                              (OCaml.Effect.State.state,
-                                                                                (list,
-                                                                                  (OCaml.Effect.State.t,
+                                                                              Type
+                                                                                (OCaml.Effect.State.state,
+                                                                                  Type
                                                                                     (list,
-                                                                                      Z))))
+                                                                                      Type
+                                                                                        (OCaml.Effect.State.t,
+                                                                                          Type
+                                                                                            (list,
+                                                                                              Type
+                                                                                                (Z)))))
                                                                             ],
                                                                             [
-                                                                              (OCaml.Effect.State.state,
-                                                                                (list,
-                                                                                  Z));
-                                                                              (OCaml.Effect.State.state,
-                                                                                (list,
-                                                                                  (OCaml.Effect.State.t,
+                                                                              Type
+                                                                                (OCaml.Effect.State.state,
+                                                                                  Type
                                                                                     (list,
-                                                                                      Z))));
+                                                                                      Type
+                                                                                        (Z)));
+                                                                              Type
+                                                                                (OCaml.Effect.State.state,
+                                                                                  Type
+                                                                                    (list,
+                                                                                      Type
+                                                                                        (OCaml.Effect.State.t,
+                                                                                          Type
+                                                                                            (list,
+                                                                                              Type
+                                                                                                (Z)))));
                                                                               Counter;
                                                                               NonTermination
                                                                             ],
@@ -1156,14 +1338,22 @@ Value
                                       Counter
                                     ],
                                     [
-                                      (OCaml.Effect.State.state,
-                                        (list,
-                                          Z));
-                                      (OCaml.Effect.State.state,
-                                        (list,
-                                          (OCaml.Effect.State.t,
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
                                             (list,
-                                              Z))));
+                                              Type
+                                                (Z)));
+                                      Type
+                                        (OCaml.Effect.State.state,
+                                          Type
+                                            (list,
+                                              Type
+                                                (OCaml.Effect.State.t,
+                                                  Type
+                                                    (list,
+                                                      Type
+                                                        (Z)))));
                                       Counter;
                                       NonTermination
                                     ],
@@ -1193,19 +1383,30 @@ Value
                             Lift
                               (?,
                                 [
-                                  (OCaml.Effect.State.state,
-                                    (list,
-                                      Z))
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (list,
+                                          Type
+                                            (Z)))
                                 ],
                                 [
-                                  (OCaml.Effect.State.state,
-                                    (list,
-                                      Z));
-                                  (OCaml.Effect.State.state,
-                                    (list,
-                                      (OCaml.Effect.State.t,
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
                                         (list,
-                                          Z))));
+                                          Type
+                                            (Z)));
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (list,
+                                          Type
+                                            (OCaml.Effect.State.t,
+                                              Type
+                                                (list,
+                                                  Type
+                                                    (Z)))));
                                   Counter;
                                   NonTermination
                                 ],
@@ -1512,14 +1713,17 @@ Value
       ((argument_effects, [ ],
         [ (x, Type (OCaml.Effect.State.t, Type (Z))); (y, Type (Z)) ],
         Monad
-          ([ (OCaml.Effect.State.state, Z); Counter; NonTermination ],
-            Type (Z))),
+          ([
+            Type (OCaml.Effect.State.state, Type (Z));
+            Counter;
+            NonTermination
+          ], Type (Z))),
         Bind
           (?,
             Lift
-              (?, [ (OCaml.Effect.State.state, Z) ],
+              (?, [ Type (OCaml.Effect.State.state, Type (Z)) ],
                 [
-                  (OCaml.Effect.State.state, Z);
+                  Type (OCaml.Effect.State.state, Type (Z));
                   Counter;
                   NonTermination
                 ],
@@ -1529,9 +1733,9 @@ Value
             Bind
               (?,
                 Lift
-                  (?, [ (OCaml.Effect.State.state, Z) ],
+                  (?, [ Type (OCaml.Effect.State.state, Type (Z)) ],
                     [
-                      (OCaml.Effect.State.state, Z);
+                      Type (OCaml.Effect.State.state, Type (Z));
                       Counter;
                       NonTermination
                     ],
@@ -1541,9 +1745,18 @@ Value
                 Bind
                   (?,
                     Lift
-                      (?, [ (OCaml.Effect.State.state, Z) ],
+                      (?,
                         [
-                          (OCaml.Effect.State.state, Z);
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z))
+                        ],
+                        [
+                          Type
+                            (OCaml.Effect.State.state,
+                              Type
+                                (Z));
                           Counter;
                           NonTermination
                         ],
@@ -1566,8 +1779,10 @@ Value
                                 ],
                                 Monad
                                   ([
-                                    (OCaml.Effect.State.state,
-                                      Z);
+                                    Type
+                                      (OCaml.Effect.State.state,
+                                        Type
+                                          (Z));
                                     Counter;
                                     NonTermination
                                   ],
@@ -1586,8 +1801,10 @@ Value
                                               NonTermination
                                             ],
                                             [
-                                              (OCaml.Effect.State.state,
-                                                Z);
+                                              Type
+                                                (OCaml.Effect.State.state,
+                                                  Type
+                                                    (Z));
                                               Counter;
                                               NonTermination
                                             ],
@@ -1609,12 +1826,16 @@ Value
                                             Lift
                                               (?,
                                                 [
-                                                  (OCaml.Effect.State.state,
-                                                    Z)
+                                                  Type
+                                                    (OCaml.Effect.State.state,
+                                                      Type
+                                                        (Z))
                                                 ],
                                                 [
-                                                  (OCaml.Effect.State.state,
-                                                    Z);
+                                                  Type
+                                                    (OCaml.Effect.State.state,
+                                                      Type
+                                                        (Z));
                                                   Counter;
                                                   NonTermination
                                                 ],
@@ -1675,12 +1896,16 @@ Value
                                                         Lift
                                                           (?,
                                                             [
-                                                              (OCaml.Effect.State.state,
-                                                                Z)
+                                                              Type
+                                                                (OCaml.Effect.State.state,
+                                                                  Type
+                                                                    (Z))
                                                             ],
                                                             [
-                                                              (OCaml.Effect.State.state,
-                                                                Z);
+                                                              Type
+                                                                (OCaml.Effect.State.state,
+                                                                  Type
+                                                                    (Z));
                                                               Counter;
                                                               NonTermination
                                                             ],
@@ -1713,8 +1938,10 @@ Value
                                                                     ],
                                                                     Monad
                                                                       ([
-                                                                        (OCaml.Effect.State.state,
-                                                                          Z);
+                                                                        Type
+                                                                          (OCaml.Effect.State.state,
+                                                                            Type
+                                                                              (Z));
                                                                         NonTermination
                                                                       ],
                                                                         ())),
@@ -1732,8 +1959,10 @@ Value
                                                                                   NonTermination
                                                                                 ],
                                                                                 [
-                                                                                  (OCaml.Effect.State.state,
-                                                                                    Z);
+                                                                                  Type
+                                                                                    (OCaml.Effect.State.state,
+                                                                                      Type
+                                                                                        (Z));
                                                                                   NonTermination
                                                                                 ],
                                                                                 Apply
@@ -1754,12 +1983,16 @@ Value
                                                                                 Lift
                                                                                   (?,
                                                                                     [
-                                                                                      (OCaml.Effect.State.state,
-                                                                                        Z)
+                                                                                      Type
+                                                                                        (OCaml.Effect.State.state,
+                                                                                          Type
+                                                                                            (Z))
                                                                                     ],
                                                                                     [
-                                                                                      (OCaml.Effect.State.state,
-                                                                                        Z);
+                                                                                      Type
+                                                                                        (OCaml.Effect.State.state,
+                                                                                          Type
+                                                                                            (Z));
                                                                                       NonTermination
                                                                                     ],
                                                                                     Bind
@@ -1817,12 +2050,16 @@ Value
                                                                                         Lift
                                                                                           (?,
                                                                                             [
-                                                                                              (OCaml.Effect.State.state,
-                                                                                                Z)
+                                                                                              Type
+                                                                                                (OCaml.Effect.State.state,
+                                                                                                  Type
+                                                                                                    (Z))
                                                                                             ],
                                                                                             [
-                                                                                              (OCaml.Effect.State.state,
-                                                                                                Z);
+                                                                                              Type
+                                                                                                (OCaml.Effect.State.state,
+                                                                                                  Type
+                                                                                                    (Z));
                                                                                               NonTermination
                                                                                             ],
                                                                                             Bind
@@ -1947,8 +2184,10 @@ Value
                                                                       Counter
                                                                     ],
                                                                     [
-                                                                      (OCaml.Effect.State.state,
-                                                                        Z);
+                                                                      Type
+                                                                        (OCaml.Effect.State.state,
+                                                                          Type
+                                                                            (Z));
                                                                       Counter;
                                                                       NonTermination
                                                                     ],
@@ -1967,13 +2206,17 @@ Value
                                                                 Lift
                                                                   (?,
                                                                     [
-                                                                      (OCaml.Effect.State.state,
-                                                                        Z);
+                                                                      Type
+                                                                        (OCaml.Effect.State.state,
+                                                                          Type
+                                                                            (Z));
                                                                       NonTermination
                                                                     ],
                                                                     [
-                                                                      (OCaml.Effect.State.state,
-                                                                        Z);
+                                                                      Type
+                                                                        (OCaml.Effect.State.state,
+                                                                          Type
+                                                                            (Z));
                                                                       Counter;
                                                                       NonTermination
                                                                     ],
@@ -1991,12 +2234,16 @@ Value
                                                             Lift
                                                               (?,
                                                                 [
-                                                                  (OCaml.Effect.State.state,
-                                                                    Z)
+                                                                  Type
+                                                                    (OCaml.Effect.State.state,
+                                                                      Type
+                                                                        (Z))
                                                                 ],
                                                                 [
-                                                                  (OCaml.Effect.State.state,
-                                                                    Z);
+                                                                  Type
+                                                                    (OCaml.Effect.State.state,
+                                                                      Type
+                                                                        (Z));
                                                                   Counter;
                                                                   NonTermination
                                                                 ],
@@ -2118,8 +2365,10 @@ Value
                             Lift
                               (?, [ Counter ],
                                 [
-                                  (OCaml.Effect.State.state,
-                                    Z);
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z));
                                   Counter;
                                   NonTermination
                                 ],
@@ -2144,12 +2393,16 @@ Value
                         Lift
                           (?,
                             [
-                              (OCaml.Effect.State.state,
-                                Z)
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z))
                             ],
                             [
-                              (OCaml.Effect.State.state,
-                                Z);
+                              Type
+                                (OCaml.Effect.State.state,
+                                  Type
+                                    (Z));
                               Counter;
                               NonTermination
                             ],


### PR DESCRIPTION
This PR
* moves `Kerneltypes.Value` into `FullEnvi`, its sole dependent
* tweaks `Kerneltypes.Type.t` and `Kerneltypes.TypeDefinition.t` to make them support `Effect.PureType.t`
* reworks `Effect.PureType.t` to use `Kerneltypes.Type.t`, and puts all general useful functions into a new `CommonType` module
  - NB: No functions referring to `FullEnvi` were moved; `FullEnvi` depends on `Effect`, which in turn depends on `CommonType`
* carries `Type.t` instead of `Effect.PureType.t` in `FullEnvi.Value.Function`, to reduce the number of unnecessary conversions