### PR TITLE
Replace Effect.t and Effect.Type.t with Type.t

### DIFF
--- a/src/commonType.ml
+++ b/src/commonType.ml
@@ -57,14 +57,6 @@ let rec unify_monad (f : 'a -> 'a option -> 'a) (typ1 : 'a t) (typ2 : 'a t)
   | Variable x, _ -> typ2
   | _, _ -> failwith "Could not unify types"
 
-let rec strip_monads (typ : 'a t) : 'b t =
-  match typ with
-  | Variable x -> Variable x
-  | Arrow (typ1, typ2) -> Arrow (strip_monads typ1, strip_monads typ2)
-  | Tuple typs -> Tuple (List.map strip_monads typs)
-  | Apply (x, typs) -> Apply (x, List.map strip_monads typs)
-  | Monad (x, typ) -> strip_monads typ
-
 let rec map (f : BoundName.t -> BoundName.t) (typ : 'a t) : 'a t =
   match typ with
   | Variable x -> Variable x

--- a/src/commonType.ml
+++ b/src/commonType.ml
@@ -42,7 +42,7 @@ let rec unify_monad (f : 'a -> 'a option -> 'a) (typ1 : 'a t) (typ2 : 'a t)
   | Tuple typs1, Tuple typs2 ->
     Tuple (List.map2 unify_monad typs1 typs2)
   | Apply (x1, typs1), Apply (x2, typs2)
-    when BoundName.stable_compare x1 x2 = 0 ->
+    (*when BoundName.stable_compare x1 x2 = 0*) ->
     Apply (x1, List.map2 unify_monad typs1 typs2)
   | Monad (d1, typ1), Monad (d2, typ2) ->
     Monad (f d1 (Some d2), unify_monad typ1 typ2)

--- a/src/commonType.ml
+++ b/src/commonType.ml
@@ -15,6 +15,13 @@ let rec pp (pp_a : 'a -> SmartPrint.t) (typ : 'a t) : SmartPrint.t =
       separate (!^ "," ^^ space) (BoundName.pp x :: List.map pp typs))))
   | Monad (d, typ) -> nest (!^ "Monad" ^^ OCaml.tuple [pp_a d; pp typ])
 
+let compare (typ1 : 'a t) (typ2 : 'a t) : int =
+  match typ1, typ2 with
+  | Apply (x, typ1), Apply (y, typ2) ->
+    let cmp = BoundName.stable_compare x y in
+    if cmp == 0 then compare typ1 typ2 else cmp
+  | _, _ -> compare typ1 typ2
+
 let rec unify (typ1 : 'a t) (typ2 : 'b t) : 'b t Name.Map.t =
   let union = Name.Map.union (fun _ typ _ -> Some typ) in
   match typ1, typ2 with

--- a/src/commonType.ml
+++ b/src/commonType.ml
@@ -31,6 +31,25 @@ let rec unify (typ1 : 'a t) (typ2 : 'b t) : 'b t Name.Map.t =
       Name.Map.empty typs1 typs2
   | _, _ -> failwith "Could not unify types"
 
+let rec unify_monad (f : 'a -> 'a option -> 'a) (typ1 : 'a t) (typ2 : 'a t)
+  : 'a t =
+  let unify_monad = unify_monad f in
+  match typ1, typ2 with
+  | _, Variable y -> typ1
+  | Variable x, _ -> typ2
+  | Arrow (typ1a, typ1b), Arrow (typ2a, typ2b) ->
+    Arrow (unify_monad typ1a typ2a, unify_monad typ1b typ2b)
+  | Tuple typs1, Tuple typs2 ->
+    Tuple (List.map2 unify_monad typs1 typs2)
+  | Apply (x1, typs1), Apply (x2, typs2)
+    when BoundName.stable_compare x1 x2 = 0 ->
+    Apply (x1, List.map2 unify_monad typs1 typs2)
+  | Monad (d1, typ1), Monad (d2, typ2) ->
+    Monad (f d1 (Some d2), unify_monad typ1 typ2)
+  | Monad (d, typ1), typ2 | typ1, Monad (d, typ2) ->
+    Monad (f d None, unify_monad typ1 typ2)
+  | _, _ -> failwith "Could not unify types"
+
 let rec strip_monads (typ : 'a t) : 'b t =
   match typ with
   | Variable x -> Variable x

--- a/src/commonType.ml
+++ b/src/commonType.ml
@@ -35,8 +35,6 @@ let rec unify_monad (f : 'a -> 'a option -> 'a) (typ1 : 'a t) (typ2 : 'a t)
   : 'a t =
   let unify_monad = unify_monad f in
   match typ1, typ2 with
-  | _, Variable y -> typ1
-  | Variable x, _ -> typ2
   | Arrow (typ1a, typ1b), Arrow (typ2a, typ2b) ->
     Arrow (unify_monad typ1a typ2a, unify_monad typ1b typ2b)
   | Tuple typs1, Tuple typs2 ->
@@ -48,6 +46,8 @@ let rec unify_monad (f : 'a -> 'a option -> 'a) (typ1 : 'a t) (typ2 : 'a t)
     Monad (f d1 (Some d2), unify_monad typ1 typ2)
   | Monad (d, typ1), typ2 | typ1, Monad (d, typ2) ->
     Monad (f d None, unify_monad typ1 typ2)
+  | _, Variable y -> typ1
+  | Variable x, _ -> typ2
   | _, _ -> failwith "Could not unify types"
 
 let rec strip_monads (typ : 'a t) : 'b t =

--- a/src/coqOfOCaml.ml
+++ b/src/coqOfOCaml.ml
@@ -5,17 +5,17 @@ let exp  (env : unit FullEnvi.t) (structure : Typedtree.structure)
   let (_, defs) = Structure.of_structure env structure in
   snd @@ Structure.monadise_let_rec env defs
 
-let effects (env : Effect.t FullEnvi.t)
+let effects (env : Type.t FullEnvi.t)
   (exp : (Loc.t * Type.t) Structure.t list)
-  : (Loc.t * Effect.t) Structure.t list =
+  : (Loc.t * Type.t) Structure.t list =
   snd @@ Structure.effects env @@ exp
 
 let monadise (env : unit FullEnvi.t)
-  (effects : (Loc.t * Effect.t) Structure.t list) : Loc.t Structure.t list =
+  (effects : (Loc.t * Type.t) Structure.t list) : Loc.t Structure.t list =
   snd @@ Structure.monadise env @@ effects
 
 let interface (module_name : string)
-  (effects : (Loc.t * Effect.t) Structure.t list) : Interface.t =
+  (effects : (Loc.t * Type.t) Structure.t list) : Interface.t =
   Interface.Interface (CoqName.Name module_name, Interface.of_structures effects)
 
 let coq (monadise : Loc.t Structure.t list) : SmartPrint.t =
@@ -45,7 +45,7 @@ let output_exp (c : out_channel) (exp : (Loc.t * Type.t) Structure.t list)
   to_out_channel c @@ Structure.pps pp_annotation exp
 
 let output_effects (c : out_channel)
-  (effects : (Loc.t * Effect.t) Structure.t list) : unit =
+  (effects : (Loc.t * Type.t) Structure.t list) : unit =
   let pp_annotation (l, effect) =
     OCaml.tuple [Loc.pp l; Effect.pp effect] in
   to_out_channel c @@ Structure.pps pp_annotation effects

--- a/src/effect.ml
+++ b/src/effect.ml
@@ -357,6 +357,13 @@ module Type = struct
       | _, _ -> typ1 in
     List.fold_left aux (Variable "_") typs
 
+  let unify (typ1 : t) (typ2 : t) : t =
+    CommonType.unify_monad (fun d1 d2 ->
+        Descriptor.union @@ match d2 with
+        | Some d2 -> [d1; d2]
+        | None -> [d1])
+      typ1 typ2
+
   let rec map_type_vars (vars_map : PureType.t Name.Map.t) (typ : t) : t =
     match typ with
     | Arrow (typ1, typ) ->
@@ -436,6 +443,11 @@ let function_typ (args : 'a list) (body_effect : t) : t =
       (Type.Arrow (Type.pure, body_effect))
 
 let pure : t = Type.pure
+
+let split_toplevel (effect : t) : Descriptor.t * t =
+  match effect with
+  | Type.Monad (d, typ) -> (d, typ)
+  | _ -> (Descriptor.pure, effect)
 
 let is_pure (effect : t) : bool = Type.is_pure effect
 

--- a/src/effect.ml
+++ b/src/effect.ml
@@ -195,35 +195,6 @@ module Type = struct
   include Kerneltypes.Type
   type t = Descriptor.t Kerneltypes.Type.t'
 
-  module Old = struct
-    type t' =
-      | Pure
-      | Arrow of Descriptor.t * t'
-
-    let to_type (typ : t') : t =
-      let rec aux i typ =
-        match typ with
-        | Pure -> Kerneltypes.Type.Variable (string_of_int i ^ "A")
-        | Arrow (d, typ) ->
-          Kerneltypes.Type.Arrow (Kerneltypes.Type.Variable (string_of_int i ^ "A"),
-            if Descriptor.is_pure d then
-              aux (i+1) typ
-            else
-              Kerneltypes.Type.Monad (d, aux (i+1) typ)) in
-      aux 1 typ
-
-    let of_type (typ : t) : t' =
-      let open Kerneltypes in
-      let rec aux typ =
-        match typ with
-        | Kerneltypes.Type.Arrow (_, Kerneltypes.Type.Monad (d, typ)) ->
-          Arrow (d, aux typ)
-        | Kerneltypes.Type.Arrow (_, typ) -> Arrow (Descriptor.pure, aux typ)
-        | Kerneltypes.Type.Monad (_, typ) -> aux typ
-        | _ -> Pure in
-      aux typ
-  end
-
   let pure : t = Variable "_"
   let arrow (d : Descriptor.t) (typ : t) : t =
     if Descriptor.is_pure d then

--- a/src/effect.ml
+++ b/src/effect.ml
@@ -282,6 +282,11 @@ module Type = struct
   end
 
   let pure : t = Variable "_"
+  let arrow (d : Descriptor.t) (typ : t) : t =
+    if Descriptor.is_pure d then
+      Arrow (pure, typ)
+    else
+      Arrow (pure, Monad (d, typ))
 
   let rec pp (typ : t) : SmartPrint.t =
     match typ with
@@ -425,10 +430,8 @@ let function_typ (args : 'a list) (body_effect : t) : t =
     { descriptor = Descriptor.pure;
       typ =
         args |> List.fold_left (fun effect_typ _ ->
-          Type.Old.Arrow (Descriptor.pure, effect_typ))
-          (Type.Old.Arrow
-              (body_effect.descriptor, Type.Old.of_type body_effect.typ))
-          |> Type.Old.to_type
+            Type.Arrow (Type.pure, effect_typ))
+          (Type.arrow body_effect.descriptor body_effect.typ)
     }
 
 let pure : t = {

--- a/src/effect.ml
+++ b/src/effect.ml
@@ -357,12 +357,18 @@ module Type = struct
       | _, _ -> typ1 in
     List.fold_left aux (Variable "_") typs
 
-  let unify (typ1 : t) (typ2 : t) : t =
-    CommonType.unify_monad (fun d1 d2 ->
-        Descriptor.union @@ match d2 with
-        | Some d2 -> [d1; d2]
-        | None -> [d1])
-      typ1 typ2
+  let unify ?collapse:(collapse=true) (typ1 : t) (typ2 : t) : t =
+    let f = if collapse then
+        (fun d1 d2 ->
+          Descriptor.union @@ match d2 with
+          | Some d2 -> [d1; d2]
+          | None -> [d1])
+      else
+        (fun d1 d2 ->
+          match d2 with
+          | Some d2 -> Descriptor.union [d1; d2]
+          | None -> d1) in
+    CommonType.unify_monad f typ1 typ2
 
   let rec map_type_vars (vars_map : PureType.t Name.Map.t) (typ : t) : t =
     match typ with

--- a/src/effect.ml
+++ b/src/effect.ml
@@ -345,18 +345,6 @@ module Type = struct
       | Monad (_, typ) -> return_single_descriptor typ nb_args
       | _ -> Descriptor.pure
 
-  let union (typs : t list) : t =
-    let rec aux typ1 typ2 =
-      match typ1, typ2 with
-      | Arrow (typ1a, typ1b), Arrow (typ2a, typ2b) ->
-        Arrow (typ1a, aux typ1b typ2b)
-      | Monad (d1, typ1), Monad (d2, typ2) ->
-        Monad (Descriptor.union [d1; d2], aux typ1 typ2)
-      | Monad (d, typ1), typ2 | typ1, Monad (d, typ2) ->
-        Monad (Descriptor.union [d], aux typ1 typ2)
-      | _, _ -> typ1 in
-    List.fold_left aux (Variable "_") typs
-
   let unify ?collapse:(collapse=true) (typ1 : t) (typ2 : t) : t =
     let f = if collapse then
         (fun d1 d2 ->
@@ -369,6 +357,9 @@ module Type = struct
           | Some d2 -> Descriptor.union [d1; d2]
           | None -> d1) in
     CommonType.unify_monad f typ1 typ2
+
+  let union (typs : t list) : t =
+    List.fold_left unify pure typs
 
   let rec map_type_vars (vars_map : PureType.t Name.Map.t) (typ : t) : t =
     match typ with

--- a/src/effect.ml
+++ b/src/effect.ml
@@ -447,12 +447,8 @@ let pp (effect : t) : SmartPrint.t =
     | _ -> [Descriptor.pp Descriptor.pure; Type.pp effect]
 
 let function_typ (args : ('a * t) list) (body_effect : t) : t =
-  match args with
-  | [] -> body_effect
-  | _ ->
-    List.fold_right (fun (_, typ) effect_typ ->
-        Type.Arrow (typ, effect_typ))
-      args body_effect
+  List.fold_right (fun (_, typ) effect_typ -> Type.Arrow (typ, effect_typ))
+    args body_effect
 
 let pure : t = Type.pure
 

--- a/src/effect.ml
+++ b/src/effect.ml
@@ -440,13 +440,13 @@ let pp (effect : t) : SmartPrint.t =
     | Type.Monad (d, typ) -> [Descriptor.pp d; Type.pp typ]
     | _ -> [Descriptor.pp Descriptor.pure; Type.pp effect]
 
-let function_typ (args : 'a list) (body_effect : t) : t =
+let function_typ (args : ('a * t) list) (body_effect : t) : t =
   match args with
   | [] -> body_effect
-  | _ :: args ->
-    args |> List.fold_left (fun effect_typ _ ->
-        Type.Arrow (Type.pure, effect_typ))
-      (Type.Arrow (Type.pure, body_effect))
+  | _ ->
+    List.fold_right (fun (_, typ) effect_typ ->
+        Type.Arrow (typ, effect_typ))
+      args body_effect
 
 let pure : t = Type.pure
 

--- a/src/effect.ml
+++ b/src/effect.ml
@@ -358,14 +358,6 @@ let split (effect : t) : Descriptor.t * t =
   | Type.Monad (d, typ) -> (d, typ)
   | _ -> (Descriptor.pure, effect)
 
-type t' = { descriptor : Descriptor.t; typ : Type.t }
-
-let to_type (e : t') : t = join e.descriptor e.typ
-
-let of_type (typ : t) : t' =
-  let (d, typ) = split typ in
-  { descriptor = d; typ = typ }
-
 let pp (effect : t) : SmartPrint.t =
   nest @@ !^ "Effect" ^^ OCaml.tuple @@
     match effect with

--- a/src/exception.ml
+++ b/src/exception.ml
@@ -37,7 +37,7 @@ let update_env_with_effects (exn : t) (env : Effect.t FullEnvi.t)
   let env = FullEnvi.Exception.assoc exn.name raise_path env in
   let bound_effect = FullEnvi.Descriptor.bound Loc.Unknown
     (PathName.of_name [] (CoqName.ocaml_name exn.name)) env in
-  let effect_typ =
+  let effect_typ = Effect.Type.to_type @@
     Effect.Type.Arrow (
       Effect.Descriptor.singleton bound_effect [],
       Effect.Type.Pure) in

--- a/src/exception.ml
+++ b/src/exception.ml
@@ -30,8 +30,8 @@ let update_env (exn : t) (env : unit FullEnvi.t) : unit FullEnvi.t =
   |> FullEnvi.Exception.assoc exn.name raise_path
   |> FullEnvi.Var.assoc exn.raise_name ()
 
-let update_env_with_effects (exn : t) (env : Effect.t FullEnvi.t)
-  : Effect.t FullEnvi.t =
+let update_env_with_effects (exn : t) (env : Type.t FullEnvi.t)
+  : Type.t FullEnvi.t =
   let raise_path = {PathName.path = FullEnvi.coq_path env;
     base = snd (CoqName.assoc_names exn.raise_name)} in
   let env = FullEnvi.Exception.assoc exn.name raise_path env in

--- a/src/exception.ml
+++ b/src/exception.ml
@@ -37,10 +37,10 @@ let update_env_with_effects (exn : t) (env : Effect.t FullEnvi.t)
   let env = FullEnvi.Exception.assoc exn.name raise_path env in
   let bound_effect = FullEnvi.Descriptor.bound Loc.Unknown
     (PathName.of_name [] (CoqName.ocaml_name exn.name)) env in
-  let effect_typ = Effect.Type.Old.to_type @@
-    Effect.Type.Old.Arrow (
-      Effect.Descriptor.singleton bound_effect [],
-      Effect.Type.Old.Pure) in
+  let effect_typ =
+    Effect.Type.Arrow (Effect.Type.Variable "_", Effect.Type.Monad
+      (Effect.Descriptor.singleton bound_effect [],
+      Effect.Type.pure)) in
   FullEnvi.Var.assoc exn.raise_name (Effect.eff effect_typ) env
 
 let to_coq (exn : t) : SmartPrint.t =

--- a/src/exception.ml
+++ b/src/exception.ml
@@ -37,10 +37,10 @@ let update_env_with_effects (exn : t) (env : Effect.t FullEnvi.t)
   let env = FullEnvi.Exception.assoc exn.name raise_path env in
   let bound_effect = FullEnvi.Descriptor.bound Loc.Unknown
     (PathName.of_name [] (CoqName.ocaml_name exn.name)) env in
-  let effect_typ = Effect.Type.to_type @@
-    Effect.Type.Arrow (
+  let effect_typ = Effect.Type.Old.to_type @@
+    Effect.Type.Old.Arrow (
       Effect.Descriptor.singleton bound_effect [],
-      Effect.Type.Pure) in
+      Effect.Type.Old.Pure) in
   FullEnvi.Var.assoc exn.raise_name (Effect.eff effect_typ) env
 
 let to_coq (exn : t) : SmartPrint.t =

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -867,10 +867,7 @@ let rec effects (env : Type.t FullEnvi.t) (e : (Loc.t * Type.t) t)
   | LetVar ((l, typ), x, e1, e2) ->
     let e1 = effects env e1 in
     let (d1, typ1) = Effect.split @@ snd (annotation e1) in
-    let env = if Effect.has_type_vars typ1 then
-      FullEnvi.Function.assoc x (typ1, typ) env
-    else
-      FullEnvi.Var.assoc x typ1 env in
+    let env = FullEnvi.Var.assoc x typ1 env in
     let e2 = effects env e2 in
     let (d2, typ2) = Effect.split @@ snd (annotation e2) in
     let descriptor = Effect.Descriptor.union [d1; d2] in
@@ -993,12 +990,7 @@ and env_after_def_with_effects (env : Type.t FullEnvi.t)
   List.fold_left (fun env (header, e) ->
     let effect = snd (annotation e) in
     let effect_typ = Effect.function_typ header.Header.args effect in
-    if Effect.has_type_vars effect then
-      let typ = List.fold_right (fun (_, arg_typ) typ ->
-        Type.Arrow (arg_typ, typ)) header.Header.args header.Header.typ in
-      FullEnvi.Function.assoc header.Header.name (effect_typ, typ) env
-    else
-      FullEnvi.Var.assoc header.Header.name effect_typ env)
+    FullEnvi.Var.assoc header.Header.name effect_typ env)
     env def.Definition.cases
 
 and effects_of_def_step (env : Type.t FullEnvi.t)

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -439,6 +439,7 @@ and open_cases (env : unit FullEnvi.t) (typ_vars : Name.t Name.Map.t)
   let l = Loc.of_location p1.pat_loc in
   let (typ_x, _, _) =
     Type.of_type_expr_new_typ_vars env l typ_vars p1.pat_type in
+  let typ = Effect.Type.return_type typ 1 in
   (CoqName.ocaml_name x, Match ((Loc.Unknown, typ),
     Variable ((Loc.Unknown, typ_x), bound_x), cases))
 

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -802,7 +802,7 @@ let rec effects (env : Effect.t FullEnvi.t) (e : (Loc.t * Type.t) t)
       if not (Effect.Type.is_pure effect.Effect.typ) then
         Error.warn loc "Compounds cannot have functional effects; effect ignored.";
       effect.Effect.descriptor)) in
-    (es, { Effect.descriptor = descriptor; typ = Effect.Type.Pure }) in
+    (es, { Effect.descriptor = descriptor; typ = Effect.Type.to_type Effect.Type.Pure }) in
   match e with
   | Constant ((l, typ), c) -> Constant ((l, Effect.pure), c)
   | Variable ((l, typ), x) ->
@@ -855,8 +855,8 @@ let rec effects (env : Effect.t FullEnvi.t) (e : (Loc.t * Type.t) t)
     let effect_e = snd (annotation e) in
     let effect = {
       Effect.descriptor = Effect.Descriptor.pure;
-      typ = Effect.Type.Arrow (
-        effect_e.Effect.descriptor, effect_e.Effect.typ) } in
+      typ = Effect.Type.to_type @@ Effect.Type.Arrow (
+        effect_e.Effect.descriptor, Effect.Type.of_type @@ effect_e.Effect.typ) } in
     Function ((l, effect), x, e)
   | LetVar ((l, typ), x, e1, e2) ->
     let e1 = effects env e1 in
@@ -959,7 +959,7 @@ let rec effects (env : Effect.t FullEnvi.t) (e : (Loc.t * Type.t) t)
         Effect.Descriptor.singleton counter [];
         Effect.Descriptor.singleton nonterm []
       ];
-      Effect.typ = Effect.Type.Pure
+      Effect.typ = Effect.Type.to_type Effect.Type.Pure
     } in
     let effect = Effect.union (loop_effects :: ([e1; e2] |> List.map (fun e ->
       snd (annotation e)))) in

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -809,8 +809,7 @@ let rec effects (env : Type.t FullEnvi.t) (e : (Loc.t * Type.t) t)
     begin try
       let typ' = FullEnvi.Var.find l x env in
       let vars_map = Type.unify typ' typ in
-      let typ' = Effect.map_type_vars (Name.Map.map Type.pure_type vars_map)
-        typ' in
+      let typ' = Effect.map_type_vars vars_map typ' in
       let typ = Effect.Type.unify ~collapse:false typ typ' in
       Variable ((l, typ), x)
     with Not_found ->

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -802,7 +802,7 @@ let rec effects (env : Effect.t FullEnvi.t) (e : (Loc.t * Type.t) t)
       if not (Effect.Type.is_pure effect.Effect.typ) then
         Error.warn loc "Compounds cannot have functional effects; effect ignored.";
       effect.Effect.descriptor)) in
-    (es, { Effect.descriptor = descriptor; typ = Effect.Type.to_type Effect.Type.Pure }) in
+    (es, { Effect.descriptor = descriptor; typ = Effect.Type.pure }) in
   match e with
   | Constant ((l, typ), c) -> Constant ((l, Effect.pure), c)
   | Variable ((l, typ), x) ->
@@ -855,8 +855,8 @@ let rec effects (env : Effect.t FullEnvi.t) (e : (Loc.t * Type.t) t)
     let effect_e = snd (annotation e) in
     let effect = {
       Effect.descriptor = Effect.Descriptor.pure;
-      typ = Effect.Type.to_type @@ Effect.Type.Arrow (
-        effect_e.Effect.descriptor, Effect.Type.of_type @@ effect_e.Effect.typ) } in
+      typ = Effect.Type.Old.to_type @@ Effect.Type.Old.Arrow (
+        effect_e.Effect.descriptor, Effect.Type.Old.of_type @@ effect_e.Effect.typ) } in
     Function ((l, effect), x, e)
   | LetVar ((l, typ), x, e1, e2) ->
     let e1 = effects env e1 in
@@ -959,7 +959,7 @@ let rec effects (env : Effect.t FullEnvi.t) (e : (Loc.t * Type.t) t)
         Effect.Descriptor.singleton counter [];
         Effect.Descriptor.singleton nonterm []
       ];
-      Effect.typ = Effect.Type.to_type Effect.Type.Pure
+      Effect.typ = Effect.Type.pure
     } in
     let effect = Effect.union (loop_effects :: ([e1; e2] |> List.map (fun e ->
       snd (annotation e)))) in

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -855,8 +855,7 @@ let rec effects (env : Effect.t FullEnvi.t) (e : (Loc.t * Type.t) t)
     let effect_e = snd (annotation e) in
     let effect = {
       Effect.descriptor = Effect.Descriptor.pure;
-      typ = Effect.Type.Old.to_type @@ Effect.Type.Old.Arrow (
-        effect_e.Effect.descriptor, Effect.Type.Old.of_type @@ effect_e.Effect.typ) } in
+      typ = Effect.Type.arrow effect_e.Effect.descriptor effect_e.Effect.typ } in
     Function ((l, effect), x, e)
   | LetVar ((l, typ), x, e1, e2) ->
     let e1 = effects env e1 in

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -1210,7 +1210,8 @@ let rec monadise (env : unit FullEnvi.t) (e : (Loc.t * Type.t) t) : Loc.t t =
         (Apply (Loc.Unknown, Variable (Loc.Unknown, while_bound),
           [Variable (Loc.Unknown, counter_bound)]))
     )
-  | Coerce ((l, d), e, typ) -> Coerce (l, monadise env e, Type.monadise typ d)
+  | Coerce ((l, d), e, typ) ->
+    Coerce (l, monadise env e, Effect.Type.unify d typ)
   | Sequence ((l, _), e1, e2) -> (* TODO: use l *)
     let (d1, d2) = (descriptor e1, descriptor e2) in
     let e1 = monadise env e1 in

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -1015,7 +1015,9 @@ and effects_of_def_step (env : Type.t FullEnvi.t)
   { def with Definition.cases =
     def.Definition.cases |> List.map (fun (header, e) ->
       let env = Header.env_in_header header env Effect.pure in
-      (header, effects env e)) }
+      let e = effects env e in
+      let typ = Effect.Type.unify header.Header.typ @@ snd @@ annotation e in
+      ({ header with Header.typ = typ }, e)) }
 
 and effects_of_def (env : Type.t FullEnvi.t)
   (def : (Loc.t * Type.t) t Definition.t) : (Loc.t * Type.t) t Definition.t =
@@ -1101,8 +1103,6 @@ let rec monadise (env : unit FullEnvi.t) (e : (Loc.t * Type.t) t) : Loc.t t =
     let env_in_def = Definition.env_in_def def env in
     let def = { def with
       Definition.cases = def.Definition.cases |> List.map (fun (header, e) ->
-      let typ = Type.monadise header.Header.typ (snd (annotation e)) in
-      let header = { header with Header.typ = typ } in
       let env = Header.env_in_header header env_in_def () in
       let e = monadise env e in
       (header, e)) } in

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -5,7 +5,6 @@ open Utils
 module Value = struct
   type 'a t =
     | Variable of 'a
-    | Function of 'a * Effect.t
     | Type of Effect.Descriptor.t Kerneltypes.TypeDefinition.t'
     | Descriptor
     | Exception of PathName.t
@@ -15,7 +14,6 @@ module Value = struct
   let map (f : 'a -> 'b) (v : 'a t) : 'b t =
     match v with
     | Variable a -> Variable (f a)
-    | Function (a, typ) -> Function (f a, typ)
     | Type def -> Type def
     | Descriptor -> Descriptor
     | Exception raise_name -> Exception raise_name
@@ -25,7 +23,6 @@ module Value = struct
   let to_string (v : 'a t) : string =
     match v with
     | Variable _ -> "variable"
-    | Function _ -> "function"
     | Type _ -> "type"
     | Descriptor -> "descriptor"
     | Exception _ -> "exception"
@@ -316,26 +313,6 @@ module Var = ValueCarrier(struct
   let unpack (v : 'a Value.t) : 'a =
     match v with
     | Variable a -> a
-    | Function (a, _) -> a
-    | _ -> failwith @@ "Could not interpret " ^ Value.to_string v ^ " as a variable."
-end)
-
-module Function = ValueCarrier(struct
-  let resolve_opt (x : PathName.t) (m : Mod.t) : PathName.t option =
-    PathName.Map.find_opt x m.Mod.vars
-
-  let assoc (x : PathName.t) (y : PathName.t) (m : Mod.t) : Mod.t =
-    { m with Mod.vars = PathName.Map.add x y m.Mod.vars }
-
-  type 'a t = 'a * Effect.t
-  type 'a t' = Effect.t option
-
-  let value ((v, typ) : 'a * Effect.t) : 'a Value.t = Function (v, typ)
-
-  let unpack (v : 'a Value.t) : Effect.t option =
-    match v with
-    | Variable _ -> None
-    | Function (_, typ) -> Some typ
     | _ -> failwith @@ "Could not interpret " ^ Value.to_string v ^ " as a variable."
 end)
 

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -553,7 +553,7 @@ let add_exception_with_effects (path : Name.t list) (base : Name.t)
   let descriptor = PathName.of_name path base in
   let bound_descriptor = Descriptor.bound Loc.Unknown descriptor env in
   let effect =
-    Effect.eff @@ Effect.Type.to_type @@ Effect.Type.Arrow (
+    Effect.eff @@ Effect.Type.Old.to_type @@ Effect.Type.Old.Arrow (
       Effect.Descriptor.singleton bound_descriptor [],
-      Effect.Type.Pure) in
+      Effect.Type.Old.Pure) in
   Var.add path ("raise_" ^ base) effect env

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -553,7 +553,7 @@ let add_exception_with_effects (path : Name.t list) (base : Name.t)
   let descriptor = PathName.of_name path base in
   let bound_descriptor = Descriptor.bound Loc.Unknown descriptor env in
   let effect =
-    Effect.eff @@ Effect.Type.Arrow (
+    Effect.eff @@ Effect.Type.to_type @@ Effect.Type.Arrow (
       Effect.Descriptor.singleton bound_descriptor [],
       Effect.Type.Pure) in
   Var.add path ("raise_" ^ base) effect env

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -553,7 +553,7 @@ let add_exception_with_effects (path : Name.t list) (base : Name.t)
   let descriptor = PathName.of_name path base in
   let bound_descriptor = Descriptor.bound Loc.Unknown descriptor env in
   let effect =
-    Effect.eff @@ Effect.Type.Old.to_type @@ Effect.Type.Old.Arrow (
+    Effect.eff @@ Effect.Type.Arrow (Effect.Type.pure, Effect.Type.Monad (
       Effect.Descriptor.singleton bound_descriptor [],
-      Effect.Type.Old.Pure) in
+      Effect.Type.pure)) in
   Var.add path ("raise_" ^ base) effect env

--- a/src/fullEnvi.ml
+++ b/src/fullEnvi.ml
@@ -5,7 +5,7 @@ open Utils
 module Value = struct
   type 'a t =
     | Variable of 'a
-    | Function of 'a * Effect.Descriptor.t Kerneltypes.Type.t'
+    | Function of 'a * Effect.t
     | Type of Effect.Descriptor.t Kerneltypes.TypeDefinition.t'
     | Descriptor
     | Exception of PathName.t
@@ -327,12 +327,12 @@ module Function = ValueCarrier(struct
   let assoc (x : PathName.t) (y : PathName.t) (m : Mod.t) : Mod.t =
     { m with Mod.vars = PathName.Map.add x y m.Mod.vars }
 
-  type 'a t = 'a * Effect.Descriptor.t Kerneltypes.Type.t'
-  type 'a t' = Effect.Descriptor.t Kerneltypes.Type.t' option
+  type 'a t = 'a * Effect.t
+  type 'a t' = Effect.t option
 
-  let value ((v, typ) : 'a t) : 'a Value.t = Function (v, typ)
+  let value ((v, typ) : 'a * Effect.t) : 'a Value.t = Function (v, typ)
 
-  let unpack (v : 'a Value.t) : 'a t' =
+  let unpack (v : 'a Value.t) : Effect.t option =
     match v with
     | Variable _ -> None
     | Function (_, typ) -> Some typ

--- a/src/include.ml
+++ b/src/include.ml
@@ -15,7 +15,7 @@ let update_env (loc : Loc.t) (incl : t) (env : unit FullEnvi.t)
   FullEnvi.include_module (fun _ _ _ -> ()) mod_body env
 
 let update_env_with_effects (loc : Loc.t) (incl : t)
-  (env : Effect.t FullEnvi.t) : Effect.t FullEnvi.t =
+  (env : Type.t FullEnvi.t) : Type.t FullEnvi.t =
   let mod_body = FullEnvi.Module.find loc incl env in
   let update_effects f env v =
     let v = v |> Effect.map (fun x ->

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -3,7 +3,7 @@ open Yojson.Basic
 open Utils
 
 type t =
-  | Var of CoqName.t * Effect.t
+  | Var of CoqName.t * Type.t
   | Typ of TypeDefinition.t
   | Descriptor of CoqName.t
   | Exception of CoqName.t * CoqName.t
@@ -39,10 +39,10 @@ and of_signature (decl : Signature.t) : t list =
   | Signature.ModType (_, name, decls) ->
     [Signature (name, of_signatures decls)]
 
-let rec of_structures (defs : ('a * Effect.t) Structure.t list) : t list =
+let rec of_structures (defs : ('a * Type.t) Structure.t list) : t list =
   List.flatten (List.map of_structure defs)
 
-and of_structure (def : ('a * Effect.t) Structure.t) : t list =
+and of_structure (def : ('a * Type.t) Structure.t) : t list =
   match def with
   | Structure.Require names -> []
   | Structure.Value (_, value) ->
@@ -68,7 +68,7 @@ and of_structure (def : ('a * Effect.t) Structure.t) : t list =
     [Signature (name, of_signatures decls)]
 
 let rec to_full_envi (top_name : Name.t option) (interface : t)
-  (env : Effect.t FullEnvi.t) : Effect.t FullEnvi.t =
+  (env : Type.t FullEnvi.t) : Type.t FullEnvi.t =
   match interface with
   | Var (x, effect) ->
     let effect = match top_name with
@@ -100,7 +100,7 @@ let rec to_full_envi (top_name : Name.t option) (interface : t)
     FullEnvi.leave_signature env
 
 let load_interface (coq_prefix : Name.t) (interface : t)
-  (env : Effect.t FullEnvi.t) : Name.t * Effect.t FullEnvi.t =
+  (env : Type.t FullEnvi.t) : Name.t * Type.t FullEnvi.t =
   let name = match interface with
     | Interface (name, _) -> CoqName.ocaml_name name
     | _ -> "" in
@@ -174,8 +174,8 @@ let of_file (file_name : string) : t =
   really_input file content 0 size;
   of_json_string (Bytes.to_string content)
 
-let load_module (module_name : Name.t) (env : Effect.t FullEnvi.t)
-  : Effect.t FullEnvi.t =
+let load_module (module_name : Name.t) (env : Type.t FullEnvi.t)
+  : Type.t FullEnvi.t =
     let file_name = String.uncapitalize_ascii (Name.to_string module_name) in
     match find_first (fun (coq_prefix, dir) ->
         let file_name = Filename.concat dir (file_name ^ ".interface") in

--- a/src/interface.ml
+++ b/src/interface.ml
@@ -50,7 +50,7 @@ and of_structure (def : ('a * Type.t) Structure.t) : t list =
       let name = header.Exp.Header.name in
       let typ =
         Effect.function_typ header.Exp.Header.args (snd (Exp.annotation e)) in
-      Var (name, Effect.compress typ))
+      Var (name, typ))
   | Structure.Primitive (_, prim) ->
     (* TODO: Update to reflect that primitives are not usually pure. *)
     [Var (prim.PrimitiveDeclaration.name, Effect.pure)]

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -19,7 +19,7 @@ let env_with_effects (interfaces : (Name.t * string) list)
       [Type.Variable x] in
   let state_type (x : string) : Type.t =
     Type.Apply
-      (bound_name ["OCaml"; "Effect"; "State"] ["Effect"; "State"] "state",
+      (bound_name ["OCaml"; "Effect"; "State"] ["Effect"; "State"] "t",
       [Type.Variable x]) in
   let add_exn path base = add_exception_with_effects path base in
   let arrow xs = List.fold_right (fun x typ ->

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -18,7 +18,7 @@ let env_with_effects (interfaces : (Name.t * string) list)
     let i = string_of_int x in
     Effect.Descriptor.singleton
       (bound_name ["OCaml"; "Effect"; "State"] ["Effect"; "State"] "state")
-      [Effect.PureType.Variable i] in
+      [Type.Variable i] in
   let state_type (x : int) : Type.t =
     let i = string_of_int x in
     Type.Apply

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -4,7 +4,7 @@ open Effect.Type.Old
 open SmartPrint
 
 let env_with_effects (interfaces : (Name.t * string) list)
-  : Effect.t FullEnvi.t =
+  : Type.t FullEnvi.t =
   let bound_name full_path path base = {
       BoundName.full_path = PathName.of_name full_path base;
       local_path = PathName.of_name path base

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -1,6 +1,6 @@
 (** The initially opened module. *)
 open FullEnvi
-open Effect.Type
+open Effect.Type.Old
 open SmartPrint
 
 let env_with_effects (interfaces : (Name.t * string) list)

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -25,7 +25,7 @@ let env_with_effects (interfaces : (Name.t * string) list)
       (bound_name ["OCaml"; "Effect"; "State"] ["Effect"; "State"] "state",
       [Type.Variable i]) in
   let add_exn path base = add_exception_with_effects path base in
-  let arrow x y = Effect.eff (Arrow (x, y)) in
+  let arrow x y = Effect.eff (to_type @@ Arrow (x, y)) in
   let pure = Effect.pure in
   FullEnvi.empty interfaces None
   (* Values specific to the translation to Coq *)

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -127,15 +127,13 @@ let env_with_effects (interfaces : (Name.t * string) list)
   |> Typ.add ["Effect"; "State"] "t" (TypeDefinition.Abstract (CoqName.Name "t", []))
   |> Var.add ["Effect"; "State"] "global" pure
   |> Function.add ["Effect"; "State"] "read"
-    (arrow (typ_d 0) Pure,
-    Type.Arrow (state_type 0, Type.Variable "0"))
+    (Type.Arrow (state_type 0, Type.Monad (typ_d 0, Type.Variable "0")),
+    Type.Arrow (state_type 0, Type.Monad (typ_d 0, Type.Variable "0")))
   |> Function.add ["Effect"; "State"] "write"
-    (arrow (d []) (Arrow (typ_d 0, Pure)),
-    Effect.PureType.Arrow
-      (state_type 0,
-        Effect.PureType.Arrow
-          (Effect.PureType.Variable "0",
-          Effect.PureType.Apply (bound_name [] [] "unit", []))))
+    (Type.Arrow (state_type 0, Type.Arrow (Type.Variable "0",
+      Type.Monad (typ_d 0, Type.Apply (bound_name [] [] "unit", [])))),
+    Type.Arrow (state_type 0, Type.Arrow (Type.Variable "0",
+      Type.Monad (typ_d 0, Type.Apply (bound_name [] [] "unit", [])))))
 
   (* Pervasives *)
   (* Exceptions *)
@@ -186,8 +184,8 @@ let env_with_effects (interfaces : (Name.t * string) list)
   (* Operations on large files *)
   (* References *)
   |> Function.add ["Pervasives"] "ref"
-    (arrow (typ_d 0) Pure,
-    Effect.PureType.Arrow (Effect.PureType.Variable "0", state_type 0))
+    (Type.Arrow (Type.Variable "0", Monad (typ_d 0, state_type 0)),
+    Type.Arrow (Type.Variable "0", Monad (typ_d 0, state_type 0)))
   (* Operations on format strings *)
   (* Program termination *)
   |> leave_module localize_effects

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -1,6 +1,5 @@
 (** The initially opened module. *)
 open FullEnvi
-open Effect.Type.Old
 open SmartPrint
 
 let env_with_effects (interfaces : (Name.t * string) list)
@@ -25,7 +24,7 @@ let env_with_effects (interfaces : (Name.t * string) list)
       (bound_name ["OCaml"; "Effect"; "State"] ["Effect"; "State"] "state",
       [Type.Variable i]) in
   let add_exn path base = add_exception_with_effects path base in
-  let arrow x y = Effect.eff (to_type @@ Arrow (x, y)) in
+  let arrow x y = Type.Arrow (Effect.Type.pure, Type.Monad (x, y)) in
   let pure = Effect.pure in
   FullEnvi.empty interfaces None
   (* Values specific to the translation to Coq *)
@@ -41,9 +40,9 @@ let env_with_effects (interfaces : (Name.t * string) list)
     ]))
   |> Descriptor.add [] "IO" ()
   |> Descriptor.add [] "Counter" ()
-  |> Var.add [] "read_counter" (arrow (d [[], [], "Counter"]) Pure)
+  |> Var.add [] "read_counter" (arrow (d [[], [], "Counter"]) Effect.Type.pure)
   |> Descriptor.add [] "NonTermination" ()
-  |> Var.add [] "not_terminated" (arrow (d [[], [], "NonTermination"]) Pure)
+  |> Var.add [] "not_terminated" (arrow (d [[], [], "NonTermination"]) Effect.Type.pure)
   |> Var.add ["OCaml"; "Basics"] "for_to" pure
   |> Var.add ["OCaml"; "Basics"] "for_downto" pure
 
@@ -107,7 +106,7 @@ let env_with_effects (interfaces : (Name.t * string) list)
 
   |> enter_module (CoqName.Name "OCaml")
   (* Values specific to the translation to Coq *)
-  |> Var.add [] "assert" (arrow (d [["OCaml"], [], "Assert_failure"]) Pure)
+  |> Var.add [] "assert" (arrow (d [["OCaml"], [], "Assert_failure"]) Effect.Type.pure)
   (* Predefined exceptions *)
   |> Typ.add [] "exn" (TypeDefinition.Abstract (CoqName.Name "exn", []))
   |> add_exn [] "Match_failure"
@@ -134,8 +133,8 @@ let env_with_effects (interfaces : (Name.t * string) list)
 
   (* Pervasives *)
   (* Exceptions *)
-  |> Var.add ["Pervasives"] "invalid_arg" (arrow (d [["OCaml"], [], "Invalid_argument"]) Pure)
-  |> Var.add ["Pervasives"] "failwith" (arrow (d [["OCaml"], [], "Failure"]) Pure)
+  |> Var.add ["Pervasives"] "invalid_arg" (arrow (d [["OCaml"], [], "Invalid_argument"]) Effect.Type.pure)
+  |> Var.add ["Pervasives"] "failwith" (arrow (d [["OCaml"], [], "Failure"]) Effect.Type.pure)
   |> add_exn ["Pervasives"] "Exit"
   (* Comparisons *)
   |> Var.add ["Pervasives"] "lt" pure
@@ -150,7 +149,7 @@ let env_with_effects (interfaces : (Name.t * string) list)
   (* Floating-point arithmetic *)
   (* Character operations *)
   |> Var.add ["Pervasives"] "int_of_char" pure
-  |> Var.add ["Pervasives"] "char_of_int" (arrow (d [["OCaml"], [], "Invalid_argument"]) Pure)
+  |> Var.add ["Pervasives"] "char_of_int" (arrow (d [["OCaml"], [], "Invalid_argument"]) Effect.Type.pure)
   (* Unit operations *)
   |> Var.add ["Pervasives"] "ignore" pure
   (* String conversion functions *)
@@ -162,20 +161,20 @@ let env_with_effects (interfaces : (Name.t * string) list)
   |> Var.add ["Pervasives"] "app" pure
   (* Input/output *)
   (* Output functions on standard output *)
-  |> Var.add ["Pervasives"] "print_char" (arrow (d [[], [], "IO"]) Pure)
-  |> Var.add ["Pervasives"] "print_string" (arrow (d [[], [], "IO"]) Pure)
-  |> Var.add ["Pervasives"] "print_int" (arrow (d [[], [], "IO"]) Pure)
-  |> Var.add ["Pervasives"] "print_endline" (arrow (d [[], [], "IO"]) Pure)
-  |> Var.add ["Pervasives"] "print_newline" (arrow (d [[], [], "IO"]) Pure)
+  |> Var.add ["Pervasives"] "print_char" (arrow (d [[], [], "IO"]) Effect.Type.pure)
+  |> Var.add ["Pervasives"] "print_string" (arrow (d [[], [], "IO"]) Effect.Type.pure)
+  |> Var.add ["Pervasives"] "print_int" (arrow (d [[], [], "IO"]) Effect.Type.pure)
+  |> Var.add ["Pervasives"] "print_endline" (arrow (d [[], [], "IO"]) Effect.Type.pure)
+  |> Var.add ["Pervasives"] "print_newline" (arrow (d [[], [], "IO"]) Effect.Type.pure)
   (* Output functions on standard error *)
-  |> Var.add ["Pervasives"] "prerr_char" (arrow (d [[], [], "IO"]) Pure)
-  |> Var.add ["Pervasives"] "prerr_string" (arrow (d [[], [], "IO"]) Pure)
-  |> Var.add ["Pervasives"] "prerr_int" (arrow (d [[], [], "IO"]) Pure)
-  |> Var.add ["Pervasives"] "prerr_endline" (arrow (d [[], [], "IO"]) Pure)
-  |> Var.add ["Pervasives"] "prerr_newline" (arrow (d [[], [], "IO"]) Pure)
+  |> Var.add ["Pervasives"] "prerr_char" (arrow (d [[], [], "IO"]) Effect.Type.pure)
+  |> Var.add ["Pervasives"] "prerr_string" (arrow (d [[], [], "IO"]) Effect.Type.pure)
+  |> Var.add ["Pervasives"] "prerr_int" (arrow (d [[], [], "IO"]) Effect.Type.pure)
+  |> Var.add ["Pervasives"] "prerr_endline" (arrow (d [[], [], "IO"]) Effect.Type.pure)
+  |> Var.add ["Pervasives"] "prerr_newline" (arrow (d [[], [], "IO"]) Effect.Type.pure)
   (* Input functions on standard input *)
-  |> Var.add ["Pervasives"] "read_line" (arrow (d [[], [], "IO"]) Pure)
-  |> Var.add ["Pervasives"] "read_int" (arrow (d [[], [], "IO"]) Pure)
+  |> Var.add ["Pervasives"] "read_line" (arrow (d [[], [], "IO"]) Effect.Type.pure)
+  |> Var.add ["Pervasives"] "read_int" (arrow (d [[], [], "IO"]) Effect.Type.pure)
   (* General output functions *)
   (* General input functions *)
   (* Operations on large files *)

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -126,13 +126,10 @@ let env_with_effects (interfaces : (Name.t * string) list)
   |> Descriptor.add ["Effect"; "State"] "state" ()
   |> Typ.add ["Effect"; "State"] "t" (TypeDefinition.Abstract (CoqName.Name "t", []))
   |> Var.add ["Effect"; "State"] "global" pure
-  |> Function.add ["Effect"; "State"] "read"
-    (Type.Arrow (state_type 0, Type.Monad (typ_d 0, Type.Variable "0")),
-    Type.Arrow (state_type 0, Type.Monad (typ_d 0, Type.Variable "0")))
-  |> Function.add ["Effect"; "State"] "write"
+  |> Var.add ["Effect"; "State"] "read"
+    (Type.Arrow (state_type 0, Type.Monad (typ_d 0, Type.Variable "0")))
+  |> Var.add ["Effect"; "State"] "write"
     (Type.Arrow (state_type 0, Type.Arrow (Type.Variable "0",
-      Type.Monad (typ_d 0, Type.Apply (bound_name [] [] "unit", [])))),
-    Type.Arrow (state_type 0, Type.Arrow (Type.Variable "0",
       Type.Monad (typ_d 0, Type.Apply (bound_name [] [] "unit", [])))))
 
   (* Pervasives *)
@@ -183,9 +180,8 @@ let env_with_effects (interfaces : (Name.t * string) list)
   (* General input functions *)
   (* Operations on large files *)
   (* References *)
-  |> Function.add ["Pervasives"] "ref"
-    (Type.Arrow (Type.Variable "0", Monad (typ_d 0, state_type 0)),
-    Type.Arrow (Type.Variable "0", Monad (typ_d 0, state_type 0)))
+  |> Var.add ["Pervasives"] "ref"
+    (Type.Arrow (Type.Variable "0", Monad (typ_d 0, state_type 0)))
   (* Operations on format strings *)
   (* Program termination *)
   |> leave_module localize_effects

--- a/src/primitiveDeclaration.ml
+++ b/src/primitiveDeclaration.ml
@@ -35,6 +35,6 @@ let update_env (prim : t) (env : unit FullEnvi.t) : unit FullEnvi.t =
   FullEnvi.Var.assoc prim.name () env
 
 (* TODO: Update to reflect that primitives are not usually pure. *)
-let update_env_with_effects (prim : t) (env : Effect.t FullEnvi.t)
-  : Effect.t FullEnvi.t =
+let update_env_with_effects (prim : t) (env : Type.t FullEnvi.t)
+  : Type.t FullEnvi.t =
   FullEnvi.Var.assoc prim.name Effect.pure env

--- a/src/reference.ml
+++ b/src/reference.ml
@@ -4,7 +4,7 @@ open SmartPrint
 type 'a t = {
   name : CoqName.t;
   state_name : CoqName.t;
-  effect : Effect.t;
+  effect : Type.t;
   typ : Type.t;
   expr : 'a Exp.t }
 
@@ -55,8 +55,8 @@ let update_env (update_exp : unit FullEnvi.t -> 'a Exp.t -> 'b Exp.t)
   (env, {r with expr = update_exp env r.expr})
 
 let update_env_with_effects (r : (Loc.t * Type.t) t)
-  (env : Effect.t FullEnvi.t)
-  : Effect.t FullEnvi.t * (Loc.t * Effect.t) t =
+  (env : Type.t FullEnvi.t)
+  : Type.t FullEnvi.t * (Loc.t * Type.t) t =
   let env = env
     |> FullEnvi.Descriptor.assoc r.state_name ()
     |> FullEnvi.Var.assoc r.name r.effect in

--- a/src/reference.ml
+++ b/src/reference.ml
@@ -36,7 +36,7 @@ let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t) (cases : value_binding list)
       (PathName.of_name ["OCaml"; "Effect"; "State"] "state") env in
     let typ = Type.of_type_expr env loc typ in
     let descriptor = Effect.Descriptor.union [
-      Effect.Descriptor.singleton state [Type.pure_type typ];
+      Effect.Descriptor.singleton state [typ];
       Effect.Descriptor.singleton bound_state [];
     ] in
     let effect = Effect.to_type { Effect.typ = Effect.Type.pure; descriptor } in

--- a/src/reference.ml
+++ b/src/reference.ml
@@ -39,7 +39,7 @@ let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t) (cases : value_binding list)
       Effect.Descriptor.singleton state [typ];
       Effect.Descriptor.singleton bound_state [];
     ] in
-    let effect = Effect.to_type { Effect.typ = Effect.Type.pure; descriptor } in
+    let effect = Effect.join descriptor Effect.Type.pure in
     { name = name;
       state_name = state_name;
       effect;

--- a/src/reference.ml
+++ b/src/reference.ml
@@ -39,7 +39,7 @@ let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t) (cases : value_binding list)
       Effect.Descriptor.singleton state [Type.pure_type typ];
       Effect.Descriptor.singleton bound_state [];
     ] in
-    let effect = { Effect.typ = Effect.Type.to_type @@ Effect.Type.Pure; descriptor } in
+    let effect = { Effect.typ = Effect.Type.pure; descriptor } in
     { name = name;
       state_name = state_name;
       effect;

--- a/src/reference.ml
+++ b/src/reference.ml
@@ -39,7 +39,7 @@ let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t) (cases : value_binding list)
       Effect.Descriptor.singleton state [Type.pure_type typ];
       Effect.Descriptor.singleton bound_state [];
     ] in
-    let effect = { Effect.typ = Effect.Type.pure; descriptor } in
+    let effect = Effect.to_type { Effect.typ = Effect.Type.pure; descriptor } in
     { name = name;
       state_name = state_name;
       effect;

--- a/src/reference.ml
+++ b/src/reference.ml
@@ -39,7 +39,7 @@ let of_ocaml (env : unit FullEnvi.t) (loc : Loc.t) (cases : value_binding list)
       Effect.Descriptor.singleton state [Type.pure_type typ];
       Effect.Descriptor.singleton bound_state [];
     ] in
-    let effect = { Effect.typ = Effect.Type.Pure; descriptor } in
+    let effect = { Effect.typ = Effect.Type.to_type @@ Effect.Type.Pure; descriptor } in
     { name = name;
       state_name = state_name;
       effect;

--- a/src/structure.ml
+++ b/src/structure.ml
@@ -205,7 +205,7 @@ let rec effects (env : Effect.t FullEnvi.t) (defs : ('a * Type.t) t list)
       let def = Exp.effects_of_def env def in
       (if def.Exp.Definition.cases |> List.exists (fun (header, e) ->
         header.Exp.Header.args = [] &&
-          not (Effect.Descriptor.is_pure (snd (Exp.annotation e)).Effect.descriptor)) then
+          not (Effect.Descriptor.is_pure (Effect.of_type @@ snd (Exp.annotation e)).Effect.descriptor)) then
         Error.warn loc "Toplevel effects are forbidden.");
       let env = Exp.env_after_def_with_effects env def in
       (env, Value (loc, def))

--- a/src/structure.ml
+++ b/src/structure.ml
@@ -204,8 +204,8 @@ let rec effects (env : Type.t FullEnvi.t) (defs : ('a * Type.t) t list)
     | Value (loc, def) ->
       let def = Exp.effects_of_def env def in
       (if def.Exp.Definition.cases |> List.exists (fun (header, e) ->
-        header.Exp.Header.args = [] &&
-          not (Effect.Descriptor.is_pure (Effect.of_type @@ snd (Exp.annotation e)).Effect.descriptor)) then
+        let d = fst @@ Effect.split @@ snd @@ Exp.annotation e in
+        header.Exp.Header.args = [] && not (Effect.Descriptor.is_pure d)) then
         Error.warn loc "Toplevel effects are forbidden.");
       let env = Exp.env_after_def_with_effects env def in
       (env, Value (loc, def))

--- a/src/structure.ml
+++ b/src/structure.ml
@@ -250,7 +250,7 @@ let rec monadise (env : unit FullEnvi.t) (defs : (Loc.t * Type.t) t list)
       let def = { def with
         Exp.Definition.cases =
           def.Exp.Definition.cases |> List.map (fun (header, e) ->
-            let typ = Type.monadise header.Exp.Header.typ (snd (Exp.annotation e)) in
+            let typ = header.Exp.Header.typ in
         let (implicit_args, typ) = Type.allocate_implicits_for_monad
           header.Exp.Header.implicit_args header.Exp.Header.args typ in
         let header = { header with Exp.Header.typ = typ; implicit_args } in

--- a/src/structure.ml
+++ b/src/structure.ml
@@ -195,10 +195,10 @@ let rec monadise_let_rec (env : unit FullEnvi.t)
     (env, []) defs in
   (env, List.rev defs)
 
-let rec effects (env : Effect.t FullEnvi.t) (defs : ('a * Type.t) t list)
-  : Effect.t FullEnvi.t * ('a * Effect.t) t list =
-  let effects_one (env : Effect.t FullEnvi.t) (def : ('a * Type.t) t)
-    : Effect.t FullEnvi.t * ('a * Effect.t) t =
+let rec effects (env : Type.t FullEnvi.t) (defs : ('a * Type.t) t list)
+  : Type.t FullEnvi.t * ('a * Type.t) t list =
+  let effects_one (env : Type.t FullEnvi.t) (def : ('a * Type.t) t)
+    : Type.t FullEnvi.t * ('a * Type.t) t =
     match def with
     | Require names -> (env, Require names)
     | Value (loc, def) ->
@@ -239,9 +239,9 @@ let rec effects (env : Effect.t FullEnvi.t) (defs : ('a * Type.t) t list)
       (env, []) defs in
   (env, List.rev defs)
 
-let rec monadise (env : unit FullEnvi.t) (defs : (Loc.t * Effect.t) t list)
+let rec monadise (env : unit FullEnvi.t) (defs : (Loc.t * Type.t) t list)
   : unit FullEnvi.t * Loc.t t list =
-  let monadise_one (env : unit FullEnvi.t) (def : (Loc.t * Effect.t) t)
+  let monadise_one (env : unit FullEnvi.t) (def : (Loc.t * Type.t) t)
     : unit FullEnvi.t * Loc.t t =
     match def with
     | Require names -> (env, Require names)

--- a/src/type.ml
+++ b/src/type.ml
@@ -87,15 +87,7 @@ let is_function (typ : t) : bool =
   | Arrow _ -> true
   | _ -> false
 
-let pure_type (typ : t) : Effect.PureType.t = CommonType.strip_monads typ
-
-let of_pure_type (typ : t) : Effect.PureType.t = CommonType.strip_monads typ
-
 let unify (typ1 : t) (typ2 : t) : t Name.Map.t = CommonType.unify typ1 typ2
-
-let unify_pure (ptyp : Effect.PureType.t) (typ : t)
-  : Effect.PureType.t Name.Map.t =
-  Name.Map.map pure_type (CommonType.unify ptyp typ)
 
 let map_vars (f : Name.t -> t) (typ : t) : t = CommonType.map_vars f typ
 

--- a/src/type.ml
+++ b/src/type.ml
@@ -140,11 +140,11 @@ let of_json (json : json) : t =
   CommonType.of_json Effect.Descriptor.of_json json
 
 let monadise (typ : t) (effect : Effect.t) : t =
-  let rec aux (typ : t) (effect_typ : Effect.Type.t') : t =
+  let rec aux (typ : t) (effect_typ : Effect.Type.Old.t') : t =
     match (typ, effect_typ) with
-    | (Variable _, Effect.Type.Pure) | (Tuple _, Effect.Type.Pure)
-      | (Apply _, Effect.Type.Pure) | (Arrow _, Effect.Type.Pure) -> typ
-    | (Arrow (typ1, typ2), Effect.Type.Arrow (d, effect_typ2)) ->
+    | (Variable _, Effect.Type.Old.Pure) | (Tuple _, Effect.Type.Old.Pure)
+      | (Apply _, Effect.Type.Old.Pure) | (Arrow _, Effect.Type.Old.Pure) -> typ
+    | (Arrow (typ1, typ2), Effect.Type.Old.Arrow (d, effect_typ2)) ->
       let typ2 = aux typ2 effect_typ2 in
       Arrow (typ1,
         if Effect.Descriptor.is_pure d then
@@ -153,7 +153,7 @@ let monadise (typ : t) (effect : Effect.t) : t =
           Monad (d, typ2))
     | (Monad _, _) -> failwith "This type is already monadic."
     | _ -> failwith "Type and effect type are not compatible." in
-  let typ = aux typ (Effect.Type.of_type effect.Effect.typ) in
+  let typ = aux typ (Effect.Type.Old.of_type effect.Effect.typ) in
   if Effect.Descriptor.is_pure effect.Effect.descriptor then
     typ
   else

--- a/src/type.ml
+++ b/src/type.ml
@@ -139,26 +139,5 @@ let to_json (typ : t) : json = CommonType.to_json Effect.Descriptor.to_json typ
 let of_json (json : json) : t =
   CommonType.of_json Effect.Descriptor.of_json json
 
-let monadise (typ : t) (effect : t) : t =
-  let rec aux (typ : t) (effect_typ : Effect.Type.Old.t') : t =
-    match (typ, effect_typ) with
-    | (Variable _, Effect.Type.Old.Pure) | (Tuple _, Effect.Type.Old.Pure)
-      | (Apply _, Effect.Type.Old.Pure) | (Arrow _, Effect.Type.Old.Pure) -> typ
-    | (Arrow (typ1, typ2), Effect.Type.Old.Arrow (d, effect_typ2)) ->
-      let typ2 = aux typ2 effect_typ2 in
-      Arrow (typ1,
-        if Effect.Descriptor.is_pure d then
-          typ2
-        else
-          Monad (d, typ2))
-    | (Monad _, _) -> failwith "This type is already monadic."
-    | _ -> failwith "Type and effect type are not compatible." in
-  let effect = Effect.of_type effect in
-  let typ = aux typ (Effect.Type.Old.of_type effect.Effect.typ) in
-  if Effect.Descriptor.is_pure effect.Effect.descriptor then
-    typ
-  else
-    Monad (effect.Effect.descriptor, typ)
-
 let to_coq (paren : bool) (typ : t) : SmartPrint.t =
   CommonType.to_coq Effect.Descriptor.to_coq paren typ

--- a/src/type.ml
+++ b/src/type.ml
@@ -153,6 +153,7 @@ let monadise (typ : t) (effect : Effect.t) : t =
           Monad (d, typ2))
     | (Monad _, _) -> failwith "This type is already monadic."
     | _ -> failwith "Type and effect type are not compatible." in
+  let effect = Effect.of_type effect in
   let typ = aux typ (Effect.Type.Old.of_type effect.Effect.typ) in
   if Effect.Descriptor.is_pure effect.Effect.descriptor then
     typ

--- a/src/type.ml
+++ b/src/type.ml
@@ -140,7 +140,7 @@ let of_json (json : json) : t =
   CommonType.of_json Effect.Descriptor.of_json json
 
 let monadise (typ : t) (effect : Effect.t) : t =
-  let rec aux (typ : t) (effect_typ : Effect.Type.t) : t =
+  let rec aux (typ : t) (effect_typ : Effect.Type.t') : t =
     match (typ, effect_typ) with
     | (Variable _, Effect.Type.Pure) | (Tuple _, Effect.Type.Pure)
       | (Apply _, Effect.Type.Pure) | (Arrow _, Effect.Type.Pure) -> typ
@@ -153,7 +153,7 @@ let monadise (typ : t) (effect : Effect.t) : t =
           Monad (d, typ2))
     | (Monad _, _) -> failwith "This type is already monadic."
     | _ -> failwith "Type and effect type are not compatible." in
-  let typ = aux typ effect.Effect.typ in
+  let typ = aux typ (Effect.Type.of_type effect.Effect.typ) in
   if Effect.Descriptor.is_pure effect.Effect.descriptor then
     typ
   else

--- a/src/type.ml
+++ b/src/type.ml
@@ -139,7 +139,7 @@ let to_json (typ : t) : json = CommonType.to_json Effect.Descriptor.to_json typ
 let of_json (json : json) : t =
   CommonType.of_json Effect.Descriptor.of_json json
 
-let monadise (typ : t) (effect : Effect.t) : t =
+let monadise (typ : t) (effect : t) : t =
   let rec aux (typ : t) (effect_typ : Effect.Type.Old.t') : t =
     match (typ, effect_typ) with
     | (Variable _, Effect.Type.Old.Pure) | (Tuple _, Effect.Type.Old.Pure)

--- a/tests/ex03.effects
+++ b/tests/ex03.effects
@@ -25,7 +25,9 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .)),
                         c),
                     [
                       Function
@@ -68,7 +70,11 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .
+                                ->
+                                .)),
                         f),
                     [
                       Constant

--- a/tests/ex06.effects
+++ b/tests/ex06.effects
@@ -4,9 +4,9 @@ Value
     [
       ((map_rec, [ A; B ],
         [ (counter, Type (nat)); (f, (A -> B)); (l, Type (list, A)) ],
-        Type (list, B)),
+        Monad ([ Type (NonTermination) ], Type (list, B))),
         Match
-          ((?, Effect ([ NonTermination ], .)),
+          ((?, Effect ([ Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), counter),
             [
               (Constructor (O),
@@ -14,7 +14,8 @@ Value
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -24,7 +25,8 @@ Value
                           ],
                             .
                               -[
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         not_terminated),
@@ -41,7 +43,8 @@ Value
                   ((4,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -69,7 +72,8 @@ Value
                           ((6,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             cons,
@@ -84,7 +88,9 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .)),
                                     f),
                                 [
                                   Variable
@@ -99,7 +105,8 @@ Value
                               ((6,
                                 Effect
                                   ([
-                                    NonTermination
+                                    Type
+                                      (NonTermination)
                                   ],
                                     .)),
                                 Apply
@@ -111,7 +118,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              NonTermination
+                                              Type
+                                                (NonTermination)
                                             ]->
                                             .)),
                                     Variable
@@ -125,7 +133,8 @@ Value
                                                 ->
                                                 .
                                                   -[
-                                                    NonTermination
+                                                    Type
+                                                      (NonTermination)
                                                   ]->
                                                   .)),
                                         map_rec),
@@ -144,7 +153,9 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .)),
                                       f);
                                   Variable
                                     ((6,
@@ -162,15 +173,18 @@ Value
 Value
   (non_rec, @.,
     [
-      ((map, [ A; B ], [ (f, (A -> B)); (l, Type (list, A)) ], Type (list, B)),
+      ((map, [ A; B ], [ (f, (A -> B)); (l, Type (list, A)) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (list, B))),
         Apply
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable
-              ((?, Effect ([ ], . -> . -> . -[ NonTermination ]-> .)),
+              ((?,
+                Effect
+                  ([ ], . -> . -> . -[ Type (NonTermination) ]-> .)),
                 map_rec),
             [
               Apply
-                ((?, Effect ([ Counter ], .)),
+                ((?, Effect ([ Type (Counter) ], .)),
                   Variable
                     ((?,
                       Effect
@@ -178,7 +192,8 @@ Value
                         ],
                           .
                             -[
-                              Counter
+                              Type
+                                (Counter)
                             ]->
                             .)),
                       read_counter),
@@ -190,7 +205,7 @@ Value
                           ],
                             .)))
                   ]);
-              Variable ((?, Effect ([ ], .)), f);
+              Variable ((?, Effect ([ ], . -> .)), f);
               Variable ((?, Effect ([ ], .)), l)
             ]))
     ])
@@ -205,9 +220,9 @@ Value
           (f, (A -> (B -> A)));
           (a, A);
           (l, Type (list, B))
-        ], A),
+        ], Monad ([ Type (NonTermination) ], A)),
         Match
-          ((?, Effect ([ NonTermination ], .)),
+          ((?, Effect ([ Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), counter),
             [
               (Constructor (O),
@@ -215,7 +230,8 @@ Value
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -225,7 +241,8 @@ Value
                           ],
                             .
                               -[
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         not_terminated),
@@ -242,7 +259,8 @@ Value
                   ((9,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -270,7 +288,8 @@ Value
                           ((11,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Apply
@@ -284,7 +303,8 @@ Value
                                         ->
                                         .
                                           -[
-                                            NonTermination
+                                            Type
+                                              (NonTermination)
                                           ]->
                                           .)),
                                 Variable
@@ -300,7 +320,8 @@ Value
                                               ->
                                               .
                                                 -[
-                                                  NonTermination
+                                                  Type
+                                                    (NonTermination)
                                                 ]->
                                                 .)),
                                     fold_rec),
@@ -319,7 +340,11 @@ Value
                                   Effect
                                     ([
                                     ],
-                                      .)),
+                                      .
+                                        ->
+                                        .
+                                          ->
+                                          .)),
                                   f);
                               Apply
                                 ((11,
@@ -332,7 +357,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       f),
                                   [
                                     Variable
@@ -366,16 +395,20 @@ Value
 Value
   (non_rec, @.,
     [
-      ((fold, [ A; B ], [ (f, (A -> (B -> A))); (a, A); (l, Type (list, B)) ], A),
+      ((fold, [ A; B ], [ (f, (A -> (B -> A))); (a, A); (l, Type (list, B)) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], A)),
         Apply
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable
               ((?,
-                Effect ([ ], . -> . -> . -> . -[ NonTermination ]-> .)),
+                Effect
+                  ([ ],
+                    . ->
+                      . -> . -> . -[ Type (NonTermination) ]-> .)),
                 fold_rec),
             [
               Apply
-                ((?, Effect ([ Counter ], .)),
+                ((?, Effect ([ Type (Counter) ], .)),
                   Variable
                     ((?,
                       Effect
@@ -383,7 +416,8 @@ Value
                         ],
                           .
                             -[
-                              Counter
+                              Type
+                                (Counter)
                             ]->
                             .)),
                       read_counter),
@@ -395,7 +429,7 @@ Value
                           ],
                             .)))
                   ]);
-              Variable ((?, Effect ([ ], .)), f);
+              Variable ((?, Effect ([ ], . -> . -> .)), f);
               Variable ((?, Effect ([ ], .)), a);
               Variable ((?, Effect ([ ], .)), l)
             ]))
@@ -429,14 +463,20 @@ Value
     [
       ((n, [ A ],
         [ (incr, (Type (Z) -> A)); (plus, (Type (Z) -> (A -> Type (Z)))) ],
-        Type (Z)),
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (Z))),
         Apply
-          ((16, Effect ([ Counter; NonTermination ], .)),
+          ((16, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable
               ((16,
                 Effect
-                  ([ ], . -> . -> . -[ Counter; NonTermination ]-> .)),
-                fold),
+                  ([ ],
+                    . ->
+                      . ->
+                        .
+                          -[
+                            Type (Counter);
+                            Type (NonTermination)
+                          ]-> .)), fold),
             [
               Function
                 ((16, Effect ([ ], . -> . -> .)), x,
@@ -460,7 +500,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               plus),
                           [
                             Variable
@@ -483,8 +527,10 @@ Value
                 ((16,
                   Effect
                     ([
-                      Counter;
-                      NonTermination
+                      Type
+                        (Counter);
+                      Type
+                        (NonTermination)
                     ], .)),
                   Variable
                     ((16,
@@ -495,8 +541,10 @@ Value
                             ->
                             .
                               -[
-                                Counter;
-                                NonTermination
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                       map),
@@ -506,7 +554,9 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .)),
                         incr);
                     Variable
                       ((16,

--- a/tests/ex06.monadise
+++ b/tests/ex06.monadise
@@ -4,7 +4,7 @@ Value
     [
       ((map_rec, [ A; B ],
         [ (counter, Type (nat)); (f, (A -> B)); (l, Type (list, A)) ],
-        Monad ([ NonTermination ], Type (list, B))),
+        Monad ([ Type (NonTermination) ], Type (list, B))),
         Match
           (?, Variable (?, counter),
             [
@@ -84,15 +84,17 @@ Value
   (non_rec, @.,
     [
       ((map, [ A; B ], [ (f, (A -> B)); (l, Type (list, A)) ],
-        Monad ([ Counter; NonTermination ], Type (list, B))),
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (list, B))),
         Bind
           (?,
             Lift
-              (?, [ Counter ], [ Counter; NonTermination ],
+              (?, [ Type (Counter) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply (?, Variable (?, read_counter), [ Tuple (?) ])),
             Some x,
             Lift
-              (?, [ NonTermination ], [ Counter; NonTermination ],
+              (?, [ Type (NonTermination) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply
                   (?, Variable (?, map_rec),
                     [
@@ -112,7 +114,7 @@ Value
           (f, (A -> (B -> A)));
           (a, A);
           (l, Type (list, B))
-        ], Monad ([ NonTermination ], A)),
+        ], Monad ([ Type (NonTermination) ], A)),
         Match
           (?, Variable (?, counter),
             [
@@ -183,15 +185,17 @@ Value
   (non_rec, @.,
     [
       ((fold, [ A; B ], [ (f, (A -> (B -> A))); (a, A); (l, Type (list, B)) ],
-        Monad ([ Counter; NonTermination ], A)),
+        Monad ([ Type (Counter); Type (NonTermination) ], A)),
         Bind
           (?,
             Lift
-              (?, [ Counter ], [ Counter; NonTermination ],
+              (?, [ Type (Counter) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply (?, Variable (?, read_counter), [ Tuple (?) ])),
             Some x,
             Lift
-              (?, [ NonTermination ], [ Counter; NonTermination ],
+              (?, [ Type (NonTermination) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply
                   (?, Variable (?, fold_rec),
                     [
@@ -224,7 +228,7 @@ Value
     [
       ((n, [ A ],
         [ (incr, (Type (Z) -> A)); (plus, (Type (Z) -> (A -> Type (Z)))) ],
-        Monad ([ Counter; NonTermination ], Type (Z))),
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (Z))),
         Bind
           (?,
             Apply

--- a/tests/ex07.effects
+++ b/tests/ex07.effects
@@ -4,7 +4,8 @@ Value
     [
       ((b, [ ], [ ], Type (bool)),
         Apply
-          ((3, Effect ([ ], .)), Variable ((3, Effect ([ ], .)), orb),
+          ((3, Effect ([ ], .)),
+            Variable ((3, Effect ([ ], . -> . -> .)), orb),
             [
               Apply
                 ((3, Effect ([ ], .)),
@@ -13,7 +14,11 @@ Value
                       Effect
                         ([
                         ],
-                          .)),
+                          .
+                            ->
+                            .
+                              ->
+                              .)),
                       equiv_decb),
                   [
                     Constructor
@@ -38,7 +43,11 @@ Value
                       Effect
                         ([
                         ],
-                          .)),
+                          .
+                            ->
+                            .
+                              ->
+                              .)),
                       andb),
                   [
                     Apply
@@ -52,7 +61,11 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .
+                                    ->
+                                    .)),
                             nequiv_decb),
                         [
                           Constructor
@@ -81,7 +94,9 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .)),
                             negb),
                         [
                           Constructor
@@ -102,7 +117,8 @@ Value
     [
       ((n1, [ ], [ ], Type (Z)),
         Apply
-          ((5, Effect ([ ], .)), Variable ((5, Effect ([ ], .)), Z.add),
+          ((5, Effect ([ ], .)),
+            Variable ((5, Effect ([ ], . -> . -> .)), Z.add),
             [
               Constant ((5, Effect ([ ], .)), Int(1));
               Apply
@@ -112,7 +128,11 @@ Value
                       Effect
                         ([
                         ],
-                          .)),
+                          .
+                            ->
+                            .
+                              ->
+                              .)),
                       Z.mul),
                   [
                     Constant
@@ -139,7 +159,8 @@ Value
     [
       ((n2, [ ], [ ], Type (Z)),
         Apply
-          ((7, Effect ([ ], .)), Variable ((7, Effect ([ ], .)), Z.sub),
+          ((7, Effect ([ ], .)),
+            Variable ((7, Effect ([ ], . -> . -> .)), Z.sub),
             [
               Apply
                 ((7, Effect ([ ], .)),
@@ -148,7 +169,11 @@ Value
                       Effect
                         ([
                         ],
-                          .)),
+                          .
+                            ->
+                            .
+                              ->
+                              .)),
                       Z.add),
                   [
                     Apply
@@ -162,7 +187,9 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .)),
                             Z.abs),
                         [
                           Constant
@@ -188,7 +215,11 @@ Value
                       Effect
                         ([
                         ],
-                          .)),
+                          .
+                            ->
+                            .
+                              ->
+                              .)),
                       Z.mul),
                   [
                     Apply
@@ -202,7 +233,11 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .
+                                    ->
+                                    .)),
                             Z.modulo),
                         [
                           Apply
@@ -216,7 +251,11 @@ Value
                                   Effect
                                     ([
                                     ],
-                                      .)),
+                                      .
+                                        ->
+                                        .
+                                          ->
+                                          .)),
                                   Z.div),
                               [
                                 Constant
@@ -259,7 +298,8 @@ Value
     [
       ((n3, [ ], [ ], Type (Z)),
         Apply
-          ((9, Effect ([ ], .)), Variable ((9, Effect ([ ], .)), Z.pred),
+          ((9, Effect ([ ], .)),
+            Variable ((9, Effect ([ ], . -> .)), Z.pred),
             [
               Apply
                 ((9, Effect ([ ], .)),
@@ -268,7 +308,9 @@ Value
                       Effect
                         ([
                         ],
-                          .)),
+                          .
+                            ->
+                            .)),
                       Z.succ),
                   [
                     Constant
@@ -288,7 +330,8 @@ Value
     [
       ((n4, [ ], [ ], Type (Z)),
         Apply
-          ((11, Effect ([ ], .)), Variable ((11, Effect ([ ], .)), Z.lxor),
+          ((11, Effect ([ ], .)),
+            Variable ((11, Effect ([ ], . -> . -> .)), Z.lxor),
             [
               Apply
                 ((11, Effect ([ ], .)),
@@ -297,7 +340,11 @@ Value
                       Effect
                         ([
                         ],
-                          .)),
+                          .
+                            ->
+                            .
+                              ->
+                              .)),
                       Z.lor),
                   [
                     Apply
@@ -311,7 +358,11 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .
+                                    ->
+                                    .)),
                             Z.land),
                         [
                           Constant
@@ -347,7 +398,8 @@ Value
     [
       ((n5, [ ], [ ], Type (Z)),
         Apply
-          ((13, Effect ([ ], .)), Variable ((13, Effect ([ ], .)), Z.add),
+          ((13, Effect ([ ], .)),
+            Variable ((13, Effect ([ ], . -> . -> .)), Z.add),
             [
               Apply
                 ((13, Effect ([ ], .)),
@@ -356,7 +408,11 @@ Value
                       Effect
                         ([
                         ],
-                          .)),
+                          .
+                            ->
+                            .
+                              ->
+                              .)),
                       Z.shiftl),
                   [
                     Constant
@@ -381,7 +437,11 @@ Value
                       Effect
                         ([
                         ],
-                          .)),
+                          .
+                            ->
+                            .
+                              ->
+                              .)),
                       Z.shiftr),
                   [
                     Constant
@@ -409,7 +469,7 @@ Value
       ((s, [ ], [ ], Type (string)),
         Apply
           ((15, Effect ([ ], .)),
-            Variable ((15, Effect ([ ], .)), String.append),
+            Variable ((15, Effect ([ ], . -> . -> .)), String.append),
             [
               Constant ((15, Effect ([ ], .)), String("ghj"));
               Constant ((15, Effect ([ ], .)), String("klm"))
@@ -420,9 +480,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((c, [ A ], [ (x, A) ], Type (ascii)),
+      ((c, [ A ], [ (x, A) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (ascii))),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument ], .)),
+          ((?, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -430,7 +491,8 @@ Value
                   ((17,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -440,7 +502,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ]->
                               .)),
                         OCaml.Pervasives.char_of_int),
@@ -456,7 +519,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               Z.add),
                           [
                             Apply
@@ -470,7 +537,9 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .)),
                                     OCaml.Pervasives.int_of_char),
                                 [
                                   Constant
@@ -500,7 +569,7 @@ Value
       ((x, [ ], [ ], Type (unit)),
         Apply
           ((19, Effect ([ ], .)),
-            Variable ((19, Effect ([ ], .)), OCaml.Pervasives.ignore),
+            Variable ((19, Effect ([ ], . -> .)), OCaml.Pervasives.ignore),
             [ Constant ((19, Effect ([ ], .)), Int(23)) ]))
     ])
 
@@ -510,7 +579,8 @@ Value
     [
       ((p, [ ], [ ], Type (Z)),
         Apply
-          ((21, Effect ([ ], .)), Variable ((21, Effect ([ ], .)), Z.add),
+          ((21, Effect ([ ], .)),
+            Variable ((21, Effect ([ ], . -> . -> .)), Z.add),
             [
               Apply
                 ((21, Effect ([ ], .)),
@@ -519,7 +589,9 @@ Value
                       Effect
                         ([
                         ],
-                          .)),
+                          .
+                            ->
+                            .)),
                       fst),
                   [
                     Tuple
@@ -550,7 +622,9 @@ Value
                       Effect
                         ([
                         ],
-                          .)),
+                          .
+                            ->
+                            .)),
                       snd),
                   [
                     Tuple
@@ -584,7 +658,8 @@ Value
       ((l, [ ], [ ], Type (list, Type (Z))),
         Apply
           ((23, Effect ([ ], .)),
-            Variable ((23, Effect ([ ], .)), OCaml.Pervasives.app),
+            Variable
+              ((23, Effect ([ ], . -> . -> .)), OCaml.Pervasives.app),
             [
               Constructor
                 ((23, Effect ([ ], .)), cons,
@@ -641,7 +716,8 @@ Value
     [
       ((y, [ ], [ ], Type (Z)),
         Apply
-          ((25, Effect ([ ], .)), Variable ((25, Effect ([ ], .)), apply),
+          ((25, Effect ([ ], .)),
+            Variable ((25, Effect ([ ], . -> . -> .)), apply),
             [
               Function
                 ((25, Effect ([ ], . -> .)), n,
@@ -656,7 +732,11 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .
+                                  ->
+                                  .)),
                           Z.add),
                       [
                         Variable

--- a/tests/ex07.monadise
+++ b/tests/ex07.monadise
@@ -213,7 +213,8 @@ Value
 Value
   (non_rec, @.,
     [
-      ((c, [ A ], [ (x, A) ], Monad ([ OCaml.Invalid_argument ], Type (ascii))),
+      ((c, [ A ], [ (x, A) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (ascii))),
         Match
           (?, Variable (?, x),
             [

--- a/tests/ex08.effects
+++ b/tests/ex08.effects
@@ -36,9 +36,9 @@ Value
   (rec, @.,
     [
       ((of_list_rec, [ A ], [ (counter, Type (nat)); (l, Type (list, A)) ],
-        Type (t2, A)),
+        Monad ([ Type (NonTermination) ], Type (t2, A))),
         Match
-          ((?, Effect ([ NonTermination ], .)),
+          ((?, Effect ([ Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), counter),
             [
               (Constructor (O),
@@ -46,7 +46,8 @@ Value
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -56,7 +57,8 @@ Value
                           ],
                             .
                               -[
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         not_terminated),
@@ -73,7 +75,8 @@ Value
                   ((19,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -101,7 +104,8 @@ Value
                           ((21,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             D2,
@@ -116,7 +120,8 @@ Value
                               ((21,
                                 Effect
                                   ([
-                                    NonTermination
+                                    Type
+                                      (NonTermination)
                                   ],
                                     .)),
                                 Apply
@@ -126,7 +131,8 @@ Value
                                       ],
                                         .
                                           -[
-                                            NonTermination
+                                            Type
+                                              (NonTermination)
                                           ]->
                                           .)),
                                     Variable
@@ -138,7 +144,8 @@ Value
                                               ->
                                               .
                                                 -[
-                                                  NonTermination
+                                                  Type
+                                                    (NonTermination)
                                                 ]->
                                                 .)),
                                         of_list_rec),
@@ -168,15 +175,16 @@ Value
 Value
   (non_rec, @.,
     [
-      ((of_list, [ A ], [ (l, Type (list, A)) ], Type (t2, A)),
+      ((of_list, [ A ], [ (l, Type (list, A)) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (t2, A))),
         Apply
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable
-              ((?, Effect ([ ], . -> . -[ NonTermination ]-> .)),
+              ((?, Effect ([ ], . -> . -[ Type (NonTermination) ]-> .)),
                 of_list_rec),
             [
               Apply
-                ((?, Effect ([ Counter ], .)),
+                ((?, Effect ([ Type (Counter) ], .)),
                   Variable
                     ((?,
                       Effect
@@ -184,7 +192,8 @@ Value
                         ],
                           .
                             -[
-                              Counter
+                              Type
+                                (Counter)
                             ]->
                             .)),
                       read_counter),
@@ -205,9 +214,9 @@ Value
   (rec, @.,
     [
       ((sum_rec, [ ], [ (counter, Type (nat)); (l, Type (t2, Type (Z))) ],
-        Type (Z)),
+        Monad ([ Type (NonTermination) ], Type (Z))),
         Match
-          ((?, Effect ([ NonTermination ], .)),
+          ((?, Effect ([ Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), counter),
             [
               (Constructor (O),
@@ -215,7 +224,8 @@ Value
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -225,7 +235,8 @@ Value
                           ],
                             .
                               -[
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         not_terminated),
@@ -242,7 +253,8 @@ Value
                   ((24,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -270,7 +282,8 @@ Value
                           ((26,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Variable
@@ -278,7 +291,11 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .
+                                        ->
+                                        .)),
                                 Z.add),
                             [
                               Variable
@@ -292,7 +309,8 @@ Value
                                 ((26,
                                   Effect
                                     ([
-                                      NonTermination
+                                      Type
+                                        (NonTermination)
                                     ],
                                       .)),
                                   Apply
@@ -302,7 +320,8 @@ Value
                                         ],
                                           .
                                             -[
-                                              NonTermination
+                                              Type
+                                                (NonTermination)
                                             ]->
                                             .)),
                                       Variable
@@ -314,7 +333,8 @@ Value
                                                 ->
                                                 .
                                                   -[
-                                                    NonTermination
+                                                    Type
+                                                      (NonTermination)
                                                   ]->
                                                   .)),
                                           sum_rec),
@@ -345,15 +365,16 @@ Value
 Value
   (non_rec, @.,
     [
-      ((sum (= sum_1), [ ], [ (l, Type (t2, Type (Z))) ], Type (Z)),
+      ((sum (= sum_1), [ ], [ (l, Type (t2, Type (Z))) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (Z))),
         Apply
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable
-              ((?, Effect ([ ], . -> . -[ NonTermination ]-> .)),
+              ((?, Effect ([ ], . -> . -[ Type (NonTermination) ]-> .)),
                 sum_rec),
             [
               Apply
-                ((?, Effect ([ Counter ], .)),
+                ((?, Effect ([ Type (Counter) ], .)),
                   Variable
                     ((?,
                       Effect
@@ -361,7 +382,8 @@ Value
                         ],
                           .
                             -[
-                              Counter
+                              Type
+                                (Counter)
                             ]->
                             .)),
                       read_counter),
@@ -381,9 +403,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((s, [ A ], [ (x, A) ], Type (Z)),
+      ((s, [ A ], [ (x, A) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (Z))),
         Match
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -391,8 +414,10 @@ Value
                   ((28,
                     Effect
                       ([
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -402,8 +427,10 @@ Value
                           ],
                             .
                               -[
-                                Counter;
-                                NonTermination
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         sum_1),
@@ -412,8 +439,10 @@ Value
                         ((28,
                           Effect
                             ([
-                              Counter;
-                              NonTermination
+                              Type
+                                (Counter);
+                              Type
+                                (NonTermination)
                             ],
                               .)),
                           Variable
@@ -423,8 +452,10 @@ Value
                                 ],
                                   .
                                     -[
-                                      Counter;
-                                      NonTermination
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination)
                                     ]->
                                     .)),
                               of_list),

--- a/tests/ex08.monadise
+++ b/tests/ex08.monadise
@@ -32,7 +32,7 @@ Value
   (rec, @.,
     [
       ((of_list_rec, [ A ], [ (counter, Type (nat)); (l, Type (list, A)) ],
-        Monad ([ NonTermination ], Type (t2, A))),
+        Monad ([ Type (NonTermination) ], Type (t2, A))),
         Match
           (?, Variable (?, counter),
             [
@@ -102,15 +102,17 @@ Value
   (non_rec, @.,
     [
       ((of_list, [ A ], [ (l, Type (list, A)) ],
-        Monad ([ Counter; NonTermination ], Type (t2, A))),
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (t2, A))),
         Bind
           (?,
             Lift
-              (?, [ Counter ], [ Counter; NonTermination ],
+              (?, [ Type (Counter) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply (?, Variable (?, read_counter), [ Tuple (?) ])),
             Some x,
             Lift
-              (?, [ NonTermination ], [ Counter; NonTermination ],
+              (?, [ Type (NonTermination) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply
                   (?, Variable (?, of_list_rec),
                     [ Variable (?, x); Variable (?, l) ]))))
@@ -121,7 +123,7 @@ Value
   (rec, @.,
     [
       ((sum_rec, [ ], [ (counter, Type (nat)); (l, Type (t2, Type (Z))) ],
-        Monad ([ NonTermination ], Type (Z))),
+        Monad ([ Type (NonTermination) ], Type (Z))),
         Match
           (?, Variable (?, counter),
             [
@@ -195,15 +197,17 @@ Value
   (non_rec, @.,
     [
       ((sum (= sum_1), [ ], [ (l, Type (t2, Type (Z))) ],
-        Monad ([ Counter; NonTermination ], Type (Z))),
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (Z))),
         Bind
           (?,
             Lift
-              (?, [ Counter ], [ Counter; NonTermination ],
+              (?, [ Type (Counter) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply (?, Variable (?, read_counter), [ Tuple (?) ])),
             Some x,
             Lift
-              (?, [ NonTermination ], [ Counter; NonTermination ],
+              (?, [ Type (NonTermination) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply
                   (?, Variable (?, sum_rec),
                     [ Variable (?, x); Variable (?, l) ]))))
@@ -213,7 +217,8 @@ Value
 Value
   (non_rec, @.,
     [
-      ((s, [ A ], [ (x, A) ], Monad ([ Counter; NonTermination ], Type (Z))),
+      ((s, [ A ], [ (x, A) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (Z))),
         Match
           (?, Variable (?, x),
             [

--- a/tests/ex09.effects
+++ b/tests/ex09.effects
@@ -2,9 +2,11 @@
 Value
   (non_rec, @.,
     [
-      ((l, [ A ], [ (x, A) ], Type (list, Type (Z))),
+      ((l, [ A ], [ (x, A) ],
+        Monad
+          ([ Type (Counter); Type (NonTermination) ], Type (list, Type (Z)))),
         Match
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -12,8 +14,10 @@ Value
                   (4,
                     Effect
                       ([
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .))
                   (rec, @.,
@@ -36,14 +40,20 @@ Value
                               (list,
                                 B))
                         ],
-                        Type
-                          (list,
-                            C)),
+                        Monad
+                          ([
+                            Type
+                              (NonTermination)
+                          ],
+                            Type
+                              (list,
+                                C))),
                         Match
                           ((?,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Variable
@@ -60,7 +70,8 @@ Value
                                   ((?,
                                     Effect
                                       ([
-                                        NonTermination
+                                        Type
+                                          (NonTermination)
                                       ],
                                         .)),
                                     Variable
@@ -70,7 +81,8 @@ Value
                                           ],
                                             .
                                               -[
-                                                NonTermination
+                                                Type
+                                                  (NonTermination)
                                               ]->
                                               .)),
                                         not_terminated),
@@ -89,7 +101,8 @@ Value
                                   ((?,
                                     Effect
                                       ([
-                                        NonTermination
+                                        Type
+                                          (NonTermination)
                                       ],
                                         .)),
                                     Variable
@@ -117,7 +130,8 @@ Value
                                           ((6,
                                             Effect
                                               ([
-                                                NonTermination
+                                                Type
+                                                  (NonTermination)
                                               ],
                                                 .)),
                                             cons,
@@ -132,7 +146,9 @@ Value
                                                     Effect
                                                       ([
                                                       ],
-                                                        .)),
+                                                        .
+                                                          ->
+                                                          .)),
                                                     f),
                                                 [
                                                   Variable
@@ -147,7 +163,8 @@ Value
                                               ((6,
                                                 Effect
                                                   ([
-                                                    NonTermination
+                                                    Type
+                                                      (NonTermination)
                                                   ],
                                                     .)),
                                                 Apply
@@ -159,7 +176,8 @@ Value
                                                           ->
                                                           .
                                                             -[
-                                                              NonTermination
+                                                              Type
+                                                                (NonTermination)
                                                             ]->
                                                             .)),
                                                     Variable
@@ -173,7 +191,8 @@ Value
                                                                 ->
                                                                 .
                                                                   -[
-                                                                    NonTermination
+                                                                    Type
+                                                                      (NonTermination)
                                                                   ]->
                                                                   .)),
                                                         map_rec),
@@ -192,7 +211,9 @@ Value
                                                       Effect
                                                         ([
                                                         ],
-                                                          .)),
+                                                          .
+                                                            ->
+                                                            .)),
                                                       f);
                                                   Variable
                                                     ((6,
@@ -210,8 +231,10 @@ Value
                   (4,
                     Effect
                       ([
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .))
                   (non_rec, @.,
@@ -231,15 +254,24 @@ Value
                               (list,
                                 B))
                         ],
-                        Type
-                          (list,
-                            C)),
+                        Monad
+                          ([
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination)
+                          ],
+                            Type
+                              (list,
+                                C))),
                         Apply
                           ((?,
                             Effect
                               ([
-                                Counter;
-                                NonTermination
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Variable
@@ -253,7 +285,8 @@ Value
                                         ->
                                         .
                                           -[
-                                            NonTermination
+                                            Type
+                                              (NonTermination)
                                           ]->
                                           .)),
                                 map_rec),
@@ -262,7 +295,8 @@ Value
                                 ((?,
                                   Effect
                                     ([
-                                      Counter
+                                      Type
+                                        (Counter)
                                     ],
                                       .)),
                                   Variable
@@ -272,7 +306,8 @@ Value
                                         ],
                                           .
                                             -[
-                                              Counter
+                                              Type
+                                                (Counter)
                                             ]->
                                             .)),
                                       read_counter),
@@ -289,7 +324,9 @@ Value
                                   Effect
                                     ([
                                     ],
-                                      .)),
+                                      .
+                                        ->
+                                        .)),
                                   f);
                               Variable
                                 ((?,
@@ -305,8 +342,10 @@ Value
                   (7,
                     Effect
                       ([
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .))
                   (rec, @.,
@@ -322,12 +361,18 @@ Value
                           (x,
                             B)
                         ],
-                        B),
+                        Monad
+                          ([
+                            Type
+                              (NonTermination)
+                          ],
+                            B)),
                         Match
                           ((?,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Variable
@@ -344,7 +389,8 @@ Value
                                   ((?,
                                     Effect
                                       ([
-                                        NonTermination
+                                        Type
+                                          (NonTermination)
                                       ],
                                         .)),
                                     Variable
@@ -354,7 +400,8 @@ Value
                                           ],
                                             .
                                               -[
-                                                NonTermination
+                                                Type
+                                                  (NonTermination)
                                               ]->
                                               .)),
                                         not_terminated),
@@ -383,8 +430,10 @@ Value
                   (7,
                     Effect
                       ([
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .))
                   (non_rec, @.,
@@ -397,13 +446,22 @@ Value
                           (x,
                             B)
                         ],
-                        B),
+                        Monad
+                          ([
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination)
+                          ],
+                            B)),
                         Apply
                           ((?,
                             Effect
                               ([
-                                Counter;
-                                NonTermination
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Variable
@@ -415,7 +473,8 @@ Value
                                       ->
                                       .
                                         -[
-                                          NonTermination
+                                          Type
+                                            (NonTermination)
                                         ]->
                                         .)),
                                 loop_rec),
@@ -424,7 +483,8 @@ Value
                                 ((?,
                                   Effect
                                     ([
-                                      Counter
+                                      Type
+                                        (Counter)
                                     ],
                                       .)),
                                   Variable
@@ -434,7 +494,8 @@ Value
                                         ],
                                           .
                                             -[
-                                              Counter
+                                              Type
+                                                (Counter)
                                             ]->
                                             .)),
                                       read_counter),
@@ -460,8 +521,10 @@ Value
                   ((8,
                     Effect
                       ([
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -473,8 +536,10 @@ Value
                               ->
                               .
                                 -[
-                                  Counter;
-                                  NonTermination
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination)
                                 ]->
                                 .)),
                         map),
@@ -499,7 +564,11 @@ Value
                                   Effect
                                     ([
                                     ],
-                                      .)),
+                                      .
+                                        ->
+                                        .
+                                          ->
+                                          .)),
                                   Z.add),
                               [
                                 Variable

--- a/tests/ex09.monadise
+++ b/tests/ex09.monadise
@@ -3,7 +3,8 @@ Value
   (non_rec, @.,
     [
       ((l, [ A ], [ (x, A) ],
-        Monad ([ Counter; NonTermination ], Type (list, Type (Z)))),
+        Monad
+          ([ Type (Counter); Type (NonTermination) ], Type (list, Type (Z)))),
         Match
           (?, Variable (?, x),
             [
@@ -31,7 +32,8 @@ Value
                         ],
                         Monad
                           ([
-                            NonTermination
+                            Type
+                              (NonTermination)
                           ],
                             Type
                               (list,
@@ -139,8 +141,10 @@ Value
                         ],
                         Monad
                           ([
-                            Counter;
-                            NonTermination
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination)
                           ],
                             Type
                               (list,
@@ -150,11 +154,14 @@ Value
                             Lift
                               (?,
                                 [
-                                  Counter
+                                  Type
+                                    (Counter)
                                 ],
                                 [
-                                  Counter;
-                                  NonTermination
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination)
                                 ],
                                 Apply
                                   (?,
@@ -170,11 +177,14 @@ Value
                             Lift
                               (?,
                                 [
-                                  NonTermination
+                                  Type
+                                    (NonTermination)
                                 ],
                                 [
-                                  Counter;
-                                  NonTermination
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination)
                                 ],
                                 Apply
                                   (?,
@@ -210,7 +220,8 @@ Value
                         ],
                         Monad
                           ([
-                            NonTermination
+                            Type
+                              (NonTermination)
                           ],
                             B)),
                         Match
@@ -254,8 +265,10 @@ Value
                         ],
                         Monad
                           ([
-                            Counter;
-                            NonTermination
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination)
                           ],
                             B)),
                         Bind
@@ -263,11 +276,14 @@ Value
                             Lift
                               (?,
                                 [
-                                  Counter
+                                  Type
+                                    (Counter)
                                 ],
                                 [
-                                  Counter;
-                                  NonTermination
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination)
                                 ],
                                 Apply
                                   (?,
@@ -283,11 +299,14 @@ Value
                             Lift
                               (?,
                                 [
-                                  NonTermination
+                                  Type
+                                    (NonTermination)
                                 ],
                                 [
-                                  Counter;
-                                  NonTermination
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination)
                                 ],
                                 Apply
                                   (?,

--- a/tests/ex10.effects
+++ b/tests/ex10.effects
@@ -8,9 +8,10 @@
     (rec, @.,
       [
         ((sum_rec, [ ],
-          [ (counter, Type (nat)); (l, Type (List2/t, Type (Z))) ], Type (Z)),
+          [ (counter, Type (nat)); (l, Type (List2/t, Type (Z))) ],
+          Monad ([ Type (NonTermination) ], Type (Z))),
           Match
-            ((?, Effect ([ NonTermination ], .)),
+            ((?, Effect ([ Type (NonTermination) ], .)),
               Variable ((?, Effect ([ ], .)), List2/counter),
               [
                 (Constructor (O),
@@ -18,7 +19,8 @@
                     ((?,
                       Effect
                         ([
-                          NonTermination
+                          Type
+                            (NonTermination)
                         ],
                           .)),
                       Variable
@@ -28,7 +30,8 @@
                             ],
                               .
                                 -[
-                                  NonTermination
+                                  Type
+                                    (NonTermination)
                                 ]->
                                 .)),
                           not_terminated),
@@ -45,7 +48,8 @@
                     ((9,
                       Effect
                         ([
-                          NonTermination
+                          Type
+                            (NonTermination)
                         ],
                           .)),
                       Variable
@@ -73,7 +77,8 @@
                             ((11,
                               Effect
                                 ([
-                                  NonTermination
+                                  Type
+                                    (NonTermination)
                                 ],
                                   .)),
                               Variable
@@ -81,7 +86,11 @@
                                   Effect
                                     ([
                                     ],
-                                      .)),
+                                      .
+                                        ->
+                                        .
+                                          ->
+                                          .)),
                                   Z.add),
                               [
                                 Variable
@@ -95,7 +104,8 @@
                                   ((11,
                                     Effect
                                       ([
-                                        NonTermination
+                                        Type
+                                          (NonTermination)
                                       ],
                                         .)),
                                     Apply
@@ -105,7 +115,8 @@
                                           ],
                                             .
                                               -[
-                                                NonTermination
+                                                Type
+                                                  (NonTermination)
                                               ]->
                                               .)),
                                         Variable
@@ -117,7 +128,8 @@
                                                   ->
                                                   .
                                                     -[
-                                                      NonTermination
+                                                      Type
+                                                        (NonTermination)
                                                     ]->
                                                     .)),
                                             List2/sum_rec),
@@ -148,20 +160,28 @@
   Value
     (non_rec, @.,
       [
-        ((sum, [ ], [ (l, Type (List2/t, Type (Z))) ], Type (Z)),
+        ((sum, [ ], [ (l, Type (List2/t, Type (Z))) ],
+          Monad ([ Type (Counter); Type (NonTermination) ], Type (Z))),
           Apply
-            ((?, Effect ([ Counter; NonTermination ], .)),
+            ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
               Variable
                 ((?,
                   Effect
-                    ([ ], . -> . -[ NonTermination ]-> .)),
+                    ([ ],
+                      . ->
+                        .
+                          -[
+                            Type
+                              (NonTermination)
+                          ]-> .)),
                   List2/sum_rec),
               [
                 Apply
                   ((?,
                     Effect
                       ([
-                        Counter
+                        Type
+                          (Counter)
                       ],
                         .)),
                     Variable
@@ -171,7 +191,8 @@
                           ],
                             .
                               -[
-                                Counter
+                                Type
+                                  (Counter)
                               ]->
                               .)),
                         read_counter),
@@ -192,9 +213,9 @@
     (rec, @.,
       [
         ((of_list_rec, [ A ], [ (counter, Type (nat)); (x, Type (list, A)) ],
-          Type (List2/t, A)),
+          Monad ([ Type (NonTermination) ], Type (List2/t, A))),
           Match
-            ((?, Effect ([ NonTermination ], .)),
+            ((?, Effect ([ Type (NonTermination) ], .)),
               Variable ((?, Effect ([ ], .)), List2/counter),
               [
                 (Constructor (O),
@@ -202,7 +223,8 @@
                     ((?,
                       Effect
                         ([
-                          NonTermination
+                          Type
+                            (NonTermination)
                         ],
                           .)),
                       Variable
@@ -212,7 +234,8 @@
                             ],
                               .
                                 -[
-                                  NonTermination
+                                  Type
+                                    (NonTermination)
                                 ]->
                                 .)),
                           not_terminated),
@@ -229,7 +252,8 @@
                     ((?,
                       Effect
                         ([
-                          NonTermination
+                          Type
+                            (NonTermination)
                         ],
                           .)),
                       Variable
@@ -257,7 +281,8 @@
                             ((15,
                               Effect
                                 ([
-                                  NonTermination
+                                  Type
+                                    (NonTermination)
                                 ],
                                   .)),
                               List2/Cons,
@@ -272,7 +297,8 @@
                                 ((15,
                                   Effect
                                     ([
-                                      NonTermination
+                                      Type
+                                        (NonTermination)
                                     ],
                                       .)),
                                   Apply
@@ -282,7 +308,8 @@
                                         ],
                                           .
                                             -[
-                                              NonTermination
+                                              Type
+                                                (NonTermination)
                                             ]->
                                             .)),
                                       Variable
@@ -294,7 +321,8 @@
                                                 ->
                                                 .
                                                   -[
-                                                    NonTermination
+                                                    Type
+                                                      (NonTermination)
                                                   ]->
                                                   .)),
                                           List2/of_list_rec),
@@ -324,20 +352,30 @@
   Value
     (non_rec, @.,
       [
-        ((of_list, [ A ], [ (x, Type (list, A)) ], Type (List2/t, A)),
+        ((of_list, [ A ], [ (x, Type (list, A)) ],
+          Monad
+            ([ Type (Counter); Type (NonTermination) ],
+              Type (List2/t, A))),
           Apply
-            ((?, Effect ([ Counter; NonTermination ], .)),
+            ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
               Variable
                 ((?,
                   Effect
-                    ([ ], . -> . -[ NonTermination ]-> .)),
+                    ([ ],
+                      . ->
+                        .
+                          -[
+                            Type
+                              (NonTermination)
+                          ]-> .)),
                   List2/of_list_rec),
               [
                 Apply
                   ((?,
                     Effect
                       ([
-                        Counter
+                        Type
+                          (Counter)
                       ],
                         .)),
                     Variable
@@ -347,7 +385,8 @@
                           ],
                             .
                               -[
-                                Counter
+                                Type
+                                  (Counter)
                               ]->
                               .)),
                         read_counter),
@@ -373,9 +412,10 @@
 Value
   (non_rec, @.,
     [
-      ((n, [ A ], [ (x, A) ], Type (Z)),
+      ((n, [ A ], [ (x, A) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (Z))),
         Match
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -383,8 +423,10 @@ Value
                   ((22,
                     Effect
                       ([
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -394,8 +436,10 @@ Value
                           ],
                             .
                               -[
-                                Counter;
-                                NonTermination
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         List2.sum),
@@ -404,8 +448,10 @@ Value
                         ((22,
                           Effect
                             ([
-                              Counter;
-                              NonTermination
+                              Type
+                                (Counter);
+                              Type
+                                (NonTermination)
                             ],
                               .)),
                           Variable
@@ -415,8 +461,10 @@ Value
                                 ],
                                   .
                                     -[
-                                      Counter;
-                                      NonTermination
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination)
                                     ]->
                                     .)),
                               List2.of_list),

--- a/tests/ex10.monadise
+++ b/tests/ex10.monadise
@@ -9,7 +9,7 @@
       [
         ((sum_rec, [ ],
           [ (counter, Type (nat)); (l, Type (List2/t, Type (Z))) ],
-          Monad ([ NonTermination ], Type (Z))),
+          Monad ([ Type (NonTermination) ], Type (Z))),
           Match
             (?, Variable (?, List2/counter),
               [
@@ -86,17 +86,18 @@
     (non_rec, @.,
       [
         ((sum, [ ], [ (l, Type (List2/t, Type (Z))) ],
-          Monad ([ Counter; NonTermination ], Type (Z))),
+          Monad ([ Type (Counter); Type (NonTermination) ], Type (Z))),
           Bind
             (?,
               Lift
-                (?, [ Counter ], [ Counter; NonTermination ],
+                (?, [ Type (Counter) ],
+                  [ Type (Counter); Type (NonTermination) ],
                   Apply
                     (?, Variable (?, read_counter),
                       [ Tuple (?) ])), Some x,
               Lift
-                (?, [ NonTermination ],
-                  [ Counter; NonTermination ],
+                (?, [ Type (NonTermination) ],
+                  [ Type (Counter); Type (NonTermination) ],
                   Apply
                     (?, Variable (?, List2/sum_rec),
                       [
@@ -110,7 +111,7 @@
     (rec, @.,
       [
         ((of_list_rec, [ A ], [ (counter, Type (nat)); (x, Type (list, A)) ],
-          Monad ([ NonTermination ], Type (List2/t, A))),
+          Monad ([ Type (NonTermination) ], Type (List2/t, A))),
           Match
             (?, Variable (?, List2/counter),
               [
@@ -183,17 +184,20 @@
     (non_rec, @.,
       [
         ((of_list, [ A ], [ (x, Type (list, A)) ],
-          Monad ([ Counter; NonTermination ], Type (List2/t, A))),
+          Monad
+            ([ Type (Counter); Type (NonTermination) ],
+              Type (List2/t, A))),
           Bind
             (?,
               Lift
-                (?, [ Counter ], [ Counter; NonTermination ],
+                (?, [ Type (Counter) ],
+                  [ Type (Counter); Type (NonTermination) ],
                   Apply
                     (?, Variable (?, read_counter),
                       [ Tuple (?) ])), Some x_1,
               Lift
-                (?, [ NonTermination ],
-                  [ Counter; NonTermination ],
+                (?, [ Type (NonTermination) ],
+                  [ Type (Counter); Type (NonTermination) ],
                   Apply
                     (?, Variable (?, List2/of_list_rec),
                       [
@@ -210,7 +214,8 @@
 Value
   (non_rec, @.,
     [
-      ((n, [ A ], [ (x, A) ], Monad ([ Counter; NonTermination ], Type (Z))),
+      ((n, [ A ], [ (x, A) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (Z))),
         Match
           (?, Variable (?, x),
             [

--- a/tests/ex11.effects
+++ b/tests/ex11.effects
@@ -47,7 +47,8 @@ Value
     [
       ((s, [ ], [ ], Type (Z)),
         Apply
-          ((13, Effect ([ ], .)), Variable ((13, Effect ([ ], .)), Z.add),
+          ((13, Effect ([ ], .)),
+            Variable ((13, Effect ([ ], . -> . -> .)), Z.add),
             [
               Field
                 ((13, Effect ([ ], .)),
@@ -179,7 +180,13 @@ Value
                   Apply
                     ((35, Effect ([ ], .)),
                       Variable
-                        ((35, Effect ([ ], .)),
+                        ((35,
+                          Effect
+                            ([ ],
+                              . ->
+                                .
+                                  ->
+                                  .)),
                           Z.add),
                       [
                         Field

--- a/tests/ex12.effects
+++ b/tests/ex12.effects
@@ -8,9 +8,9 @@ Value
     [
       ((find_rec, [ ],
         [ (counter, Type (nat)); (x, Type (Z)); (t, Type (tree)) ],
-        Type (bool)),
+        Monad ([ Type (NonTermination) ], Type (bool))),
         Match
-          ((?, Effect ([ NonTermination ], .)),
+          ((?, Effect ([ Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), counter),
             [
               (Constructor (O),
@@ -18,7 +18,8 @@ Value
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -28,7 +29,8 @@ Value
                           ],
                             .
                               -[
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         not_terminated),
@@ -45,7 +47,8 @@ Value
                   ((8,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -74,7 +77,8 @@ Value
                           ((11,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Apply
@@ -88,7 +92,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     OCaml.Pervasives.lt),
                                 [
                                   Variable
@@ -110,7 +118,8 @@ Value
                               ((12,
                                 Effect
                                   ([
-                                    NonTermination
+                                    Type
+                                      (NonTermination)
                                   ],
                                     .)),
                                 Apply
@@ -122,7 +131,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              NonTermination
+                                              Type
+                                                (NonTermination)
                                             ]->
                                             .)),
                                     Variable
@@ -136,7 +146,8 @@ Value
                                                 ->
                                                 .
                                                   -[
-                                                    NonTermination
+                                                    Type
+                                                      (NonTermination)
                                                   ]->
                                                   .)),
                                         find_rec),
@@ -169,7 +180,8 @@ Value
                               ((13,
                                 Effect
                                   ([
-                                    NonTermination
+                                    Type
+                                      (NonTermination)
                                   ],
                                     .)),
                                 Apply
@@ -183,7 +195,11 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         OCaml.Pervasives.lt),
                                     [
                                       Variable
@@ -205,7 +221,8 @@ Value
                                   ((14,
                                     Effect
                                       ([
-                                        NonTermination
+                                        Type
+                                          (NonTermination)
                                       ],
                                         .)),
                                     Apply
@@ -217,7 +234,8 @@ Value
                                               ->
                                               .
                                                 -[
-                                                  NonTermination
+                                                  Type
+                                                    (NonTermination)
                                                 ]->
                                                 .)),
                                         Variable
@@ -231,7 +249,8 @@ Value
                                                     ->
                                                     .
                                                       -[
-                                                        NonTermination
+                                                        Type
+                                                          (NonTermination)
                                                       ]->
                                                       .)),
                                             find_rec),
@@ -275,15 +294,18 @@ Value
 Value
   (non_rec, @.,
     [
-      ((find, [ ], [ (x, Type (Z)); (t, Type (tree)) ], Type (bool)),
+      ((find, [ ], [ (x, Type (Z)); (t, Type (tree)) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (bool))),
         Apply
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable
-              ((?, Effect ([ ], . -> . -> . -[ NonTermination ]-> .)),
+              ((?,
+                Effect
+                  ([ ], . -> . -> . -[ Type (NonTermination) ]-> .)),
                 find_rec),
             [
               Apply
-                ((?, Effect ([ Counter ], .)),
+                ((?, Effect ([ Type (Counter) ], .)),
                   Variable
                     ((?,
                       Effect
@@ -291,7 +313,8 @@ Value
                         ],
                           .
                             -[
-                              Counter
+                              Type
+                                (Counter)
                             ]->
                             .)),
                       read_counter),

--- a/tests/ex12.monadise
+++ b/tests/ex12.monadise
@@ -8,7 +8,7 @@ Value
     [
       ((find_rec, [ ],
         [ (counter, Type (nat)); (x, Type (Z)); (t, Type (tree)) ],
-        Monad ([ NonTermination ], Type (bool))),
+        Monad ([ Type (NonTermination) ], Type (bool))),
         Match
           (?, Variable (?, counter),
             [
@@ -122,15 +122,17 @@ Value
   (non_rec, @.,
     [
       ((find, [ ], [ (x, Type (Z)); (t, Type (tree)) ],
-        Monad ([ Counter; NonTermination ], Type (bool))),
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (bool))),
         Bind
           (?,
             Lift
-              (?, [ Counter ], [ Counter; NonTermination ],
+              (?, [ Type (Counter) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply (?, Variable (?, read_counter), [ Tuple (?) ])),
             Some x_1,
             Lift
-              (?, [ NonTermination ], [ Counter; NonTermination ],
+              (?, [ Type (NonTermination) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply
                   (?, Variable (?, find_rec),
                     [

--- a/tests/ex13.effects
+++ b/tests/ex13.effects
@@ -2,9 +2,10 @@
 Value
   (non_rec, @.,
     [
-      ((tail, [ A ], [ (l, Type (list, A)) ], Type (list, A)),
+      ((tail, [ A ], [ (l, Type (list, A)) ],
+        Monad ([ Type (OCaml.Failure) ], Type (list, A))),
         Match
-          ((4, Effect ([ OCaml.Failure ], .)),
+          ((4, Effect ([ Type (OCaml.Failure) ], .)),
             Variable ((4, Effect ([ ], .)), l),
             [
               (Constructor (cons, Any, xs),
@@ -14,7 +15,8 @@ Value
                   ((6,
                     Effect
                       ([
-                        OCaml.Failure
+                        Type
+                          (OCaml.Failure)
                       ],
                         .)),
                     Variable
@@ -24,7 +26,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Failure
+                                Type
+                                  (OCaml.Failure)
                               ]->
                               .)),
                         OCaml.Pervasives.failwith),
@@ -46,9 +49,9 @@ Value
     [
       ((print_list_rec, [ ],
         [ (counter, Type (nat)); (x, Type (list, Type (string))) ],
-        Type (unit)),
+        Monad ([ Type (IO); Type (NonTermination) ], Type (unit))),
         Match
-          ((?, Effect ([ IO; NonTermination ], .)),
+          ((?, Effect ([ Type (IO); Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), counter),
             [
               (Constructor (O),
@@ -56,7 +59,8 @@ Value
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -66,7 +70,8 @@ Value
                           ],
                             .
                               -[
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         not_terminated),
@@ -83,8 +88,10 @@ Value
                   ((?,
                     Effect
                       ([
-                        IO;
-                        NonTermination
+                        Type
+                          (IO);
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -112,15 +119,18 @@ Value
                           ((11,
                             Effect
                               ([
-                                IO;
-                                NonTermination
+                                Type
+                                  (IO);
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Apply
                               ((11,
                                 Effect
                                   ([
-                                    IO
+                                    Type
+                                      (IO)
                                   ],
                                     .)),
                                 Variable
@@ -130,7 +140,8 @@ Value
                                       ],
                                         .
                                           -[
-                                            IO
+                                            Type
+                                              (IO)
                                           ]->
                                           .)),
                                     OCaml.Pervasives.print_string),
@@ -147,8 +158,10 @@ Value
                               ((12,
                                 Effect
                                   ([
-                                    IO;
-                                    NonTermination
+                                    Type
+                                      (IO);
+                                    Type
+                                      (NonTermination)
                                   ],
                                     .)),
                                 Apply
@@ -158,8 +171,10 @@ Value
                                       ],
                                         .
                                           -[
-                                            IO;
-                                            NonTermination
+                                            Type
+                                              (IO);
+                                            Type
+                                              (NonTermination)
                                           ]->
                                           .)),
                                     Variable
@@ -171,8 +186,10 @@ Value
                                               ->
                                               .
                                                 -[
-                                                  IO;
-                                                  NonTermination
+                                                  Type
+                                                    (IO);
+                                                  Type
+                                                    (NonTermination)
                                                 ]->
                                                 .)),
                                         print_list_rec),
@@ -202,15 +219,23 @@ Value
 Value
   (non_rec, @.,
     [
-      ((print_list, [ ], [ (x, Type (list, Type (string))) ], Type (unit)),
+      ((print_list, [ ], [ (x, Type (list, Type (string))) ],
+        Monad
+          ([ Type (Counter); Type (IO); Type (NonTermination) ], Type (unit))),
         Apply
-          ((?, Effect ([ Counter; IO; NonTermination ], .)),
+          ((?,
+            Effect
+              ([ Type (Counter); Type (IO); Type (NonTermination) ], .)),
             Variable
-              ((?, Effect ([ ], . -> . -[ IO; NonTermination ]-> .)),
-                print_list_rec),
+              ((?,
+                Effect
+                  ([ ],
+                    . ->
+                      . -[ Type (IO); Type (NonTermination) ]->
+                        .)), print_list_rec),
             [
               Apply
-                ((?, Effect ([ Counter ], .)),
+                ((?, Effect ([ Type (Counter) ], .)),
                   Variable
                     ((?,
                       Effect
@@ -218,7 +243,8 @@ Value
                         ],
                           .
                             -[
-                              Counter
+                              Type
+                                (Counter)
                             ]->
                             .)),
                       read_counter),
@@ -238,25 +264,62 @@ Value
 Value
   (non_rec, @.,
     [
-      ((f, [ ], [ ], (Type (list, Type (string)) -> Type (unit))),
+      ((f, [ ], [ ],
+        (Type (list, Type (string)) ->
+          Monad
+            ([ Type (Counter); Type (IO); Type (NonTermination) ],
+              Type (unit)))),
         Variable
-          ((14, Effect ([ ], . -[ Counter; IO; NonTermination ]-> .)),
-            print_list))
+          ((14,
+            Effect
+              ([ ],
+                .
+                  -[
+                    Type (Counter);
+                    Type (IO);
+                    Type (NonTermination)
+                  ]-> .)), print_list))
     ])
 
 16
 Value
   (non_rec, @.,
     [
-      ((x, [ A ], [ (z, A) ], Type (unit)),
+      ((x, [ A ], [ (z, A) ],
+        Monad
+          ([
+            Type (Counter);
+            Type (IO);
+            Type (NonTermination);
+            Type (OCaml.Failure)
+          ], Type (unit))),
         Apply
-          ((16, Effect ([ Counter; IO; NonTermination; OCaml.Failure ], .)),
+          ((16,
+            Effect
+              ([
+                Type (Counter);
+                Type (IO);
+                Type (NonTermination);
+                Type (OCaml.Failure)
+              ], .)),
             Variable
-              ((16, Effect ([ ], . -[ Counter; IO; NonTermination ]-> .)),
-                f),
+              ((16,
+                Effect
+                  ([ ],
+                    .
+                      -[
+                        Type (Counter);
+                        Type (IO);
+                        Type (NonTermination)
+                      ]-> .)), f),
             [
               Apply
-                ((16, Effect ([ OCaml.Failure ], .)),
+                ((16,
+                  Effect
+                    ([
+                      Type
+                        (OCaml.Failure)
+                    ], .)),
                   Variable
                     ((16,
                       Effect
@@ -264,7 +327,8 @@ Value
                         ],
                           .
                             -[
-                              OCaml.Failure
+                              Type
+                                (OCaml.Failure)
                             ]->
                             .)),
                       tail),

--- a/tests/ex13.monadise
+++ b/tests/ex13.monadise
@@ -3,7 +3,7 @@ Value
   (non_rec, @.,
     [
       ((tail, [ A ], [ (l, Type (list, A)) ],
-        Monad ([ OCaml.Failure ], Type (list, A))),
+        Monad ([ Type (OCaml.Failure) ], Type (list, A))),
         Match
           (4, Variable (4, l),
             [
@@ -29,7 +29,7 @@ Value
     [
       ((print_list_rec, [ ],
         [ (counter, Type (nat)); (x, Type (list, Type (string))) ],
-        Monad ([ IO; NonTermination ], Type (unit))),
+        Monad ([ Type (IO); Type (NonTermination) ], Type (unit))),
         Match
           (?, Variable (?, counter),
             [
@@ -37,11 +37,14 @@ Value
                 Lift
                   (?,
                     [
-                      NonTermination
+                      Type
+                        (NonTermination)
                     ],
                     [
-                      IO;
-                      NonTermination
+                      Type
+                        (IO);
+                      Type
+                        (NonTermination)
                     ],
                     Apply
                       (?,
@@ -72,11 +75,14 @@ Value
                             Lift
                               (?,
                                 [
-                                  IO
+                                  Type
+                                    (IO)
                                 ],
                                 [
-                                  IO;
-                                  NonTermination
+                                  Type
+                                    (IO);
+                                  Type
+                                    (NonTermination)
                                 ],
                                 Apply
                                   (11,
@@ -115,16 +121,18 @@ Value
   (non_rec, @.,
     [
       ((print_list, [ ], [ (x, Type (list, Type (string))) ],
-        Monad ([ Counter; IO; NonTermination ], Type (unit))),
+        Monad
+          ([ Type (Counter); Type (IO); Type (NonTermination) ], Type (unit))),
         Bind
           (?,
             Lift
-              (?, [ Counter ], [ Counter; IO; NonTermination ],
+              (?, [ Type (Counter) ],
+                [ Type (Counter); Type (IO); Type (NonTermination) ],
                 Apply (?, Variable (?, read_counter), [ Tuple (?) ])),
             Some x_1,
             Lift
-              (?, [ IO; NonTermination ],
-                [ Counter; IO; NonTermination ],
+              (?, [ Type (IO); Type (NonTermination) ],
+                [ Type (Counter); Type (IO); Type (NonTermination) ],
                 Apply
                   (?, Variable (?, print_list_rec),
                     [ Variable (?, x_1); Variable (?, x) ]))))
@@ -136,8 +144,9 @@ Value
     [
       ((f, [ ], [ ],
         (Type (list, Type (string)) ->
-          Monad ([ Counter; IO; NonTermination ], Type (unit)))),
-        Variable (14, print_list))
+          Monad
+            ([ Type (Counter); Type (IO); Type (NonTermination) ],
+              Type (unit)))), Variable (14, print_list))
     ])
 
 16
@@ -145,12 +154,23 @@ Value
   (non_rec, @.,
     [
       ((x, [ A ], [ (z, A) ],
-        Monad ([ Counter; IO; NonTermination; OCaml.Failure ], Type (unit))),
+        Monad
+          ([
+            Type (Counter);
+            Type (IO);
+            Type (NonTermination);
+            Type (OCaml.Failure)
+          ], Type (unit))),
         Bind
           (?,
             Lift
-              (?, [ OCaml.Failure ],
-                [ Counter; IO; NonTermination; OCaml.Failure ],
+              (?, [ Type (OCaml.Failure) ],
+                [
+                  Type (Counter);
+                  Type (IO);
+                  Type (NonTermination);
+                  Type (OCaml.Failure)
+                ],
                 Apply
                   (16, Variable (16, tail),
                     [
@@ -183,7 +203,11 @@ Value
                                           [])))))
                     ])), Some x,
             Lift
-              (?, [ Counter; IO; NonTermination ],
-                [ Counter; IO; NonTermination; OCaml.Failure ],
-                Apply (16, Variable (16, f), [ Variable (?, x) ]))))
+              (?, [ Type (Counter); Type (IO); Type (NonTermination) ],
+                [
+                  Type (Counter);
+                  Type (IO);
+                  Type (NonTermination);
+                  Type (OCaml.Failure)
+                ], Apply (16, Variable (16, f), [ Variable (?, x) ]))))
     ])

--- a/tests/ex14.effects
+++ b/tests/ex14.effects
@@ -7,14 +7,14 @@ Value
           ((4, Effect ([ ], .)), Variable ((4, Effect ([ ], .)), b),
             Apply
               ((5, Effect ([ ], .)),
-                Variable ((5, Effect ([ ], .)), Z.add),
+                Variable ((5, Effect ([ ], . -> . -> .)), Z.add),
                 [
                   Variable ((5, Effect ([ ], .)), n);
                   Constant ((5, Effect ([ ], .)), Int(1))
                 ]),
             Apply
               ((7, Effect ([ ], .)),
-                Variable ((7, Effect ([ ], .)), Z.sub),
+                Variable ((7, Effect ([ ], . -> . -> .)), Z.sub),
                 [
                   Variable ((7, Effect ([ ], .)), n);
                   Constant ((7, Effect ([ ], .)), Int(1))

--- a/tests/ex15.effects
+++ b/tests/ex15.effects
@@ -14,9 +14,10 @@ Value
   (rec, @.,
     [
       ((member_rec, [ ],
-        [ (counter, Type (nat)); (x, Type (Z)); (s, Type (set)) ], Type (bool)),
+        [ (counter, Type (nat)); (x, Type (Z)); (s, Type (set)) ],
+        Monad ([ Type (NonTermination) ], Type (bool))),
         Match
-          ((?, Effect ([ NonTermination ], .)),
+          ((?, Effect ([ Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), counter),
             [
               (Constructor (O),
@@ -24,7 +25,8 @@ Value
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -34,7 +36,8 @@ Value
                           ],
                             .
                               -[
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         not_terminated),
@@ -51,7 +54,8 @@ Value
                   ((10,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -80,7 +84,8 @@ Value
                           ((13,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Apply
@@ -94,7 +99,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     OCaml.Pervasives.lt),
                                 [
                                   Variable
@@ -116,7 +125,8 @@ Value
                               ((14,
                                 Effect
                                   ([
-                                    NonTermination
+                                    Type
+                                      (NonTermination)
                                   ],
                                     .)),
                                 Apply
@@ -128,7 +138,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              NonTermination
+                                              Type
+                                                (NonTermination)
                                             ]->
                                             .)),
                                     Variable
@@ -142,7 +153,8 @@ Value
                                                 ->
                                                 .
                                                   -[
-                                                    NonTermination
+                                                    Type
+                                                      (NonTermination)
                                                   ]->
                                                   .)),
                                         member_rec),
@@ -175,7 +187,8 @@ Value
                               ((15,
                                 Effect
                                   ([
-                                    NonTermination
+                                    Type
+                                      (NonTermination)
                                   ],
                                     .)),
                                 Apply
@@ -189,7 +202,11 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         OCaml.Pervasives.lt),
                                     [
                                       Variable
@@ -211,7 +228,8 @@ Value
                                   ((16,
                                     Effect
                                       ([
-                                        NonTermination
+                                        Type
+                                          (NonTermination)
                                       ],
                                         .)),
                                     Apply
@@ -223,7 +241,8 @@ Value
                                               ->
                                               .
                                                 -[
-                                                  NonTermination
+                                                  Type
+                                                    (NonTermination)
                                                 ]->
                                                 .)),
                                         Variable
@@ -237,7 +256,8 @@ Value
                                                     ->
                                                     .
                                                       -[
-                                                        NonTermination
+                                                        Type
+                                                          (NonTermination)
                                                       ]->
                                                       .)),
                                             member_rec),
@@ -281,15 +301,18 @@ Value
 Value
   (non_rec, @.,
     [
-      ((member, [ ], [ (x, Type (Z)); (s, Type (set)) ], Type (bool)),
+      ((member, [ ], [ (x, Type (Z)); (s, Type (set)) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (bool))),
         Apply
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable
-              ((?, Effect ([ ], . -> . -> . -[ NonTermination ]-> .)),
+              ((?,
+                Effect
+                  ([ ], . -> . -> . -[ Type (NonTermination) ]-> .)),
                 member_rec),
             [
               Apply
-                ((?, Effect ([ Counter ], .)),
+                ((?, Effect ([ Type (Counter) ], .)),
                   Variable
                     ((?,
                       Effect
@@ -297,7 +320,8 @@ Value
                         ],
                           .
                             -[
-                              Counter
+                              Type
+                                (Counter)
                             ]->
                             .)),
                       read_counter),
@@ -319,9 +343,10 @@ Value
   (rec, @.,
     [
       ((insert_rec, [ ],
-        [ (counter, Type (nat)); (x, Type (Z)); (s, Type (set)) ], Type (set)),
+        [ (counter, Type (nat)); (x, Type (Z)); (s, Type (set)) ],
+        Monad ([ Type (NonTermination) ], Type (set))),
         Match
-          ((?, Effect ([ NonTermination ], .)),
+          ((?, Effect ([ Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), counter),
             [
               (Constructor (O),
@@ -329,7 +354,8 @@ Value
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -339,7 +365,8 @@ Value
                           ],
                             .
                               -[
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         not_terminated),
@@ -356,7 +383,8 @@ Value
                   ((21,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -406,7 +434,8 @@ Value
                           ((24,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Apply
@@ -420,7 +449,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     OCaml.Pervasives.lt),
                                 [
                                   Variable
@@ -442,7 +475,8 @@ Value
                               ((25,
                                 Effect
                                   ([
-                                    NonTermination
+                                    Type
+                                      (NonTermination)
                                   ],
                                     .)),
                                 Node,
@@ -450,7 +484,8 @@ Value
                                   ((25,
                                     Effect
                                       ([
-                                        NonTermination
+                                        Type
+                                          (NonTermination)
                                       ],
                                         .)),
                                     Apply
@@ -462,7 +497,8 @@ Value
                                               ->
                                               .
                                                 -[
-                                                  NonTermination
+                                                  Type
+                                                    (NonTermination)
                                                 ]->
                                                 .)),
                                         Variable
@@ -476,7 +512,8 @@ Value
                                                     ->
                                                     .
                                                       -[
-                                                        NonTermination
+                                                        Type
+                                                          (NonTermination)
                                                       ]->
                                                       .)),
                                             insert_rec),
@@ -523,7 +560,8 @@ Value
                               ((26,
                                 Effect
                                   ([
-                                    NonTermination
+                                    Type
+                                      (NonTermination)
                                   ],
                                     .)),
                                 Apply
@@ -537,7 +575,11 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         OCaml.Pervasives.lt),
                                     [
                                       Variable
@@ -559,7 +601,8 @@ Value
                                   ((27,
                                     Effect
                                       ([
-                                        NonTermination
+                                        Type
+                                          (NonTermination)
                                       ],
                                         .)),
                                     Node,
@@ -581,7 +624,8 @@ Value
                                       ((27,
                                         Effect
                                           ([
-                                            NonTermination
+                                            Type
+                                              (NonTermination)
                                           ],
                                             .)),
                                         Apply
@@ -593,7 +637,8 @@ Value
                                                   ->
                                                   .
                                                     -[
-                                                      NonTermination
+                                                      Type
+                                                        (NonTermination)
                                                     ]->
                                                     .)),
                                             Variable
@@ -607,7 +652,8 @@ Value
                                                         ->
                                                         .
                                                           -[
-                                                            NonTermination
+                                                            Type
+                                                              (NonTermination)
                                                           ]->
                                                           .)),
                                                 insert_rec),
@@ -651,15 +697,18 @@ Value
 Value
   (non_rec, @.,
     [
-      ((insert, [ ], [ (x, Type (Z)); (s, Type (set)) ], Type (set)),
+      ((insert, [ ], [ (x, Type (Z)); (s, Type (set)) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (set))),
         Apply
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable
-              ((?, Effect ([ ], . -> . -> . -[ NonTermination ]-> .)),
+              ((?,
+                Effect
+                  ([ ], . -> . -> . -[ Type (NonTermination) ]-> .)),
                 insert_rec),
             [
               Apply
-                ((?, Effect ([ Counter ], .)),
+                ((?, Effect ([ Type (Counter) ], .)),
                   Variable
                     ((?,
                       Effect
@@ -667,7 +716,8 @@ Value
                         ],
                           .
                             -[
-                              Counter
+                              Type
+                                (Counter)
                             ]->
                             .)),
                       read_counter),

--- a/tests/ex15.monadise
+++ b/tests/ex15.monadise
@@ -11,7 +11,7 @@ Value
     [
       ((member_rec, [ ],
         [ (counter, Type (nat)); (x, Type (Z)); (s, Type (set)) ],
-        Monad ([ NonTermination ], Type (bool))),
+        Monad ([ Type (NonTermination) ], Type (bool))),
         Match
           (?, Variable (?, counter),
             [
@@ -125,15 +125,17 @@ Value
   (non_rec, @.,
     [
       ((member, [ ], [ (x, Type (Z)); (s, Type (set)) ],
-        Monad ([ Counter; NonTermination ], Type (bool))),
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (bool))),
         Bind
           (?,
             Lift
-              (?, [ Counter ], [ Counter; NonTermination ],
+              (?, [ Type (Counter) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply (?, Variable (?, read_counter), [ Tuple (?) ])),
             Some x_1,
             Lift
-              (?, [ NonTermination ], [ Counter; NonTermination ],
+              (?, [ Type (NonTermination) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply
                   (?, Variable (?, member_rec),
                     [
@@ -149,7 +151,7 @@ Value
     [
       ((insert_rec, [ ],
         [ (counter, Type (nat)); (x, Type (Z)); (s, Type (set)) ],
-        Monad ([ NonTermination ], Type (set))),
+        Monad ([ Type (NonTermination) ], Type (set))),
         Match
           (?, Variable (?, counter),
             [
@@ -308,15 +310,17 @@ Value
   (non_rec, @.,
     [
       ((insert, [ ], [ (x, Type (Z)); (s, Type (set)) ],
-        Monad ([ Counter; NonTermination ], Type (set))),
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (set))),
         Bind
           (?,
             Lift
-              (?, [ Counter ], [ Counter; NonTermination ],
+              (?, [ Type (Counter) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply (?, Variable (?, read_counter), [ Tuple (?) ])),
             Some x_1,
             Lift
-              (?, [ NonTermination ], [ Counter; NonTermination ],
+              (?, [ Type (NonTermination) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply
                   (?, Variable (?, insert_rec),
                     [

--- a/tests/ex17.effects
+++ b/tests/ex17.effects
@@ -4,12 +4,12 @@
 Value
   (non_rec, @.,
     [
-      ((f, [ A; B ], [ (x, A) ], B),
+      ((f, [ A; B ], [ (x, A) ], Monad ([ Type (Outside) ], B)),
         Apply
-          ((5, Effect ([ Outside ], .)),
+          ((5, Effect ([ Type (Outside) ], .)),
             Variable
-              ((5, Effect ([ ], . -[ Outside ]-> .)), raise_Outside),
-            [ Tuple ((?, Effect ([ ], .))) ]))
+              ((5, Effect ([ ], . -[ Type (Outside) ]-> .)),
+                raise_Outside), [ Tuple ((?, Effect ([ ], .))) ]))
     ])
 
 7 Module G:
@@ -19,18 +19,22 @@ Value
   Value
     (non_rec, @.,
       [
-        ((g, [ A ], [ (b, Type (bool)) ], A),
+        ((g, [ A ], [ (b, Type (bool)) ],
+          Monad ([ Type (Outside); Type (G/Inside) ], A)),
           IfThenElse
-            ((11, Effect ([ Outside; G/Inside ], .)),
+            ((11, Effect ([ Type (Outside); Type (G/Inside) ], .)),
               Variable ((11, Effect ([ ], .)), G/b),
               Apply
-                ((12, Effect ([ G/Inside ], .)),
+                ((12, Effect ([ Type (G/Inside) ], .)),
                   Variable
                     ((12,
                       Effect
                         ([ ],
-                          . -[ G/Inside ]->
-                            .)),
+                          .
+                            -[
+                              Type
+                                (G/Inside)
+                            ]-> .)),
                       G/raise_Inside),
                   [
                     Tuple
@@ -55,11 +59,16 @@ Value
                             String("no")))
                   ]),
               Apply
-                ((14, Effect ([ Outside ], .)),
+                ((14, Effect ([ Type (Outside) ], .)),
                   Variable
                     ((14,
                       Effect
-                        ([ ], . -[ Outside ]-> .)),
+                        ([ ],
+                          .
+                            -[
+                              Type
+                                (Outside)
+                            ]-> .)),
                       raise_Outside),
                   [ Tuple ((?, Effect ([ ], .))) ])))
       ])
@@ -68,17 +77,31 @@ Value
 Value
   (rec, @.,
     [
-      ((h_rec, [ A; B ], [ (counter, Type (nat)); (l, Type (list, A)) ], B),
+      ((h_rec, [ A; B ], [ (counter, Type (nat)); (l, Type (list, A)) ],
+        Monad
+          ([
+            Type (IO);
+            Type (NonTermination);
+            Type (Outside);
+            Type (G.Inside)
+          ], B)),
         Match
-          ((?, Effect ([ IO; NonTermination; Outside; G.Inside ], .)),
-            Variable ((?, Effect ([ ], .)), counter),
+          ((?,
+            Effect
+              ([
+                Type (IO);
+                Type (NonTermination);
+                Type (Outside);
+                Type (G.Inside)
+              ], .)), Variable ((?, Effect ([ ], .)), counter),
             [
               (Constructor (O),
                 Apply
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -88,7 +111,8 @@ Value
                           ],
                             .
                               -[
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         not_terminated),
@@ -105,10 +129,14 @@ Value
                   ((18,
                     Effect
                       ([
-                        IO;
-                        NonTermination;
-                        Outside;
-                        G.Inside
+                        Type
+                          (IO);
+                        Type
+                          (NonTermination);
+                        Type
+                          (Outside);
+                        Type
+                          (G.Inside)
                       ],
                         .)),
                     Variable
@@ -125,16 +153,20 @@ Value
                           ((19,
                             Effect
                               ([
-                                IO;
-                                Outside;
-                                G.Inside
+                                Type
+                                  (IO);
+                                Type
+                                  (Outside);
+                                Type
+                                  (G.Inside)
                               ],
                                 .)),
                             Apply
                               ((19,
                                 Effect
                                   ([
-                                    IO
+                                    Type
+                                      (IO)
                                   ],
                                     .)),
                                 Variable
@@ -144,7 +176,8 @@ Value
                                       ],
                                         .
                                           -[
-                                            IO
+                                            Type
+                                              (IO)
                                           ]->
                                           .)),
                                     OCaml.Pervasives.print_string),
@@ -161,8 +194,10 @@ Value
                               ((19,
                                 Effect
                                   ([
-                                    Outside;
-                                    G.Inside
+                                    Type
+                                      (Outside);
+                                    Type
+                                      (G.Inside)
                                   ],
                                     .)),
                                 Variable
@@ -172,8 +207,10 @@ Value
                                       ],
                                         .
                                           -[
-                                            Outside;
-                                            G.Inside
+                                            Type
+                                              (Outside);
+                                            Type
+                                              (G.Inside)
                                           ]->
                                           .)),
                                     G.g),
@@ -195,7 +232,8 @@ Value
                           ((20,
                             Effect
                               ([
-                                G.Inside
+                                Type
+                                  (G.Inside)
                               ],
                                 .)),
                             Variable
@@ -205,7 +243,8 @@ Value
                                   ],
                                     .
                                       -[
-                                        G.Inside
+                                        Type
+                                          (G.Inside)
                                       ]->
                                       .)),
                                 G.raise_Inside),
@@ -239,10 +278,14 @@ Value
                           ((21,
                             Effect
                               ([
-                                IO;
-                                NonTermination;
-                                Outside;
-                                G.Inside
+                                Type
+                                  (IO);
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (Outside);
+                                Type
+                                  (G.Inside)
                               ],
                                 .)),
                             Apply
@@ -252,10 +295,14 @@ Value
                                   ],
                                     .
                                       -[
-                                        IO;
-                                        NonTermination;
-                                        Outside;
-                                        G.Inside
+                                        Type
+                                          (IO);
+                                        Type
+                                          (NonTermination);
+                                        Type
+                                          (Outside);
+                                        Type
+                                          (G.Inside)
                                       ]->
                                       .)),
                                 Variable
@@ -267,10 +314,14 @@ Value
                                           ->
                                           .
                                             -[
-                                              IO;
-                                              NonTermination;
-                                              Outside;
-                                              G.Inside
+                                              Type
+                                                (IO);
+                                              Type
+                                                (NonTermination);
+                                              Type
+                                                (Outside);
+                                              Type
+                                                (G.Inside)
                                             ]->
                                             .)),
                                     h_rec),
@@ -300,10 +351,25 @@ Value
 Value
   (non_rec, @.,
     [
-      ((h, [ A; B ], [ (l, Type (list, A)) ], B),
+      ((h, [ A; B ], [ (l, Type (list, A)) ],
+        Monad
+          ([
+            Type (Counter);
+            Type (IO);
+            Type (NonTermination);
+            Type (Outside);
+            Type (G.Inside)
+          ], B)),
         Apply
           ((?,
-            Effect ([ Counter; IO; NonTermination; Outside; G.Inside ], .)),
+            Effect
+              ([
+                Type (Counter);
+                Type (IO);
+                Type (NonTermination);
+                Type (Outside);
+                Type (G.Inside)
+              ], .)),
             Variable
               ((?,
                 Effect
@@ -311,14 +377,14 @@ Value
                     . ->
                       .
                         -[
-                          IO;
-                          NonTermination;
-                          Outside;
-                          G.Inside
+                          Type (IO);
+                          Type (NonTermination);
+                          Type (Outside);
+                          Type (G.Inside)
                         ]-> .)), h_rec),
             [
               Apply
-                ((?, Effect ([ Counter ], .)),
+                ((?, Effect ([ Type (Counter) ], .)),
                   Variable
                     ((?,
                       Effect
@@ -326,7 +392,8 @@ Value
                         ],
                           .
                             -[
-                              Counter
+                              Type
+                                (Counter)
                             ]->
                             .)),
                       read_counter),

--- a/tests/ex17.monadise
+++ b/tests/ex17.monadise
@@ -4,7 +4,7 @@
 Value
   (non_rec, @.,
     [
-      ((f, [ A; B ], [ (x, A) ], Monad ([ Outside ], B)),
+      ((f, [ A; B ], [ (x, A) ], Monad ([ Type (Outside) ], B)),
         Apply (5, Variable (5, raise_Outside), [ Tuple (?) ]))
     ])
 
@@ -15,11 +15,13 @@ Value
   Value
     (non_rec, @.,
       [
-        ((g, [ A ], [ (b, Type (bool)) ], Monad ([ Outside; G/Inside ], A)),
+        ((g, [ A ], [ (b, Type (bool)) ],
+          Monad ([ Type (Outside); Type (G/Inside) ], A)),
           IfThenElse
             (11, Variable (11, G/b),
               Lift
-                (?, [ G/Inside ], [ Outside; G/Inside ],
+                (?, [ Type (G/Inside) ],
+                  [ Type (Outside); Type (G/Inside) ],
                   Apply
                     (12, Variable (12, G/raise_Inside),
                       [
@@ -33,7 +35,8 @@ Value
                                 String("no")))
                       ])),
               Lift
-                (?, [ Outside ], [ Outside; G/Inside ],
+                (?, [ Type (Outside) ],
+                  [ Type (Outside); Type (G/Inside) ],
                   Apply
                     (14, Variable (14, raise_Outside),
                       [ Tuple (?) ]))))
@@ -44,7 +47,13 @@ Value
   (rec, @.,
     [
       ((h_rec, [ A; B ], [ (counter, Type (nat)); (l, Type (list, A)) ],
-        Monad ([ IO; NonTermination; Outside; G.Inside ], B)),
+        Monad
+          ([
+            Type (IO);
+            Type (NonTermination);
+            Type (Outside);
+            Type (G.Inside)
+          ], B)),
         Match
           (?, Variable (?, counter),
             [
@@ -52,13 +61,18 @@ Value
                 Lift
                   (?,
                     [
-                      NonTermination
+                      Type
+                        (NonTermination)
                     ],
                     [
-                      IO;
-                      NonTermination;
-                      Outside;
-                      G.Inside
+                      Type
+                        (IO);
+                      Type
+                        (NonTermination);
+                      Type
+                        (Outside);
+                      Type
+                        (G.Inside)
                     ],
                     Apply
                       (?,
@@ -78,27 +92,38 @@ Value
                         Lift
                           (?,
                             [
-                              IO;
-                              Outside;
-                              G.Inside
+                              Type
+                                (IO);
+                              Type
+                                (Outside);
+                              Type
+                                (G.Inside)
                             ],
                             [
-                              IO;
-                              NonTermination;
-                              Outside;
-                              G.Inside
+                              Type
+                                (IO);
+                              Type
+                                (NonTermination);
+                              Type
+                                (Outside);
+                              Type
+                                (G.Inside)
                             ],
                             Bind
                               (?,
                                 Lift
                                   (?,
                                     [
-                                      IO
+                                      Type
+                                        (IO)
                                     ],
                                     [
-                                      IO;
-                                      Outside;
-                                      G.Inside
+                                      Type
+                                        (IO);
+                                      Type
+                                        (Outside);
+                                      Type
+                                        (G.Inside)
                                     ],
                                     Apply
                                       (19,
@@ -114,13 +139,18 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      Outside;
-                                      G.Inside
+                                      Type
+                                        (Outside);
+                                      Type
+                                        (G.Inside)
                                     ],
                                     [
-                                      IO;
-                                      Outside;
-                                      G.Inside
+                                      Type
+                                        (IO);
+                                      Type
+                                        (Outside);
+                                      Type
+                                        (G.Inside)
                                     ],
                                     Apply
                                       (19,
@@ -140,13 +170,18 @@ Value
                         Lift
                           (?,
                             [
-                              G.Inside
+                              Type
+                                (G.Inside)
                             ],
                             [
-                              IO;
-                              NonTermination;
-                              Outside;
-                              G.Inside
+                              Type
+                                (IO);
+                              Type
+                                (NonTermination);
+                              Type
+                                (Outside);
+                              Type
+                                (G.Inside)
                             ],
                             Apply
                               (20,
@@ -193,17 +228,42 @@ Value
   (non_rec, @.,
     [
       ((h, [ A; B ], [ (l, Type (list, A)) ],
-        Monad ([ Counter; IO; NonTermination; Outside; G.Inside ], B)),
+        Monad
+          ([
+            Type (Counter);
+            Type (IO);
+            Type (NonTermination);
+            Type (Outside);
+            Type (G.Inside)
+          ], B)),
         Bind
           (?,
             Lift
-              (?, [ Counter ],
-                [ Counter; IO; NonTermination; Outside; G.Inside ],
+              (?, [ Type (Counter) ],
+                [
+                  Type (Counter);
+                  Type (IO);
+                  Type (NonTermination);
+                  Type (Outside);
+                  Type (G.Inside)
+                ],
                 Apply (?, Variable (?, read_counter), [ Tuple (?) ])),
             Some x,
             Lift
-              (?, [ IO; NonTermination; Outside; G.Inside ],
-                [ Counter; IO; NonTermination; Outside; G.Inside ],
+              (?,
+                [
+                  Type (IO);
+                  Type (NonTermination);
+                  Type (Outside);
+                  Type (G.Inside)
+                ],
+                [
+                  Type (Counter);
+                  Type (IO);
+                  Type (NonTermination);
+                  Type (Outside);
+                  Type (G.Inside)
+                ],
                 Apply
                   (?, Variable (?, h_rec),
                     [ Variable (?, x); Variable (?, l) ]))))

--- a/tests/ex18.effects
+++ b/tests/ex18.effects
@@ -4,12 +4,17 @@
 Value
   (non_rec, @.,
     [
-      ((plus_one, [ A ], [ (x, A) ], Type (Z)),
+      ((plus_one, [ A ], [ (x, A) ],
+        Monad
+          ([ Type (OCaml.Effect.State.state, Type (Z)); Type (r_state) ],
+            Type (Z))),
         Match
           ((?,
             Effect
-              ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], .)),
-            Variable ((?, Effect ([ ], .)), x),
+              ([
+                Type (OCaml.Effect.State.state, Type (Z));
+                Type (r_state)
+              ], .)), Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
                 Apply
@@ -20,7 +25,8 @@ Value
                           (OCaml.Effect.State.state,
                             Type
                               (Z));
-                        r_state
+                        Type
+                          (r_state)
                       ],
                         .)),
                     Variable
@@ -28,7 +34,11 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .
+                                ->
+                                .)),
                         Z.add),
                     [
                       Apply
@@ -39,7 +49,8 @@ Value
                                 (OCaml.Effect.State.state,
                                   Type
                                     (Z));
-                              r_state
+                              Type
+                                (r_state)
                             ],
                               .)),
                           Variable
@@ -65,7 +76,8 @@ Value
                                       (OCaml.Effect.State.state,
                                         Type
                                           (Z));
-                                    r_state
+                                    Type
+                                      (r_state)
                                   ],
                                     .)),
                                 r)
@@ -89,14 +101,20 @@ Reference
 Value
   (non_rec, @.,
     [
-      ((fail, [ A; B ], [ (x, A) ], B),
+      ((fail, [ A; B ], [ (x, A) ],
+        Monad
+          ([
+            Type (OCaml.Effect.State.state, Type (string));
+            Type (s_state);
+            Type (OCaml.Failure)
+          ], B)),
         Match
           ((?,
             Effect
               ([
                 Type (OCaml.Effect.State.state, Type (string));
-                s_state;
-                OCaml.Failure
+                Type (s_state);
+                Type (OCaml.Failure)
               ], .)), Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -108,8 +126,10 @@ Value
                           (OCaml.Effect.State.state,
                             Type
                               (string));
-                        s_state;
-                        OCaml.Failure
+                        Type
+                          (s_state);
+                        Type
+                          (OCaml.Failure)
                       ],
                         .)),
                     Variable
@@ -119,7 +139,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Failure
+                                Type
+                                  (OCaml.Failure)
                               ]->
                               .)),
                         OCaml.Pervasives.failwith),
@@ -132,7 +153,8 @@ Value
                                 (OCaml.Effect.State.state,
                                   Type
                                     (string));
-                              s_state
+                              Type
+                                (s_state)
                             ],
                               .)),
                           Variable
@@ -158,7 +180,8 @@ Value
                                       (OCaml.Effect.State.state,
                                         Type
                                           (string));
-                                    s_state
+                                    Type
+                                      (s_state)
                                   ],
                                     .)),
                                 s)
@@ -171,12 +194,17 @@ Value
 Value
   (non_rec, @.,
     [
-      ((reset, [ A ], [ (x, A) ], Type (unit)),
+      ((reset, [ A ], [ (x, A) ],
+        Monad
+          ([ Type (OCaml.Effect.State.state, Type (Z)); Type (r_state) ],
+            Type (unit))),
         Match
           ((?,
             Effect
-              ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], .)),
-            Variable ((?, Effect ([ ], .)), x),
+              ([
+                Type (OCaml.Effect.State.state, Type (Z));
+                Type (r_state)
+              ], .)), Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
                 Apply
@@ -187,7 +215,8 @@ Value
                           (OCaml.Effect.State.state,
                             Type
                               (Z));
-                        r_state
+                        Type
+                          (r_state)
                       ],
                         .)),
                     Variable
@@ -215,7 +244,8 @@ Value
                                 (OCaml.Effect.State.state,
                                   Type
                                     (Z));
-                              r_state
+                              Type
+                                (r_state)
                             ],
                               .)),
                           r);
@@ -234,12 +264,17 @@ Value
 Value
   (non_rec, @.,
     [
-      ((incr, [ A ], [ (x, A) ], Type (unit)),
+      ((incr, [ A ], [ (x, A) ],
+        Monad
+          ([ Type (OCaml.Effect.State.state, Type (Z)); Type (r_state) ],
+            Type (unit))),
         Match
           ((?,
             Effect
-              ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], .)),
-            Variable ((?, Effect ([ ], .)), x),
+              ([
+                Type (OCaml.Effect.State.state, Type (Z));
+                Type (r_state)
+              ], .)), Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
                 Apply
@@ -250,7 +285,8 @@ Value
                           (OCaml.Effect.State.state,
                             Type
                               (Z));
-                        r_state
+                        Type
+                          (r_state)
                       ],
                         .)),
                     Variable
@@ -278,7 +314,8 @@ Value
                                 (OCaml.Effect.State.state,
                                   Type
                                     (Z));
-                              r_state
+                              Type
+                                (r_state)
                             ],
                               .)),
                           r);
@@ -290,7 +327,8 @@ Value
                                 (OCaml.Effect.State.state,
                                   Type
                                     (Z));
-                              r_state
+                              Type
+                                (r_state)
                             ],
                               .)),
                           Variable
@@ -298,7 +336,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               Z.add),
                           [
                             Apply
@@ -309,7 +351,8 @@ Value
                                       (OCaml.Effect.State.state,
                                         Type
                                           (Z));
-                                    r_state
+                                    Type
+                                      (r_state)
                                   ],
                                     .)),
                                 Variable
@@ -335,7 +378,8 @@ Value
                                             (OCaml.Effect.State.state,
                                               Type
                                                 (Z));
-                                          r_state
+                                          Type
+                                            (r_state)
                                         ],
                                           .)),
                                       r)

--- a/tests/ex18.monadise
+++ b/tests/ex18.monadise
@@ -6,7 +6,8 @@ Value
     [
       ((plus_one, [ A ], [ (x, A) ],
         Monad
-          ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], Type (Z))),
+          ([ Type (OCaml.Effect.State.state, Type (Z)); Type (r_state) ],
+            Type (Z))),
         Match
           (?, Variable (?, x),
             [
@@ -33,7 +34,8 @@ Value
                                 (OCaml.Effect.State.state,
                                   Type
                                     (Z));
-                              r_state
+                              Type
+                                (r_state)
                             ],
                             Apply
                               (4,
@@ -75,8 +77,8 @@ Value
         Monad
           ([
             Type (OCaml.Effect.State.state, Type (string));
-            s_state;
-            OCaml.Failure
+            Type (s_state);
+            Type (OCaml.Failure)
           ], B)),
         Match
           (?, Variable (?, x),
@@ -91,15 +93,18 @@ Value
                             (OCaml.Effect.State.state,
                               Type
                                 (string));
-                          s_state
+                          Type
+                            (s_state)
                         ],
                         [
                           Type
                             (OCaml.Effect.State.state,
                               Type
                                 (string));
-                          s_state;
-                          OCaml.Failure
+                          Type
+                            (s_state);
+                          Type
+                            (OCaml.Failure)
                         ],
                         Bind
                           (?,
@@ -121,7 +126,8 @@ Value
                                     (OCaml.Effect.State.state,
                                       Type
                                         (string));
-                                  s_state
+                                  Type
+                                    (s_state)
                                 ],
                                 Apply
                                   (8,
@@ -138,15 +144,18 @@ Value
                     Lift
                       (?,
                         [
-                          OCaml.Failure
+                          Type
+                            (OCaml.Failure)
                         ],
                         [
                           Type
                             (OCaml.Effect.State.state,
                               Type
                                 (string));
-                          s_state;
-                          OCaml.Failure
+                          Type
+                            (s_state);
+                          Type
+                            (OCaml.Failure)
                         ],
                         Apply
                           (8,
@@ -167,7 +176,7 @@ Value
     [
       ((reset, [ A ], [ (x, A) ],
         Monad
-          ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ],
+          ([ Type (OCaml.Effect.State.state, Type (Z)); Type (r_state) ],
             Type (unit))),
         Match
           (?, Variable (?, x),
@@ -190,7 +199,8 @@ Value
                             (OCaml.Effect.State.state,
                               Type
                                 (Z));
-                          r_state
+                          Type
+                            (r_state)
                         ],
                         Apply
                           (11,
@@ -214,7 +224,7 @@ Value
     [
       ((incr, [ A ], [ (x, A) ],
         Monad
-          ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ],
+          ([ Type (OCaml.Effect.State.state, Type (Z)); Type (r_state) ],
             Type (unit))),
         Match
           (?, Variable (?, x),
@@ -248,7 +258,8 @@ Value
                                         (OCaml.Effect.State.state,
                                           Type
                                             (Z));
-                                      r_state
+                                      Type
+                                        (r_state)
                                     ],
                                     Apply
                                       (14,
@@ -292,7 +303,8 @@ Value
                                 (OCaml.Effect.State.state,
                                   Type
                                     (Z));
-                              r_state
+                              Type
+                                (r_state)
                             ],
                             Apply
                               (14,

--- a/tests/ex19.effects
+++ b/tests/ex19.effects
@@ -10,9 +10,9 @@ Value
             Run
               ((?, Effect ([ ], .)), Error, [ ],
                 Apply
-                  ((6, Effect ([ Error ], .)),
+                  ((6, Effect ([ Type (Error) ], .)),
                     Variable
-                      ((6, Effect ([ ], . -[ Error ]-> .)),
+                      ((6, Effect ([ ], . -[ Type (Error) ]-> .)),
                         raise_Error),
                     [ Tuple ((?, Effect ([ ], .))) ])),
             [
@@ -26,9 +26,9 @@ Value
 Value
   (non_rec, @.,
     [
-      ((x2, [ A; B ], [ (x, A) ], B),
+      ((x2, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Failure) ], B)),
         Match
-          ((?, Effect ([ OCaml.Failure ], .)),
+          ((?, Effect ([ Type (OCaml.Failure) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -36,7 +36,8 @@ Value
                   ((10,
                     Effect
                       ([
-                        OCaml.Failure
+                        Type
+                          (OCaml.Failure)
                       ],
                         .)),
                     Run
@@ -52,7 +53,8 @@ Value
                           ((10,
                             Effect
                               ([
-                                Error
+                                Type
+                                  (Error)
                               ],
                                 .)),
                             Variable
@@ -62,7 +64,8 @@ Value
                                   ],
                                     .
                                       -[
-                                        Error
+                                        Type
+                                          (Error)
                                       ]->
                                       .)),
                                 raise_Error),
@@ -93,7 +96,8 @@ Value
                           ((11,
                             Effect
                               ([
-                                OCaml.Failure
+                                Type
+                                  (OCaml.Failure)
                               ],
                                 .)),
                             Variable
@@ -103,7 +107,8 @@ Value
                                   ],
                                     .
                                       -[
-                                        OCaml.Failure
+                                        Type
+                                          (OCaml.Failure)
                                       ]->
                                       .)),
                                 OCaml.Pervasives.failwith),
@@ -124,22 +129,28 @@ Value
 Value
   (non_rec, @.,
     [
-      ((x3, [ ], [ (b, Type (bool)) ], Type (Z)),
+      ((x3, [ ], [ (b, Type (bool)) ],
+        Monad ([ Type (OCaml.Failure) ], Type (Z))),
         Match
-          ((14, Effect ([ OCaml.Failure ], .)),
+          ((14, Effect ([ Type (OCaml.Failure) ], .)),
             Run
-              ((?, Effect ([ OCaml.Failure ], .)), Error, [ ],
+              ((?, Effect ([ Type (OCaml.Failure) ], .)), Error, [ ],
                 IfThenElse
-                  ((14, Effect ([ Error; OCaml.Failure ], .)),
+                  ((14,
+                    Effect
+                      ([ Type (Error); Type (OCaml.Failure) ], .)),
                     Variable ((14, Effect ([ ], .)), b),
                     Apply
-                      ((14, Effect ([ OCaml.Failure ], .)),
+                      ((14, Effect ([ Type (OCaml.Failure) ], .)),
                         Variable
                           ((14,
                             Effect
                               ([ ],
-                                . -[ OCaml.Failure ]->
-                                  .)),
+                                .
+                                  -[
+                                    Type
+                                      (OCaml.Failure)
+                                  ]-> .)),
                             OCaml.Pervasives.failwith),
                         [
                           Constant
@@ -151,11 +162,13 @@ Value
                               String("arg"))
                         ]),
                     Apply
-                      ((14, Effect ([ Error ], .)),
+                      ((14, Effect ([ Type (Error) ], .)),
                         Variable
                           ((14,
-                            Effect ([ ], . -[ Error ]-> .)),
-                            raise_Error),
+                            Effect
+                              ([ ],
+                                . -[ Type (Error) ]->
+                                  .)), raise_Error),
                         [ Tuple ((?, Effect ([ ], .))) ]))),
             [
               (Constructor (inl, x), Variable ((?, Effect ([ ], .)), x));

--- a/tests/ex19.monadise
+++ b/tests/ex19.monadise
@@ -20,7 +20,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((x2, [ A; B ], [ (x, A) ], Monad ([ OCaml.Failure ], B)),
+      ((x2, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Failure) ], B)),
         Match
           (?, Variable (?, x),
             [
@@ -72,16 +72,17 @@ Value
 Value
   (non_rec, @.,
     [
-      ((x3, [ ], [ (b, Type (bool)) ], Monad ([ OCaml.Failure ], Type (Z))),
+      ((x3, [ ], [ (b, Type (bool)) ],
+        Monad ([ Type (OCaml.Failure) ], Type (Z))),
         Bind
           (?,
             Run
-              (?, Error, [ Error; OCaml.Failure ],
+              (?, Error, [ Type (Error); Type (OCaml.Failure) ],
                 IfThenElse
                   (14, Variable (14, b),
                     Lift
-                      (?, [ OCaml.Failure ],
-                        [ Error; OCaml.Failure ],
+                      (?, [ Type (OCaml.Failure) ],
+                        [ Type (Error); Type (OCaml.Failure) ],
                         Apply
                           (14,
                             Variable
@@ -93,7 +94,8 @@ Value
                                   String("arg"))
                             ])),
                     Lift
-                      (?, [ Error ], [ Error; OCaml.Failure ],
+                      (?, [ Type (Error) ],
+                        [ Type (Error); Type (OCaml.Failure) ],
                         Apply
                           (14, Variable (14, raise_Error),
                             [ Tuple (?) ])))), Some x,

--- a/tests/ex20.effects
+++ b/tests/ex20.effects
@@ -4,9 +4,10 @@ Value
     [
       ((sums_rec, [ ],
         [ (counter, Type (nat)); (ls, Type (list, Type (list, Type (Z)))) ],
-        Type (list, Type (Z))),
+        Monad
+          ([ Type (Counter); Type (NonTermination) ], Type (list, Type (Z)))),
         Match
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), counter),
             [
               (Constructor (O),
@@ -14,7 +15,8 @@ Value
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -24,7 +26,8 @@ Value
                           ],
                             .
                               -[
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         not_terminated),
@@ -41,8 +44,10 @@ Value
                   (4,
                     Effect
                       ([
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .))
                   (rec, @.,
@@ -60,14 +65,23 @@ Value
                                 Type
                                   (Z)))
                         ],
-                        Type
-                          (Z)),
+                        Monad
+                          ([
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination)
+                          ],
+                            Type
+                              (Z))),
                         Match
                           ((?,
                             Effect
                               ([
-                                Counter;
-                                NonTermination
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Variable
@@ -84,7 +98,8 @@ Value
                                   ((?,
                                     Effect
                                       ([
-                                        NonTermination
+                                        Type
+                                          (NonTermination)
                                       ],
                                         .)),
                                     Variable
@@ -94,7 +109,8 @@ Value
                                           ],
                                             .
                                               -[
-                                                NonTermination
+                                                Type
+                                                  (NonTermination)
                                               ]->
                                               .)),
                                         not_terminated),
@@ -113,8 +129,10 @@ Value
                                   ((5,
                                     Effect
                                       ([
-                                        Counter;
-                                        NonTermination
+                                        Type
+                                          (Counter);
+                                        Type
+                                          (NonTermination)
                                       ],
                                         .)),
                                     Variable
@@ -142,8 +160,10 @@ Value
                                           ((8,
                                             Effect
                                               ([
-                                                Counter;
-                                                NonTermination
+                                                Type
+                                                  (Counter);
+                                                Type
+                                                  (NonTermination)
                                               ],
                                                 .)),
                                             Apply
@@ -157,7 +177,11 @@ Value
                                                     Effect
                                                       ([
                                                       ],
-                                                        .)),
+                                                        .
+                                                          ->
+                                                          .
+                                                            ->
+                                                            .)),
                                                     equiv_decb),
                                                 [
                                                   Variable
@@ -179,16 +203,20 @@ Value
                                               ((9,
                                                 Effect
                                                   ([
-                                                    Counter;
-                                                    NonTermination
+                                                    Type
+                                                      (Counter);
+                                                    Type
+                                                      (NonTermination)
                                                   ],
                                                     .)),
                                                 Apply
                                                   ((9,
                                                     Effect
                                                       ([
-                                                        Counter;
-                                                        NonTermination
+                                                        Type
+                                                          (Counter);
+                                                        Type
+                                                          (NonTermination)
                                                       ],
                                                         .)),
                                                     Apply
@@ -198,8 +226,10 @@ Value
                                                           ],
                                                             .
                                                               -[
-                                                                Counter;
-                                                                NonTermination
+                                                                Type
+                                                                  (Counter);
+                                                                Type
+                                                                  (NonTermination)
                                                               ]->
                                                               .)),
                                                         Variable
@@ -211,8 +241,10 @@ Value
                                                                   ->
                                                                   .
                                                                     -[
-                                                                      Counter;
-                                                                      NonTermination
+                                                                      Type
+                                                                        (Counter);
+                                                                      Type
+                                                                        (NonTermination)
                                                                     ]->
                                                                     .)),
                                                             sums_rec),
@@ -278,7 +310,11 @@ Value
                                                             Effect
                                                               ([
                                                               ],
-                                                                .)),
+                                                                .
+                                                                  ->
+                                                                  .
+                                                                    ->
+                                                                    .)),
                                                             Z.sub),
                                                         [
                                                           Variable
@@ -309,8 +345,10 @@ Value
                                               ((13,
                                                 Effect
                                                   ([
-                                                    Counter;
-                                                    NonTermination
+                                                    Type
+                                                      (Counter);
+                                                    Type
+                                                      (NonTermination)
                                                   ],
                                                     .)),
                                                 Variable
@@ -318,7 +356,11 @@ Value
                                                     Effect
                                                       ([
                                                       ],
-                                                        .)),
+                                                        .
+                                                          ->
+                                                          .
+                                                            ->
+                                                            .)),
                                                     Z.add),
                                                 [
                                                   Variable
@@ -332,8 +374,10 @@ Value
                                                     ((13,
                                                       Effect
                                                         ([
-                                                          Counter;
-                                                          NonTermination
+                                                          Type
+                                                            (Counter);
+                                                          Type
+                                                            (NonTermination)
                                                         ],
                                                           .)),
                                                       Apply
@@ -343,8 +387,10 @@ Value
                                                             ],
                                                               .
                                                                 -[
-                                                                  Counter;
-                                                                  NonTermination
+                                                                  Type
+                                                                    (Counter);
+                                                                  Type
+                                                                    (NonTermination)
                                                                 ]->
                                                                 .)),
                                                           Variable
@@ -356,8 +402,10 @@ Value
                                                                     ->
                                                                     .
                                                                       -[
-                                                                        Counter;
-                                                                        NonTermination
+                                                                        Type
+                                                                          (Counter);
+                                                                        Type
+                                                                          (NonTermination)
                                                                       ]->
                                                                       .)),
                                                               sum_rec),
@@ -388,8 +436,10 @@ Value
                   (4,
                     Effect
                       ([
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .))
                   (non_rec, @.,
@@ -406,14 +456,23 @@ Value
                                 Type
                                   (Z)))
                         ],
-                        Type
-                          (Z)),
+                        Monad
+                          ([
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination)
+                          ],
+                            Type
+                              (Z))),
                         Apply
                           ((?,
                             Effect
                               ([
-                                Counter;
-                                NonTermination
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Variable
@@ -425,8 +484,10 @@ Value
                                       ->
                                       .
                                         -[
-                                          Counter;
-                                          NonTermination
+                                          Type
+                                            (Counter);
+                                          Type
+                                            (NonTermination)
                                         ]->
                                         .)),
                                 sum_rec),
@@ -435,7 +496,8 @@ Value
                                 ((?,
                                   Effect
                                     ([
-                                      Counter
+                                      Type
+                                        (Counter)
                                     ],
                                       .)),
                                   Variable
@@ -445,7 +507,8 @@ Value
                                         ],
                                           .
                                             -[
-                                              Counter
+                                              Type
+                                                (Counter)
                                             ]->
                                             .)),
                                       read_counter),
@@ -471,8 +534,10 @@ Value
                   ((14,
                     Effect
                       ([
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -500,8 +565,10 @@ Value
                           ((16,
                             Effect
                               ([
-                                Counter;
-                                NonTermination
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             cons,
@@ -509,8 +576,10 @@ Value
                               ((16,
                                 Effect
                                   ([
-                                    Counter;
-                                    NonTermination
+                                    Type
+                                      (Counter);
+                                    Type
+                                      (NonTermination)
                                   ],
                                     .)),
                                 Variable
@@ -520,8 +589,10 @@ Value
                                       ],
                                         .
                                           -[
-                                            Counter;
-                                            NonTermination
+                                            Type
+                                              (Counter);
+                                            Type
+                                              (NonTermination)
                                           ]->
                                           .)),
                                     sum_1),
@@ -538,8 +609,10 @@ Value
                               ((16,
                                 Effect
                                   ([
-                                    Counter;
-                                    NonTermination
+                                    Type
+                                      (Counter);
+                                    Type
+                                      (NonTermination)
                                   ],
                                     .)),
                                 Apply
@@ -549,8 +622,10 @@ Value
                                       ],
                                         .
                                           -[
-                                            Counter;
-                                            NonTermination
+                                            Type
+                                              (Counter);
+                                            Type
+                                              (NonTermination)
                                           ]->
                                           .)),
                                     Variable
@@ -562,8 +637,10 @@ Value
                                               ->
                                               .
                                                 -[
-                                                  Counter;
-                                                  NonTermination
+                                                  Type
+                                                    (Counter);
+                                                  Type
+                                                    (NonTermination)
                                                 ]->
                                                 .)),
                                         sums_rec),
@@ -594,15 +671,23 @@ Value
   (non_rec, @.,
     [
       ((sums, [ ], [ (ls, Type (list, Type (list, Type (Z)))) ],
-        Type (list, Type (Z))),
+        Monad
+          ([ Type (Counter); Type (NonTermination) ], Type (list, Type (Z)))),
         Apply
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable
-              ((?, Effect ([ ], . -> . -[ Counter; NonTermination ]-> .)),
-                sums_rec),
+              ((?,
+                Effect
+                  ([ ],
+                    . ->
+                      .
+                        -[
+                          Type (Counter);
+                          Type (NonTermination)
+                        ]-> .)), sums_rec),
             [
               Apply
-                ((?, Effect ([ Counter ], .)),
+                ((?, Effect ([ Type (Counter) ], .)),
                   Variable
                     ((?,
                       Effect
@@ -610,7 +695,8 @@ Value
                         ],
                           .
                             -[
-                              Counter
+                              Type
+                                (Counter)
                             ]->
                             .)),
                       read_counter),

--- a/tests/ex20.monadise
+++ b/tests/ex20.monadise
@@ -4,7 +4,8 @@ Value
     [
       ((sums_rec, [ ],
         [ (counter, Type (nat)); (ls, Type (list, Type (list, Type (Z)))) ],
-        Monad ([ Counter; NonTermination ], Type (list, Type (Z)))),
+        Monad
+          ([ Type (Counter); Type (NonTermination) ], Type (list, Type (Z)))),
         Match
           (?, Variable (?, counter),
             [
@@ -12,11 +13,14 @@ Value
                 Lift
                   (?,
                     [
-                      NonTermination
+                      Type
+                        (NonTermination)
                     ],
                     [
-                      Counter;
-                      NonTermination
+                      Type
+                        (Counter);
+                      Type
+                        (NonTermination)
                     ],
                     Apply
                       (?,
@@ -46,8 +50,10 @@ Value
                         ],
                         Monad
                           ([
-                            Counter;
-                            NonTermination
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination)
                           ],
                             Type
                               (Z))),
@@ -62,11 +68,14 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      NonTermination
+                                      Type
+                                        (NonTermination)
                                     ],
                                     [
-                                      Counter;
-                                      NonTermination
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination)
                                     ],
                                     Apply
                                       (?,
@@ -234,8 +243,10 @@ Value
                         ],
                         Monad
                           ([
-                            Counter;
-                            NonTermination
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination)
                           ],
                             Type
                               (Z))),
@@ -244,11 +255,14 @@ Value
                             Lift
                               (?,
                                 [
-                                  Counter
+                                  Type
+                                    (Counter)
                                 ],
                                 [
-                                  Counter;
-                                  NonTermination
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination)
                                 ],
                                 Apply
                                   (?,
@@ -348,11 +362,13 @@ Value
   (non_rec, @.,
     [
       ((sums, [ ], [ (ls, Type (list, Type (list, Type (Z)))) ],
-        Monad ([ Counter; NonTermination ], Type (list, Type (Z)))),
+        Monad
+          ([ Type (Counter); Type (NonTermination) ], Type (list, Type (Z)))),
         Bind
           (?,
             Lift
-              (?, [ Counter ], [ Counter; NonTermination ],
+              (?, [ Type (Counter) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply (?, Variable (?, read_counter), [ Tuple (?) ])),
             Some x,
             Apply

--- a/tests/ex21.effects
+++ b/tests/ex21.effects
@@ -2,22 +2,26 @@
 Value
   (non_rec, @.,
     [
-      ((f, [ A; B; C ], [ (x, A) ], (B -> C)),
+      ((f, [ A; B; C ], [ (x, A) ],
+        Monad ([ Type (IO) ], (B -> Monad ([ Type (OCaml.Failure) ], C)))),
         Sequence
-          ((4, Effect ([ IO ], . -[ OCaml.Failure ]-> .)),
+          ((4, Effect ([ Type (IO) ], . -[ Type (OCaml.Failure) ]-> .)),
             Apply
-              ((4, Effect ([ IO ], .)),
+              ((4, Effect ([ Type (IO) ], .)),
                 Variable
-                  ((4, Effect ([ ], . -[ IO ]-> .)),
+                  ((4, Effect ([ ], . -[ Type (IO) ]-> .)),
                     OCaml.Pervasives.print_string),
                 [ Constant ((4, Effect ([ ], .)), String("Hi")) ]),
             Function
-              ((5, Effect ([ ], . -[ OCaml.Failure ]-> .)), y,
+              ((5, Effect ([ ], . -[ Type (OCaml.Failure) ]-> .)), y,
                 Apply
-                  ((5, Effect ([ OCaml.Failure ], .)),
+                  ((5, Effect ([ Type (OCaml.Failure) ], .)),
                     Variable
                       ((5,
-                        Effect ([ ], . -[ OCaml.Failure ]-> .)),
+                        Effect
+                          ([ ],
+                            . -[ Type (OCaml.Failure) ]->
+                              .)),
                         OCaml.Pervasives.failwith),
                     [
                       Constant
@@ -34,9 +38,9 @@ Value
 Value
   (non_rec, @.,
     [
-      ((r, [ A; B ], [ (x, A) ], B),
+      ((r, [ A; B ], [ (x, A) ], Monad ([ Type (IO); Type (OCaml.Failure) ], B)),
         Match
-          ((?, Effect ([ IO; OCaml.Failure ], .)),
+          ((?, Effect ([ Type (IO); Type (OCaml.Failure) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -44,19 +48,23 @@ Value
                   ((7,
                     Effect
                       ([
-                        IO;
-                        OCaml.Failure
+                        Type
+                          (IO);
+                        Type
+                          (OCaml.Failure)
                       ],
                         .)),
                     Apply
                       ((7,
                         Effect
                           ([
-                            IO
+                            Type
+                              (IO)
                           ],
                             .
                               -[
-                                OCaml.Failure
+                                Type
+                                  (OCaml.Failure)
                               ]->
                               .)),
                         Variable
@@ -66,11 +74,13 @@ Value
                               ],
                                 .
                                   -[
-                                    IO
+                                    Type
+                                      (IO)
                                   ]->
                                   .
                                     -[
-                                      OCaml.Failure
+                                      Type
+                                        (OCaml.Failure)
                                     ]->
                                     .)),
                             f),

--- a/tests/ex21.monadise
+++ b/tests/ex21.monadise
@@ -3,7 +3,7 @@ Value
   (non_rec, @.,
     [
       ((f, [ A; B; C ], [ (x, A) ],
-        Monad ([ IO ], (B -> Monad ([ OCaml.Failure ], C)))),
+        Monad ([ Type (IO) ], (B -> Monad ([ Type (OCaml.Failure) ], C)))),
         Bind
           (?,
             Apply
@@ -24,7 +24,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((r, [ A; B ], [ (x, A) ], Monad ([ IO; OCaml.Failure ], B)),
+      ((r, [ A; B ], [ (x, A) ], Monad ([ Type (IO); Type (OCaml.Failure) ], B)),
         Match
           (?, Variable (?, x),
             [
@@ -34,11 +34,14 @@ Value
                     Lift
                       (?,
                         [
-                          IO
+                          Type
+                            (IO)
                         ],
                         [
-                          IO;
-                          OCaml.Failure
+                          Type
+                            (IO);
+                          Type
+                            (OCaml.Failure)
                         ],
                         Apply
                           (7,
@@ -55,11 +58,14 @@ Value
                     Lift
                       (?,
                         [
-                          OCaml.Failure
+                          Type
+                            (OCaml.Failure)
                         ],
                         [
-                          IO;
-                          OCaml.Failure
+                          Type
+                            (IO);
+                          Type
+                            (OCaml.Failure)
                         ],
                         Apply
                           (7,

--- a/tests/ex22.effects
+++ b/tests/ex22.effects
@@ -4,7 +4,8 @@ Value
     [
       ((op_plus_plus_plus, [ ], [ (x, Type (Z)); (y, Type (Z)) ], Type (Z)),
         Apply
-          ((3, Effect ([ ], .)), Variable ((3, Effect ([ ], .)), Z.add),
+          ((3, Effect ([ ], .)),
+            Variable ((3, Effect ([ ], . -> . -> .)), Z.add),
             [
               Variable ((3, Effect ([ ], .)), x);
               Variable ((3, Effect ([ ], .)), y)
@@ -17,7 +18,8 @@ Value
     [
       ((op_tilde_tilde, [ ], [ (x, Type (Z)) ], Type (Z)),
         Apply
-          ((4, Effect ([ ], .)), Variable ((4, Effect ([ ], .)), Z.opp),
+          ((4, Effect ([ ], .)),
+            Variable ((4, Effect ([ ], . -> .)), Z.opp),
             [ Variable ((4, Effect ([ ], .)), x) ]))
     ])
 

--- a/tests/ex23.effects
+++ b/tests/ex23.effects
@@ -102,9 +102,9 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_match, [ A; B ], [ (x, A) ], B),
+      ((e_match, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Match_failure) ], B)),
         Match
-          ((?, Effect ([ OCaml.Match_failure ], .)),
+          ((?, Effect ([ Type (OCaml.Match_failure) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -112,7 +112,8 @@ Value
                   ((26,
                     Effect
                       ([
-                        OCaml.Match_failure
+                        Type
+                          (OCaml.Match_failure)
                       ],
                         .)),
                     Variable
@@ -122,7 +123,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Match_failure
+                                Type
+                                  (OCaml.Match_failure)
                               ]->
                               .)),
                         OCaml.raise_Match_failure),
@@ -168,9 +170,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_assert, [ A; B ], [ (x, A) ], B),
+      ((e_assert, [ A; B ], [ (x, A) ],
+        Monad ([ Type (OCaml.Assert_failure) ], B)),
         Match
-          ((?, Effect ([ OCaml.Assert_failure ], .)),
+          ((?, Effect ([ Type (OCaml.Assert_failure) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -178,7 +181,8 @@ Value
                   ((27,
                     Effect
                       ([
-                        OCaml.Assert_failure
+                        Type
+                          (OCaml.Assert_failure)
                       ],
                         .)),
                     Variable
@@ -188,7 +192,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Assert_failure
+                                Type
+                                  (OCaml.Assert_failure)
                               ]->
                               .)),
                         OCaml.raise_Assert_failure),
@@ -234,9 +239,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_invalid, [ A; B ], [ (x, A) ], B),
+      ((e_invalid, [ A; B ], [ (x, A) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], B)),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument ], .)),
+          ((?, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -244,7 +250,8 @@ Value
                   ((28,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -254,7 +261,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ]->
                               .)),
                         OCaml.raise_Invalid_argument),
@@ -280,9 +288,9 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_failure, [ A; B ], [ (x, A) ], B),
+      ((e_failure, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Failure) ], B)),
         Match
-          ((?, Effect ([ OCaml.Failure ], .)),
+          ((?, Effect ([ Type (OCaml.Failure) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -290,7 +298,8 @@ Value
                   ((29,
                     Effect
                       ([
-                        OCaml.Failure
+                        Type
+                          (OCaml.Failure)
                       ],
                         .)),
                     Variable
@@ -300,7 +309,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Failure
+                                Type
+                                  (OCaml.Failure)
                               ]->
                               .)),
                         OCaml.raise_Failure),
@@ -326,9 +336,9 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_not_found, [ A; B ], [ (x, A) ], B),
+      ((e_not_found, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Not_found) ], B)),
         Match
-          ((?, Effect ([ OCaml.Not_found ], .)),
+          ((?, Effect ([ Type (OCaml.Not_found) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -336,7 +346,8 @@ Value
                   ((30,
                     Effect
                       ([
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Variable
@@ -346,7 +357,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Not_found
+                                Type
+                                  (OCaml.Not_found)
                               ]->
                               .)),
                         OCaml.raise_Not_found),
@@ -365,9 +377,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_out_of_mem, [ A; B ], [ (x, A) ], B),
+      ((e_out_of_mem, [ A; B ], [ (x, A) ],
+        Monad ([ Type (OCaml.Out_of_memory) ], B)),
         Match
-          ((?, Effect ([ OCaml.Out_of_memory ], .)),
+          ((?, Effect ([ Type (OCaml.Out_of_memory) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -375,7 +388,8 @@ Value
                   ((31,
                     Effect
                       ([
-                        OCaml.Out_of_memory
+                        Type
+                          (OCaml.Out_of_memory)
                       ],
                         .)),
                     Variable
@@ -385,7 +399,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Out_of_memory
+                                Type
+                                  (OCaml.Out_of_memory)
                               ]->
                               .)),
                         OCaml.raise_Out_of_memory),
@@ -404,9 +419,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_overflow, [ A; B ], [ (x, A) ], B),
+      ((e_overflow, [ A; B ], [ (x, A) ],
+        Monad ([ Type (OCaml.Stack_overflow) ], B)),
         Match
-          ((?, Effect ([ OCaml.Stack_overflow ], .)),
+          ((?, Effect ([ Type (OCaml.Stack_overflow) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -414,7 +430,8 @@ Value
                   ((32,
                     Effect
                       ([
-                        OCaml.Stack_overflow
+                        Type
+                          (OCaml.Stack_overflow)
                       ],
                         .)),
                     Variable
@@ -424,7 +441,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Stack_overflow
+                                Type
+                                  (OCaml.Stack_overflow)
                               ]->
                               .)),
                         OCaml.raise_Stack_overflow),
@@ -443,9 +461,9 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_sys_err, [ A; B ], [ (x, A) ], B),
+      ((e_sys_err, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Sys_error) ], B)),
         Match
-          ((?, Effect ([ OCaml.Sys_error ], .)),
+          ((?, Effect ([ Type (OCaml.Sys_error) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -453,7 +471,8 @@ Value
                   ((33,
                     Effect
                       ([
-                        OCaml.Sys_error
+                        Type
+                          (OCaml.Sys_error)
                       ],
                         .)),
                     Variable
@@ -463,7 +482,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Sys_error
+                                Type
+                                  (OCaml.Sys_error)
                               ]->
                               .)),
                         OCaml.raise_Sys_error),
@@ -489,9 +509,9 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_EOF, [ A; B ], [ (x, A) ], B),
+      ((e_EOF, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.End_of_file) ], B)),
         Match
-          ((?, Effect ([ OCaml.End_of_file ], .)),
+          ((?, Effect ([ Type (OCaml.End_of_file) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -499,7 +519,8 @@ Value
                   ((34,
                     Effect
                       ([
-                        OCaml.End_of_file
+                        Type
+                          (OCaml.End_of_file)
                       ],
                         .)),
                     Variable
@@ -509,7 +530,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.End_of_file
+                                Type
+                                  (OCaml.End_of_file)
                               ]->
                               .)),
                         OCaml.raise_End_of_file),
@@ -528,9 +550,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_div, [ A; B ], [ (x, A) ], B),
+      ((e_div, [ A; B ], [ (x, A) ],
+        Monad ([ Type (OCaml.Division_by_zero) ], B)),
         Match
-          ((?, Effect ([ OCaml.Division_by_zero ], .)),
+          ((?, Effect ([ Type (OCaml.Division_by_zero) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -538,7 +561,8 @@ Value
                   ((35,
                     Effect
                       ([
-                        OCaml.Division_by_zero
+                        Type
+                          (OCaml.Division_by_zero)
                       ],
                         .)),
                     Variable
@@ -548,7 +572,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Division_by_zero
+                                Type
+                                  (OCaml.Division_by_zero)
                               ]->
                               .)),
                         OCaml.raise_Division_by_zero),
@@ -567,9 +592,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_sys_blocked, [ A; B ], [ (x, A) ], B),
+      ((e_sys_blocked, [ A; B ], [ (x, A) ],
+        Monad ([ Type (OCaml.Sys_blocked_io) ], B)),
         Match
-          ((?, Effect ([ OCaml.Sys_blocked_io ], .)),
+          ((?, Effect ([ Type (OCaml.Sys_blocked_io) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -577,7 +603,8 @@ Value
                   ((36,
                     Effect
                       ([
-                        OCaml.Sys_blocked_io
+                        Type
+                          (OCaml.Sys_blocked_io)
                       ],
                         .)),
                     Variable
@@ -587,7 +614,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Sys_blocked_io
+                                Type
+                                  (OCaml.Sys_blocked_io)
                               ]->
                               .)),
                         OCaml.raise_Sys_blocked_io),
@@ -606,9 +634,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_rec_module, [ A; B ], [ (x, A) ], B),
+      ((e_rec_module, [ A; B ], [ (x, A) ],
+        Monad ([ Type (OCaml.Undefined_recursive_module) ], B)),
         Match
-          ((?, Effect ([ OCaml.Undefined_recursive_module ], .)),
+          ((?, Effect ([ Type (OCaml.Undefined_recursive_module) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -616,7 +645,8 @@ Value
                   ((37,
                     Effect
                       ([
-                        OCaml.Undefined_recursive_module
+                        Type
+                          (OCaml.Undefined_recursive_module)
                       ],
                         .)),
                     Variable
@@ -626,7 +656,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Undefined_recursive_module
+                                Type
+                                  (OCaml.Undefined_recursive_module)
                               ]->
                               .)),
                         OCaml.raise_Undefined_recursive_module),

--- a/tests/ex23.monadise
+++ b/tests/ex23.monadise
@@ -62,7 +62,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_match, [ A; B ], [ (x, A) ], Monad ([ OCaml.Match_failure ], B)),
+      ((e_match, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Match_failure) ], B)),
         Match
           (?, Variable (?, x),
             [
@@ -94,7 +94,8 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_assert, [ A; B ], [ (x, A) ], Monad ([ OCaml.Assert_failure ], B)),
+      ((e_assert, [ A; B ], [ (x, A) ],
+        Monad ([ Type (OCaml.Assert_failure) ], B)),
         Match
           (?, Variable (?, x),
             [
@@ -126,7 +127,8 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_invalid, [ A; B ], [ (x, A) ], Monad ([ OCaml.Invalid_argument ], B)),
+      ((e_invalid, [ A; B ], [ (x, A) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], B)),
         Match
           (?, Variable (?, x),
             [
@@ -150,7 +152,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_failure, [ A; B ], [ (x, A) ], Monad ([ OCaml.Failure ], B)),
+      ((e_failure, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Failure) ], B)),
         Match
           (?, Variable (?, x),
             [
@@ -174,7 +176,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_not_found, [ A; B ], [ (x, A) ], Monad ([ OCaml.Not_found ], B)),
+      ((e_not_found, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Not_found) ], B)),
         Match
           (?, Variable (?, x),
             [
@@ -195,7 +197,8 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_out_of_mem, [ A; B ], [ (x, A) ], Monad ([ OCaml.Out_of_memory ], B)),
+      ((e_out_of_mem, [ A; B ], [ (x, A) ],
+        Monad ([ Type (OCaml.Out_of_memory) ], B)),
         Match
           (?, Variable (?, x),
             [
@@ -216,7 +219,8 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_overflow, [ A; B ], [ (x, A) ], Monad ([ OCaml.Stack_overflow ], B)),
+      ((e_overflow, [ A; B ], [ (x, A) ],
+        Monad ([ Type (OCaml.Stack_overflow) ], B)),
         Match
           (?, Variable (?, x),
             [
@@ -237,7 +241,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_sys_err, [ A; B ], [ (x, A) ], Monad ([ OCaml.Sys_error ], B)),
+      ((e_sys_err, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Sys_error) ], B)),
         Match
           (?, Variable (?, x),
             [
@@ -261,7 +265,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_EOF, [ A; B ], [ (x, A) ], Monad ([ OCaml.End_of_file ], B)),
+      ((e_EOF, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.End_of_file) ], B)),
         Match
           (?, Variable (?, x),
             [
@@ -282,7 +286,8 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_div, [ A; B ], [ (x, A) ], Monad ([ OCaml.Division_by_zero ], B)),
+      ((e_div, [ A; B ], [ (x, A) ],
+        Monad ([ Type (OCaml.Division_by_zero) ], B)),
         Match
           (?, Variable (?, x),
             [
@@ -303,7 +308,8 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_sys_blocked, [ A; B ], [ (x, A) ], Monad ([ OCaml.Sys_blocked_io ], B)),
+      ((e_sys_blocked, [ A; B ], [ (x, A) ],
+        Monad ([ Type (OCaml.Sys_blocked_io) ], B)),
         Match
           (?, Variable (?, x),
             [
@@ -325,7 +331,7 @@ Value
   (non_rec, @.,
     [
       ((e_rec_module, [ A; B ], [ (x, A) ],
-        Monad ([ OCaml.Undefined_recursive_module ], B)),
+        Monad ([ Type (OCaml.Undefined_recursive_module) ], B)),
         Match
           (?, Variable (?, x),
             [

--- a/tests/ex24.effects
+++ b/tests/ex24.effects
@@ -2,9 +2,10 @@
 Value
   (non_rec, @.,
     [
-      ((e_invalid, [ A; B ], [ (x, A) ], B),
+      ((e_invalid, [ A; B ], [ (x, A) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], B)),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument ], .)),
+          ((?, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -12,7 +13,8 @@ Value
                   ((5,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -22,7 +24,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ]->
                               .)),
                         OCaml.Pervasives.invalid_arg),
@@ -42,9 +45,9 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_failure, [ A; B ], [ (x, A) ], B),
+      ((e_failure, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Failure) ], B)),
         Match
-          ((?, Effect ([ OCaml.Failure ], .)),
+          ((?, Effect ([ Type (OCaml.Failure) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -52,7 +55,8 @@ Value
                   ((6,
                     Effect
                       ([
-                        OCaml.Failure
+                        Type
+                          (OCaml.Failure)
                       ],
                         .)),
                     Variable
@@ -62,7 +66,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Failure
+                                Type
+                                  (OCaml.Failure)
                               ]->
                               .)),
                         OCaml.Pervasives.failwith),
@@ -82,9 +87,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_exit1, [ A; B ], [ (x, A) ], B),
+      ((e_exit1, [ A; B ], [ (x, A) ],
+        Monad ([ Type (OCaml.Pervasives.Exit) ], B)),
         Match
-          ((?, Effect ([ OCaml.Pervasives.Exit ], .)),
+          ((?, Effect ([ Type (OCaml.Pervasives.Exit) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -92,7 +98,8 @@ Value
                   ((7,
                     Effect
                       ([
-                        OCaml.Pervasives.Exit
+                        Type
+                          (OCaml.Pervasives.Exit)
                       ],
                         .)),
                     Variable
@@ -102,7 +109,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Pervasives.Exit
+                                Type
+                                  (OCaml.Pervasives.Exit)
                               ]->
                               .)),
                         OCaml.Pervasives.raise_Exit),
@@ -121,9 +129,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_exit2, [ A; B ], [ (x, A) ], B),
+      ((e_exit2, [ A; B ], [ (x, A) ],
+        Monad ([ Type (OCaml.Pervasives.Exit) ], B)),
         Match
-          ((?, Effect ([ OCaml.Pervasives.Exit ], .)),
+          ((?, Effect ([ Type (OCaml.Pervasives.Exit) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -131,7 +140,8 @@ Value
                   ((8,
                     Effect
                       ([
-                        OCaml.Pervasives.Exit
+                        Type
+                          (OCaml.Pervasives.Exit)
                       ],
                         .)),
                     Variable
@@ -141,7 +151,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Pervasives.Exit
+                                Type
+                                  (OCaml.Pervasives.Exit)
                               ]->
                               .)),
                         OCaml.Pervasives.raise_Exit),
@@ -163,7 +174,7 @@ Value
       ((b_eq, [ ], [ ], Type (bool)),
         Apply
           ((11, Effect ([ ], .)),
-            Variable ((11, Effect ([ ], .)), equiv_decb),
+            Variable ((11, Effect ([ ], . -> . -> .)), equiv_decb),
             [
               Constant ((11, Effect ([ ], .)), Int(1));
               Constant ((11, Effect ([ ], .)), Int(2))
@@ -177,7 +188,7 @@ Value
       ((b_neq1, [ ], [ ], Type (bool)),
         Apply
           ((12, Effect ([ ], .)),
-            Variable ((12, Effect ([ ], .)), nequiv_decb),
+            Variable ((12, Effect ([ ], . -> . -> .)), nequiv_decb),
             [
               Constructor ((12, Effect ([ ], .)), true);
               Constructor ((12, Effect ([ ], .)), false)
@@ -191,7 +202,7 @@ Value
       ((b_neq2, [ ], [ ], Type (bool)),
         Apply
           ((13, Effect ([ ], .)),
-            Variable ((13, Effect ([ ], .)), nequiv_decb),
+            Variable ((13, Effect ([ ], . -> . -> .)), nequiv_decb),
             [
               Constructor ((13, Effect ([ ], .)), tt);
               Constructor ((13, Effect ([ ], .)), tt)
@@ -205,7 +216,8 @@ Value
       ((b_lt, [ ], [ ], Type (bool)),
         Apply
           ((14, Effect ([ ], .)),
-            Variable ((14, Effect ([ ], .)), OCaml.Pervasives.lt),
+            Variable
+              ((14, Effect ([ ], . -> . -> .)), OCaml.Pervasives.lt),
             [
               Constant ((14, Effect ([ ], .)), Int(1));
               Constant ((14, Effect ([ ], .)), Int(2))
@@ -219,7 +231,8 @@ Value
       ((b_gt, [ ], [ ], Type (bool)),
         Apply
           ((15, Effect ([ ], .)),
-            Variable ((15, Effect ([ ], .)), OCaml.Pervasives.gt),
+            Variable
+              ((15, Effect ([ ], . -> . -> .)), OCaml.Pervasives.gt),
             [
               Constant ((15, Effect ([ ], .)), Int(1));
               Constant ((15, Effect ([ ], .)), Int(2))
@@ -233,7 +246,8 @@ Value
       ((b_le, [ ], [ ], Type (bool)),
         Apply
           ((16, Effect ([ ], .)),
-            Variable ((16, Effect ([ ], .)), OCaml.Pervasives.le),
+            Variable
+              ((16, Effect ([ ], . -> . -> .)), OCaml.Pervasives.le),
             [
               Constructor ((16, Effect ([ ], .)), true);
               Constructor ((16, Effect ([ ], .)), false)
@@ -247,7 +261,8 @@ Value
       ((b_ge, [ ], [ ], Type (bool)),
         Apply
           ((17, Effect ([ ], .)),
-            Variable ((17, Effect ([ ], .)), OCaml.Pervasives.ge),
+            Variable
+              ((17, Effect ([ ], . -> . -> .)), OCaml.Pervasives.ge),
             [
               Constructor ((17, Effect ([ ], .)), tt);
               Constructor ((17, Effect ([ ], .)), tt)
@@ -261,7 +276,8 @@ Value
       ((comp, [ ], [ ], Type (Z)),
         Apply
           ((18, Effect ([ ], .)),
-            Variable ((18, Effect ([ ], .)), OCaml.Pervasives.compare),
+            Variable
+              ((18, Effect ([ ], . -> . -> .)), OCaml.Pervasives.compare),
             [
               Constant ((18, Effect ([ ], .)), Int(1));
               Constant ((18, Effect ([ ], .)), Int(2))
@@ -275,7 +291,8 @@ Value
       ((n_min, [ ], [ ], Type (Z)),
         Apply
           ((19, Effect ([ ], .)),
-            Variable ((19, Effect ([ ], .)), OCaml.Pervasives.min),
+            Variable
+              ((19, Effect ([ ], . -> . -> .)), OCaml.Pervasives.min),
             [
               Constant ((19, Effect ([ ], .)), Int(1));
               Constant ((19, Effect ([ ], .)), Int(2))
@@ -289,7 +306,8 @@ Value
       ((n_max, [ ], [ ], Type (Z)),
         Apply
           ((20, Effect ([ ], .)),
-            Variable ((20, Effect ([ ], .)), OCaml.Pervasives.max),
+            Variable
+              ((20, Effect ([ ], . -> . -> .)), OCaml.Pervasives.max),
             [
               Constant ((20, Effect ([ ], .)), Int(1));
               Constant ((20, Effect ([ ], .)), Int(2))
@@ -302,7 +320,8 @@ Value
     [
       ((b_not, [ ], [ ], Type (bool)),
         Apply
-          ((25, Effect ([ ], .)), Variable ((25, Effect ([ ], .)), negb),
+          ((25, Effect ([ ], .)),
+            Variable ((25, Effect ([ ], . -> .)), negb),
             [ Constructor ((25, Effect ([ ], .)), false) ]))
     ])
 
@@ -312,7 +331,8 @@ Value
     [
       ((b_and, [ ], [ ], Type (bool)),
         Apply
-          ((26, Effect ([ ], .)), Variable ((26, Effect ([ ], .)), andb),
+          ((26, Effect ([ ], .)),
+            Variable ((26, Effect ([ ], . -> . -> .)), andb),
             [
               Constructor ((26, Effect ([ ], .)), true);
               Constructor ((26, Effect ([ ], .)), false)
@@ -325,7 +345,8 @@ Value
     [
       ((b_and_old, [ ], [ ], Type (bool)),
         Apply
-          ((27, Effect ([ ], .)), Variable ((27, Effect ([ ], .)), andb),
+          ((27, Effect ([ ], .)),
+            Variable ((27, Effect ([ ], . -> . -> .)), andb),
             [
               Constructor ((27, Effect ([ ], .)), true);
               Constructor ((27, Effect ([ ], .)), false)
@@ -338,7 +359,8 @@ Value
     [
       ((b_or, [ ], [ ], Type (bool)),
         Apply
-          ((28, Effect ([ ], .)), Variable ((28, Effect ([ ], .)), orb),
+          ((28, Effect ([ ], .)),
+            Variable ((28, Effect ([ ], . -> . -> .)), orb),
             [
               Constructor ((28, Effect ([ ], .)), true);
               Constructor ((28, Effect ([ ], .)), false)
@@ -351,7 +373,8 @@ Value
     [
       ((b_or_old, [ ], [ ], Type (bool)),
         Apply
-          ((29, Effect ([ ], .)), Variable ((29, Effect ([ ], .)), orb),
+          ((29, Effect ([ ], .)),
+            Variable ((29, Effect ([ ], . -> . -> .)), orb),
             [
               Constructor ((29, Effect ([ ], .)), true);
               Constructor ((29, Effect ([ ], .)), false)
@@ -366,7 +389,8 @@ Value
         Apply
           ((32, Effect ([ ], .)),
             Variable
-              ((32, Effect ([ ], .)), OCaml.Pervasives.reverse_apply),
+              ((32, Effect ([ ], . -> . -> .)),
+                OCaml.Pervasives.reverse_apply),
             [
               Constant ((32, Effect ([ ], .)), Int(12));
               Function
@@ -387,7 +411,8 @@ Value
     [
       ((app2, [ ], [ ], Type (Z)),
         Apply
-          ((33, Effect ([ ], .)), Variable ((33, Effect ([ ], .)), apply),
+          ((33, Effect ([ ], .)),
+            Variable ((33, Effect ([ ], . -> . -> .)), apply),
             [
               Function
                 ((33, Effect ([ ], . -> .)), x,
@@ -408,7 +433,8 @@ Value
     [
       ((n_neg1, [ ], [ ], Type (Z)),
         Apply
-          ((36, Effect ([ ], .)), Variable ((36, Effect ([ ], .)), Z.opp),
+          ((36, Effect ([ ], .)),
+            Variable ((36, Effect ([ ], . -> .)), Z.opp),
             [ Constant ((36, Effect ([ ], .)), Int(12)) ]))
     ])
 
@@ -425,7 +451,7 @@ Value
     [
       ((n_pos1, [ ], [ ], Type (Z)),
         Apply
-          ((38, Effect ([ ], .)), Variable ((38, Effect ([ ], .)), ),
+          ((38, Effect ([ ], .)), Variable ((38, Effect ([ ], . -> .)), ),
             [ Constant ((38, Effect ([ ], .)), Int(12)) ]))
     ])
 
@@ -440,7 +466,8 @@ Value
     [
       ((n_succ, [ ], [ ], Type (Z)),
         Apply
-          ((40, Effect ([ ], .)), Variable ((40, Effect ([ ], .)), Z.succ),
+          ((40, Effect ([ ], .)),
+            Variable ((40, Effect ([ ], . -> .)), Z.succ),
             [ Constant ((40, Effect ([ ], .)), Int(1)) ]))
     ])
 
@@ -450,7 +477,8 @@ Value
     [
       ((n_pred, [ ], [ ], Type (Z)),
         Apply
-          ((41, Effect ([ ], .)), Variable ((41, Effect ([ ], .)), Z.pred),
+          ((41, Effect ([ ], .)),
+            Variable ((41, Effect ([ ], . -> .)), Z.pred),
             [ Constant ((41, Effect ([ ], .)), Int(1)) ]))
     ])
 
@@ -460,7 +488,8 @@ Value
     [
       ((n_plus, [ ], [ ], Type (Z)),
         Apply
-          ((42, Effect ([ ], .)), Variable ((42, Effect ([ ], .)), Z.add),
+          ((42, Effect ([ ], .)),
+            Variable ((42, Effect ([ ], . -> . -> .)), Z.add),
             [
               Constant ((42, Effect ([ ], .)), Int(1));
               Constant ((42, Effect ([ ], .)), Int(2))
@@ -473,7 +502,8 @@ Value
     [
       ((n_minus, [ ], [ ], Type (Z)),
         Apply
-          ((43, Effect ([ ], .)), Variable ((43, Effect ([ ], .)), Z.sub),
+          ((43, Effect ([ ], .)),
+            Variable ((43, Effect ([ ], . -> . -> .)), Z.sub),
             [
               Constant ((43, Effect ([ ], .)), Int(1));
               Constant ((43, Effect ([ ], .)), Int(2))
@@ -486,7 +516,8 @@ Value
     [
       ((n_times, [ ], [ ], Type (Z)),
         Apply
-          ((44, Effect ([ ], .)), Variable ((44, Effect ([ ], .)), Z.mul),
+          ((44, Effect ([ ], .)),
+            Variable ((44, Effect ([ ], . -> . -> .)), Z.mul),
             [
               Constant ((44, Effect ([ ], .)), Int(1));
               Constant ((44, Effect ([ ], .)), Int(2))
@@ -499,7 +530,8 @@ Value
     [
       ((n_div, [ ], [ ], Type (Z)),
         Apply
-          ((45, Effect ([ ], .)), Variable ((45, Effect ([ ], .)), Z.div),
+          ((45, Effect ([ ], .)),
+            Variable ((45, Effect ([ ], . -> . -> .)), Z.div),
             [
               Constant ((45, Effect ([ ], .)), Int(1));
               Constant ((45, Effect ([ ], .)), Int(2))
@@ -513,7 +545,7 @@ Value
       ((n_mod, [ ], [ ], Type (Z)),
         Apply
           ((46, Effect ([ ], .)),
-            Variable ((46, Effect ([ ], .)), Z.modulo),
+            Variable ((46, Effect ([ ], . -> . -> .)), Z.modulo),
             [
               Constant ((46, Effect ([ ], .)), Int(1));
               Constant ((46, Effect ([ ], .)), Int(2))
@@ -526,7 +558,8 @@ Value
     [
       ((n_abs, [ ], [ ], Type (Z)),
         Apply
-          ((47, Effect ([ ], .)), Variable ((47, Effect ([ ], .)), Z.abs),
+          ((47, Effect ([ ], .)),
+            Variable ((47, Effect ([ ], . -> .)), Z.abs),
             [ Constant ((47, Effect ([ ], .)), Int(1)) ]))
     ])
 
@@ -536,7 +569,8 @@ Value
     [
       ((n_land, [ ], [ ], Type (Z)),
         Apply
-          ((52, Effect ([ ], .)), Variable ((52, Effect ([ ], .)), Z.land),
+          ((52, Effect ([ ], .)),
+            Variable ((52, Effect ([ ], . -> . -> .)), Z.land),
             [
               Constant ((52, Effect ([ ], .)), Int(12));
               Constant ((52, Effect ([ ], .)), Int(13))
@@ -549,7 +583,8 @@ Value
     [
       ((n_lor, [ ], [ ], Type (Z)),
         Apply
-          ((53, Effect ([ ], .)), Variable ((53, Effect ([ ], .)), Z.lor),
+          ((53, Effect ([ ], .)),
+            Variable ((53, Effect ([ ], . -> . -> .)), Z.lor),
             [
               Constant ((53, Effect ([ ], .)), Int(12));
               Constant ((53, Effect ([ ], .)), Int(13))
@@ -562,7 +597,8 @@ Value
     [
       ((n_lxor, [ ], [ ], Type (Z)),
         Apply
-          ((54, Effect ([ ], .)), Variable ((54, Effect ([ ], .)), Z.lxor),
+          ((54, Effect ([ ], .)),
+            Variable ((54, Effect ([ ], . -> . -> .)), Z.lxor),
             [
               Constant ((54, Effect ([ ], .)), Int(12));
               Constant ((54, Effect ([ ], .)), Int(13))
@@ -576,7 +612,7 @@ Value
       ((n_lsl, [ ], [ ], Type (Z)),
         Apply
           ((56, Effect ([ ], .)),
-            Variable ((56, Effect ([ ], .)), Z.shiftl),
+            Variable ((56, Effect ([ ], . -> . -> .)), Z.shiftl),
             [
               Constant ((56, Effect ([ ], .)), Int(12));
               Constant ((56, Effect ([ ], .)), Int(13))
@@ -590,7 +626,7 @@ Value
       ((n_lsr, [ ], [ ], Type (Z)),
         Apply
           ((57, Effect ([ ], .)),
-            Variable ((57, Effect ([ ], .)), Z.shiftr),
+            Variable ((57, Effect ([ ], . -> . -> .)), Z.shiftr),
             [
               Constant ((57, Effect ([ ], .)), Int(12));
               Constant ((57, Effect ([ ], .)), Int(13))
@@ -604,7 +640,7 @@ Value
       ((ss, [ ], [ ], Type (string)),
         Apply
           ((64, Effect ([ ], .)),
-            Variable ((64, Effect ([ ], .)), String.append),
+            Variable ((64, Effect ([ ], . -> . -> .)), String.append),
             [
               Constant ((64, Effect ([ ], .)), String("begin"));
               Constant ((64, Effect ([ ], .)), String("end"))
@@ -618,7 +654,8 @@ Value
       ((n_char, [ ], [ ], Type (Z)),
         Apply
           ((67, Effect ([ ], .)),
-            Variable ((67, Effect ([ ], .)), OCaml.Pervasives.int_of_char),
+            Variable
+              ((67, Effect ([ ], . -> .)), OCaml.Pervasives.int_of_char),
             [ Constant ((67, Effect ([ ], .)), Char("c")) ]))
     ])
 
@@ -626,9 +663,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((char_n, [ A ], [ (x, A) ], Type (ascii)),
+      ((char_n, [ A ], [ (x, A) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (ascii))),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument ], .)),
+          ((?, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -636,7 +674,8 @@ Value
                   ((68,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -646,7 +685,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ]->
                               .)),
                         OCaml.Pervasives.char_of_int),
@@ -669,7 +709,7 @@ Value
       ((i, [ ], [ ], Type (unit)),
         Apply
           ((71, Effect ([ ], .)),
-            Variable ((71, Effect ([ ], .)), OCaml.Pervasives.ignore),
+            Variable ((71, Effect ([ ], . -> .)), OCaml.Pervasives.ignore),
             [ Constant ((71, Effect ([ ], .)), Int(12)) ]))
     ])
 
@@ -681,7 +721,8 @@ Value
         Apply
           ((74, Effect ([ ], .)),
             Variable
-              ((74, Effect ([ ], .)), OCaml.Pervasives.string_of_bool),
+              ((74, Effect ([ ], . -> .)),
+                OCaml.Pervasives.string_of_bool),
             [ Constructor ((74, Effect ([ ], .)), false) ]))
     ])
 
@@ -693,7 +734,8 @@ Value
         Apply
           ((75, Effect ([ ], .)),
             Variable
-              ((75, Effect ([ ], .)), OCaml.Pervasives.bool_of_string),
+              ((75, Effect ([ ], . -> .)),
+                OCaml.Pervasives.bool_of_string),
             [ Constant ((75, Effect ([ ], .)), String("false")) ]))
     ])
 
@@ -705,7 +747,8 @@ Value
         Apply
           ((76, Effect ([ ], .)),
             Variable
-              ((76, Effect ([ ], .)), OCaml.Pervasives.string_of_int),
+              ((76, Effect ([ ], . -> .)),
+                OCaml.Pervasives.string_of_int),
             [ Constant ((76, Effect ([ ], .)), Int(12)) ]))
     ])
 
@@ -717,7 +760,8 @@ Value
         Apply
           ((77, Effect ([ ], .)),
             Variable
-              ((77, Effect ([ ], .)), OCaml.Pervasives.int_of_string),
+              ((77, Effect ([ ], . -> .)),
+                OCaml.Pervasives.int_of_string),
             [ Constant ((77, Effect ([ ], .)), String("12")) ]))
     ])
 
@@ -727,7 +771,8 @@ Value
     [
       ((n1, [ ], [ ], Type (Z)),
         Apply
-          ((82, Effect ([ ], .)), Variable ((82, Effect ([ ], .)), fst),
+          ((82, Effect ([ ], .)),
+            Variable ((82, Effect ([ ], . -> .)), fst),
             [
               Tuple
                 ((82, Effect ([ ], .)),
@@ -754,7 +799,8 @@ Value
     [
       ((n2, [ ], [ ], Type (Z)),
         Apply
-          ((83, Effect ([ ], .)), Variable ((83, Effect ([ ], .)), snd),
+          ((83, Effect ([ ], .)),
+            Variable ((83, Effect ([ ], . -> .)), snd),
             [
               Tuple
                 ((83, Effect ([ ], .)),
@@ -782,7 +828,8 @@ Value
       ((ll, [ ], [ ], Type (list, Type (Z))),
         Apply
           ((86, Effect ([ ], .)),
-            Variable ((86, Effect ([ ], .)), OCaml.Pervasives.app),
+            Variable
+              ((86, Effect ([ ], . -> . -> .)), OCaml.Pervasives.app),
             [
               Constructor
                 ((86, Effect ([ ], .)), cons,
@@ -851,16 +898,18 @@ Value
 Value
   (non_rec, @.,
     [
-      ((p_c, [ A ], [ (x, A) ], Type (unit)),
+      ((p_c, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
-          ((?, Effect ([ IO ], .)), Variable ((?, Effect ([ ], .)), x),
+          ((?, Effect ([ Type (IO) ], .)),
+            Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
                 Apply
                   ((94,
                     Effect
                       ([
-                        IO
+                        Type
+                          (IO)
                       ],
                         .)),
                     Variable
@@ -870,7 +919,8 @@ Value
                           ],
                             .
                               -[
-                                IO
+                                Type
+                                  (IO)
                               ]->
                               .)),
                         OCaml.Pervasives.print_char),
@@ -890,16 +940,18 @@ Value
 Value
   (non_rec, @.,
     [
-      ((p_s, [ A ], [ (x, A) ], Type (unit)),
+      ((p_s, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
-          ((?, Effect ([ IO ], .)), Variable ((?, Effect ([ ], .)), x),
+          ((?, Effect ([ Type (IO) ], .)),
+            Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
                 Apply
                   ((95,
                     Effect
                       ([
-                        IO
+                        Type
+                          (IO)
                       ],
                         .)),
                     Variable
@@ -909,7 +961,8 @@ Value
                           ],
                             .
                               -[
-                                IO
+                                Type
+                                  (IO)
                               ]->
                               .)),
                         OCaml.Pervasives.print_string),
@@ -929,16 +982,18 @@ Value
 Value
   (non_rec, @.,
     [
-      ((p_n, [ A ], [ (x, A) ], Type (unit)),
+      ((p_n, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
-          ((?, Effect ([ IO ], .)), Variable ((?, Effect ([ ], .)), x),
+          ((?, Effect ([ Type (IO) ], .)),
+            Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
                 Apply
                   ((96,
                     Effect
                       ([
-                        IO
+                        Type
+                          (IO)
                       ],
                         .)),
                     Variable
@@ -948,7 +1003,8 @@ Value
                           ],
                             .
                               -[
-                                IO
+                                Type
+                                  (IO)
                               ]->
                               .)),
                         OCaml.Pervasives.print_int),
@@ -968,16 +1024,18 @@ Value
 Value
   (non_rec, @.,
     [
-      ((p_endline, [ A ], [ (x, A) ], Type (unit)),
+      ((p_endline, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
-          ((?, Effect ([ IO ], .)), Variable ((?, Effect ([ ], .)), x),
+          ((?, Effect ([ Type (IO) ], .)),
+            Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
                 Apply
                   ((98,
                     Effect
                       ([
-                        IO
+                        Type
+                          (IO)
                       ],
                         .)),
                     Variable
@@ -987,7 +1045,8 @@ Value
                           ],
                             .
                               -[
-                                IO
+                                Type
+                                  (IO)
                               ]->
                               .)),
                         OCaml.Pervasives.print_endline),
@@ -1007,16 +1066,18 @@ Value
 Value
   (non_rec, @.,
     [
-      ((p_newline, [ A ], [ (x, A) ], Type (unit)),
+      ((p_newline, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
-          ((?, Effect ([ IO ], .)), Variable ((?, Effect ([ ], .)), x),
+          ((?, Effect ([ Type (IO) ], .)),
+            Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
                 Apply
                   ((99,
                     Effect
                       ([
-                        IO
+                        Type
+                          (IO)
                       ],
                         .)),
                     Variable
@@ -1026,7 +1087,8 @@ Value
                           ],
                             .
                               -[
-                                IO
+                                Type
+                                  (IO)
                               ]->
                               .)),
                         OCaml.Pervasives.print_newline),
@@ -1046,16 +1108,18 @@ Value
 Value
   (non_rec, @.,
     [
-      ((perr_c, [ A ], [ (x, A) ], Type (unit)),
+      ((perr_c, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
-          ((?, Effect ([ IO ], .)), Variable ((?, Effect ([ ], .)), x),
+          ((?, Effect ([ Type (IO) ], .)),
+            Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
                 Apply
                   ((102,
                     Effect
                       ([
-                        IO
+                        Type
+                          (IO)
                       ],
                         .)),
                     Variable
@@ -1065,7 +1129,8 @@ Value
                           ],
                             .
                               -[
-                                IO
+                                Type
+                                  (IO)
                               ]->
                               .)),
                         OCaml.Pervasives.prerr_char),
@@ -1085,16 +1150,18 @@ Value
 Value
   (non_rec, @.,
     [
-      ((perr_s, [ A ], [ (x, A) ], Type (unit)),
+      ((perr_s, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
-          ((?, Effect ([ IO ], .)), Variable ((?, Effect ([ ], .)), x),
+          ((?, Effect ([ Type (IO) ], .)),
+            Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
                 Apply
                   ((103,
                     Effect
                       ([
-                        IO
+                        Type
+                          (IO)
                       ],
                         .)),
                     Variable
@@ -1104,7 +1171,8 @@ Value
                           ],
                             .
                               -[
-                                IO
+                                Type
+                                  (IO)
                               ]->
                               .)),
                         OCaml.Pervasives.prerr_string),
@@ -1124,16 +1192,18 @@ Value
 Value
   (non_rec, @.,
     [
-      ((perr_n, [ A ], [ (x, A) ], Type (unit)),
+      ((perr_n, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
-          ((?, Effect ([ IO ], .)), Variable ((?, Effect ([ ], .)), x),
+          ((?, Effect ([ Type (IO) ], .)),
+            Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
                 Apply
                   ((104,
                     Effect
                       ([
-                        IO
+                        Type
+                          (IO)
                       ],
                         .)),
                     Variable
@@ -1143,7 +1213,8 @@ Value
                           ],
                             .
                               -[
-                                IO
+                                Type
+                                  (IO)
                               ]->
                               .)),
                         OCaml.Pervasives.prerr_int),
@@ -1163,16 +1234,18 @@ Value
 Value
   (non_rec, @.,
     [
-      ((perr_endline, [ A ], [ (x, A) ], Type (unit)),
+      ((perr_endline, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
-          ((?, Effect ([ IO ], .)), Variable ((?, Effect ([ ], .)), x),
+          ((?, Effect ([ Type (IO) ], .)),
+            Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
                 Apply
                   ((106,
                     Effect
                       ([
-                        IO
+                        Type
+                          (IO)
                       ],
                         .)),
                     Variable
@@ -1182,7 +1255,8 @@ Value
                           ],
                             .
                               -[
-                                IO
+                                Type
+                                  (IO)
                               ]->
                               .)),
                         OCaml.Pervasives.prerr_endline),
@@ -1202,16 +1276,18 @@ Value
 Value
   (non_rec, @.,
     [
-      ((perr_newline, [ A ], [ (x, A) ], Type (unit)),
+      ((perr_newline, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
-          ((?, Effect ([ IO ], .)), Variable ((?, Effect ([ ], .)), x),
+          ((?, Effect ([ Type (IO) ], .)),
+            Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
                 Apply
                   ((107,
                     Effect
                       ([
-                        IO
+                        Type
+                          (IO)
                       ],
                         .)),
                     Variable
@@ -1221,7 +1297,8 @@ Value
                           ],
                             .
                               -[
-                                IO
+                                Type
+                                  (IO)
                               ]->
                               .)),
                         OCaml.Pervasives.prerr_newline),
@@ -1241,16 +1318,18 @@ Value
 Value
   (non_rec, @.,
     [
-      ((r_s, [ A ], [ (x, A) ], Type (string)),
+      ((r_s, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (string))),
         Match
-          ((?, Effect ([ IO ], .)), Variable ((?, Effect ([ ], .)), x),
+          ((?, Effect ([ Type (IO) ], .)),
+            Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
                 Apply
                   ((110,
                     Effect
                       ([
-                        IO
+                        Type
+                          (IO)
                       ],
                         .)),
                     Variable
@@ -1260,7 +1339,8 @@ Value
                           ],
                             .
                               -[
-                                IO
+                                Type
+                                  (IO)
                               ]->
                               .)),
                         OCaml.Pervasives.read_line),
@@ -1280,16 +1360,18 @@ Value
 Value
   (non_rec, @.,
     [
-      ((r_n, [ A ], [ (x, A) ], Type (Z)),
+      ((r_n, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (Z))),
         Match
-          ((?, Effect ([ IO ], .)), Variable ((?, Effect ([ ], .)), x),
+          ((?, Effect ([ Type (IO) ], .)),
+            Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
                 Apply
                   ((111,
                     Effect
                       ([
-                        IO
+                        Type
+                          (IO)
                       ],
                         .)),
                     Variable
@@ -1299,7 +1381,8 @@ Value
                           ],
                             .
                               -[
-                                IO
+                                Type
+                                  (IO)
                               ]->
                               .)),
                         OCaml.Pervasives.read_int),

--- a/tests/ex24.monadise
+++ b/tests/ex24.monadise
@@ -2,7 +2,8 @@
 Value
   (non_rec, @.,
     [
-      ((e_invalid, [ A; B ], [ (x, A) ], Monad ([ OCaml.Invalid_argument ], B)),
+      ((e_invalid, [ A; B ], [ (x, A) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], B)),
         Match
           (?, Variable (?, x),
             [
@@ -24,7 +25,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_failure, [ A; B ], [ (x, A) ], Monad ([ OCaml.Failure ], B)),
+      ((e_failure, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Failure) ], B)),
         Match
           (?, Variable (?, x),
             [
@@ -46,7 +47,8 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_exit1, [ A; B ], [ (x, A) ], Monad ([ OCaml.Pervasives.Exit ], B)),
+      ((e_exit1, [ A; B ], [ (x, A) ],
+        Monad ([ Type (OCaml.Pervasives.Exit) ], B)),
         Match
           (?, Variable (?, x),
             [
@@ -67,7 +69,8 @@ Value
 Value
   (non_rec, @.,
     [
-      ((e_exit2, [ A; B ], [ (x, A) ], Monad ([ OCaml.Pervasives.Exit ], B)),
+      ((e_exit2, [ A; B ], [ (x, A) ],
+        Monad ([ Type (OCaml.Pervasives.Exit) ], B)),
         Match
           (?, Variable (?, x),
             [
@@ -426,7 +429,7 @@ Value
   (non_rec, @.,
     [
       ((char_n, [ A ], [ (x, A) ],
-        Monad ([ OCaml.Invalid_argument ], Type (ascii))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (ascii))),
         Match
           (?, Variable (?, x),
             [
@@ -551,7 +554,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((p_c, [ A ], [ (x, A) ], Monad ([ IO ], Type (unit))),
+      ((p_c, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
           (?, Variable (?, x),
             [
@@ -573,7 +576,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((p_s, [ A ], [ (x, A) ], Monad ([ IO ], Type (unit))),
+      ((p_s, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
           (?, Variable (?, x),
             [
@@ -595,7 +598,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((p_n, [ A ], [ (x, A) ], Monad ([ IO ], Type (unit))),
+      ((p_n, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
           (?, Variable (?, x),
             [
@@ -617,7 +620,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((p_endline, [ A ], [ (x, A) ], Monad ([ IO ], Type (unit))),
+      ((p_endline, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
           (?, Variable (?, x),
             [
@@ -639,7 +642,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((p_newline, [ A ], [ (x, A) ], Monad ([ IO ], Type (unit))),
+      ((p_newline, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
           (?, Variable (?, x),
             [
@@ -661,7 +664,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((perr_c, [ A ], [ (x, A) ], Monad ([ IO ], Type (unit))),
+      ((perr_c, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
           (?, Variable (?, x),
             [
@@ -683,7 +686,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((perr_s, [ A ], [ (x, A) ], Monad ([ IO ], Type (unit))),
+      ((perr_s, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
           (?, Variable (?, x),
             [
@@ -705,7 +708,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((perr_n, [ A ], [ (x, A) ], Monad ([ IO ], Type (unit))),
+      ((perr_n, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
           (?, Variable (?, x),
             [
@@ -727,7 +730,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((perr_endline, [ A ], [ (x, A) ], Monad ([ IO ], Type (unit))),
+      ((perr_endline, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
           (?, Variable (?, x),
             [
@@ -749,7 +752,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((perr_newline, [ A ], [ (x, A) ], Monad ([ IO ], Type (unit))),
+      ((perr_newline, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (unit))),
         Match
           (?, Variable (?, x),
             [
@@ -771,7 +774,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((r_s, [ A ], [ (x, A) ], Monad ([ IO ], Type (string))),
+      ((r_s, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (string))),
         Match
           (?, Variable (?, x),
             [
@@ -793,7 +796,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((r_n, [ A ], [ (x, A) ], Monad ([ IO ], Type (Z))),
+      ((r_n, [ A ], [ (x, A) ], Monad ([ Type (IO) ], Type (Z))),
         Match
           (?, Variable (?, x),
             [

--- a/tests/ex25.effects
+++ b/tests/ex25.effects
@@ -56,7 +56,7 @@ Value
       ((s1, [ ], [ ], Type (Z)),
         Apply
           ((7, Effect ([ ], .)),
-            Variable ((7, Effect ([ ], .)), OCaml.List.length),
+            Variable ((7, Effect ([ ], . -> .)), OCaml.List.length),
             [ Variable ((7, Effect ([ ], .)), l1) ]))
     ])
 
@@ -67,7 +67,7 @@ Value
       ((s2, [ ], [ ], Type (Z)),
         Apply
           ((8, Effect ([ ], .)),
-            Variable ((8, Effect ([ ], .)), OCaml.List.length),
+            Variable ((8, Effect ([ ], . -> .)), OCaml.List.length),
             [ Variable ((8, Effect ([ ], .)), l2) ]))
     ])
 
@@ -75,9 +75,9 @@ Value
 Value
   (non_rec, @.,
     [
-      ((h, [ A ], [ (x, A) ], Type (Z)),
+      ((h, [ A ], [ (x, A) ], Monad ([ Type (OCaml.Failure) ], Type (Z))),
         Match
-          ((?, Effect ([ OCaml.Failure ], .)),
+          ((?, Effect ([ Type (OCaml.Failure) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -85,7 +85,8 @@ Value
                   ((9,
                     Effect
                       ([
-                        OCaml.Failure
+                        Type
+                          (OCaml.Failure)
                       ],
                         .)),
                     Variable
@@ -95,7 +96,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Failure
+                                Type
+                                  (OCaml.Failure)
                               ]->
                               .)),
                         OCaml.List.hd),
@@ -115,9 +117,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((t, [ A ], [ (x, A) ], Type (list, Type (Z))),
+      ((t, [ A ], [ (x, A) ],
+        Monad ([ Type (OCaml.Failure) ], Type (list, Type (Z)))),
         Match
-          ((?, Effect ([ OCaml.Failure ], .)),
+          ((?, Effect ([ Type (OCaml.Failure) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -125,7 +128,8 @@ Value
                   ((10,
                     Effect
                       ([
-                        OCaml.Failure
+                        Type
+                          (OCaml.Failure)
                       ],
                         .)),
                     Variable
@@ -135,7 +139,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Failure
+                                Type
+                                  (OCaml.Failure)
                               ]->
                               .)),
                         OCaml.List.tl),
@@ -155,18 +160,24 @@ Value
 Value
   (non_rec, @.,
     [
-      ((x, [ A ], [ (x, A) ], Type (Z)),
+      ((x, [ A ], [ (x, A) ],
+        Monad
+          ([ Type (OCaml.Failure); Type (OCaml.Invalid_argument) ], Type (Z))),
         Match
-          ((?, Effect ([ OCaml.Failure; OCaml.Invalid_argument ], .)),
-            Variable ((?, Effect ([ ], .)), x),
+          ((?,
+            Effect
+              ([ Type (OCaml.Failure); Type (OCaml.Invalid_argument) ],
+                .)), Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
                 Apply
                   ((11,
                     Effect
                       ([
-                        OCaml.Failure;
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Failure);
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -178,8 +189,10 @@ Value
                               ->
                               .
                                 -[
-                                  OCaml.Failure;
-                                  OCaml.Invalid_argument
+                                  Type
+                                    (OCaml.Failure);
+                                  Type
+                                    (OCaml.Invalid_argument)
                                 ]->
                                 .)),
                         OCaml.List.nth),
@@ -209,7 +222,7 @@ Value
       ((rl, [ ], [ ], Type (list, Type (Z))),
         Apply
           ((12, Effect ([ ], .)),
-            Variable ((12, Effect ([ ], .)), OCaml.List.rev),
+            Variable ((12, Effect ([ ], . -> .)), OCaml.List.rev),
             [ Variable ((12, Effect ([ ], .)), l2) ]))
     ])
 
@@ -220,7 +233,7 @@ Value
       ((ll, [ ], [ ], Type (list, Type (Z))),
         Apply
           ((13, Effect ([ ], .)),
-            Variable ((13, Effect ([ ], .)), OCaml.List.append),
+            Variable ((13, Effect ([ ], . -> . -> .)), OCaml.List.append),
             [
               Variable ((13, Effect ([ ], .)), l2);
               Variable ((13, Effect ([ ], .)), l2)
@@ -234,7 +247,8 @@ Value
       ((rll, [ ], [ ], Type (list, Type (Z))),
         Apply
           ((14, Effect ([ ], .)),
-            Variable ((14, Effect ([ ], .)), OCaml.List.rev_append),
+            Variable
+              ((14, Effect ([ ], . -> . -> .)), OCaml.List.rev_append),
             [
               Variable ((14, Effect ([ ], .)), l2);
               Variable ((14, Effect ([ ], .)), l2)
@@ -248,7 +262,7 @@ Value
       ((lc, [ ], [ ], Type (list, Type (Z))),
         Apply
           ((15, Effect ([ ], .)),
-            Variable ((15, Effect ([ ], .)), OCaml.List.concat),
+            Variable ((15, Effect ([ ], . -> .)), OCaml.List.concat),
             [
               Constructor
                 ((15, Effect ([ ], .)), cons,
@@ -318,7 +332,7 @@ Value
       ((lf, [ ], [ ], Type (list, Type (Z))),
         Apply
           ((16, Effect ([ ], .)),
-            Variable ((16, Effect ([ ], .)), OCaml.List.flatten),
+            Variable ((16, Effect ([ ], . -> .)), OCaml.List.flatten),
             [
               Constructor
                 ((16, Effect ([ ], .)), cons,
@@ -388,7 +402,7 @@ Value
       ((m, [ ], [ ], Type (list, Type (Z))),
         Apply
           ((21, Effect ([ ], .)),
-            Variable ((21, Effect ([ ], .)), OCaml.List.map),
+            Variable ((21, Effect ([ ], . -> . -> .)), OCaml.List.map),
             [
               Function
                 ((21, Effect ([ ], . -> .)), x,
@@ -403,7 +417,11 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .
+                                  ->
+                                  .)),
                           Z.add),
                       [
                         Variable
@@ -432,7 +450,7 @@ Value
       ((mi, [ ], [ ], Type (list, Type (Z))),
         Apply
           ((22, Effect ([ ], .)),
-            Variable ((22, Effect ([ ], .)), OCaml.List.mapi),
+            Variable ((22, Effect ([ ], . -> . -> .)), OCaml.List.mapi),
             [
               Function
                 ((22, Effect ([ ], . -> . -> .)), i,
@@ -456,7 +474,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               Z.add),
                           [
                             Variable
@@ -485,7 +507,7 @@ Value
       ((rm, [ ], [ ], Type (list, Type (Z))),
         Apply
           ((23, Effect ([ ], .)),
-            Variable ((23, Effect ([ ], .)), OCaml.List.rev_map),
+            Variable ((23, Effect ([ ], . -> . -> .)), OCaml.List.rev_map),
             [
               Function
                 ((23, Effect ([ ], . -> .)), x,
@@ -500,7 +522,11 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .
+                                  ->
+                                  .)),
                           Z.add),
                       [
                         Variable
@@ -529,7 +555,9 @@ Value
       ((fl, [ ], [ ], Type (Z)),
         Apply
           ((24, Effect ([ ], .)),
-            Variable ((24, Effect ([ ], .)), OCaml.List.fold_left),
+            Variable
+              ((24, Effect ([ ], . -> . -> . -> .)),
+                OCaml.List.fold_left),
             [
               Function
                 ((24, Effect ([ ], . -> . -> .)), s,
@@ -553,7 +581,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               Z.add),
                           [
                             Variable
@@ -583,7 +615,9 @@ Value
       ((fr, [ ], [ ], Type (Z)),
         Apply
           ((25, Effect ([ ], .)),
-            Variable ((25, Effect ([ ], .)), OCaml.List.fold_right),
+            Variable
+              ((25, Effect ([ ], . -> . -> . -> .)),
+                OCaml.List.fold_right),
             [
               Function
                 ((25, Effect ([ ], . -> . -> .)), x,
@@ -607,7 +641,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               Z.add),
                           [
                             Variable
@@ -634,9 +672,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((m2, [ A ], [ (x_1, A) ], Type (list, Type (Z))),
+      ((m2, [ A ], [ (x_1, A) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (list, Type (Z)))),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument ], .)),
+          ((?, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable ((?, Effect ([ ], .)), x_1),
             [
               (Any,
@@ -644,7 +683,8 @@ Value
                   ((29,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -658,7 +698,8 @@ Value
                                 ->
                                 .
                                   -[
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ]->
                                   .)),
                         OCaml.List.map2),
@@ -694,7 +735,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       Z.add),
                                   [
                                     Variable
@@ -734,9 +779,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((rm2, [ A ], [ (x_1, A) ], Type (list, Type (Z))),
+      ((rm2, [ A ], [ (x_1, A) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (list, Type (Z)))),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument ], .)),
+          ((?, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable ((?, Effect ([ ], .)), x_1),
             [
               (Any,
@@ -744,7 +790,8 @@ Value
                   ((30,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -758,7 +805,8 @@ Value
                                 ->
                                 .
                                   -[
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ]->
                                   .)),
                         OCaml.List.rev_map2),
@@ -794,7 +842,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       Z.add),
                                   [
                                     Variable
@@ -834,9 +886,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((fl2, [ A ], [ (x_1, A) ], Type (Z)),
+      ((fl2, [ A ], [ (x_1, A) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (Z))),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument ], .)),
+          ((?, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable ((?, Effect ([ ], .)), x_1),
             [
               (Any,
@@ -844,7 +897,8 @@ Value
                   ((31,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -860,7 +914,8 @@ Value
                                   ->
                                   .
                                     -[
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ]->
                                     .)),
                         OCaml.List.fold_left2),
@@ -909,7 +964,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           Z.add),
                                       [
                                         Apply
@@ -923,7 +982,11 @@ Value
                                                 Effect
                                                   ([
                                                   ],
-                                                    .)),
+                                                    .
+                                                      ->
+                                                      .
+                                                        ->
+                                                        .)),
                                                 Z.add),
                                             [
                                               Variable
@@ -978,9 +1041,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((fr2, [ A ], [ (x_1, A) ], Type (Z)),
+      ((fr2, [ A ], [ (x_1, A) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (Z))),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument ], .)),
+          ((?, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable ((?, Effect ([ ], .)), x_1),
             [
               (Any,
@@ -988,7 +1052,8 @@ Value
                   ((32,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -1004,7 +1069,8 @@ Value
                                   ->
                                   .
                                     -[
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ]->
                                     .)),
                         OCaml.List.fold_right2),
@@ -1053,7 +1119,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           Z.add),
                                       [
                                         Apply
@@ -1067,7 +1137,11 @@ Value
                                                 Effect
                                                   ([
                                                   ],
-                                                    .)),
+                                                    .
+                                                      ->
+                                                      .
+                                                        ->
+                                                        .)),
                                                 Z.add),
                                             [
                                               Variable
@@ -1125,7 +1199,7 @@ Value
       ((all, [ ], [ ], Type (bool)),
         Apply
           ((35, Effect ([ ], .)),
-            Variable ((35, Effect ([ ], .)), OCaml.List.for_all),
+            Variable ((35, Effect ([ ], . -> . -> .)), OCaml.List.for_all),
             [
               Function
                 ((35, Effect ([ ], . -> .)), x,
@@ -1140,7 +1214,11 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .
+                                  ->
+                                  .)),
                           equiv_decb),
                       [
                         Variable
@@ -1169,7 +1247,7 @@ Value
       ((ex, [ ], [ ], Type (bool)),
         Apply
           ((36, Effect ([ ], .)),
-            Variable ((36, Effect ([ ], .)), OCaml.List._exists),
+            Variable ((36, Effect ([ ], . -> . -> .)), OCaml.List._exists),
             [
               Function
                 ((36, Effect ([ ], . -> .)), x,
@@ -1184,7 +1262,11 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .
+                                  ->
+                                  .)),
                           equiv_decb),
                       [
                         Variable
@@ -1210,9 +1292,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((all2, [ A ], [ (x_1, A) ], Type (bool)),
+      ((all2, [ A ], [ (x_1, A) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (bool))),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument ], .)),
+          ((?, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable ((?, Effect ([ ], .)), x_1),
             [
               (Any,
@@ -1220,7 +1303,8 @@ Value
                   ((37,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -1234,7 +1318,8 @@ Value
                                 ->
                                 .
                                   -[
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ]->
                                   .)),
                         OCaml.List.for_all2),
@@ -1270,7 +1355,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       equiv_decb),
                                   [
                                     Variable
@@ -1310,9 +1399,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((ex2, [ A ], [ (x_1, A) ], Type (bool)),
+      ((ex2, [ A ], [ (x_1, A) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (bool))),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument ], .)),
+          ((?, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable ((?, Effect ([ ], .)), x_1),
             [
               (Any,
@@ -1320,7 +1410,8 @@ Value
                   ((38,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -1334,7 +1425,8 @@ Value
                                 ->
                                 .
                                   -[
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ]->
                                   .)),
                         OCaml.List._exists2),
@@ -1370,7 +1462,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       equiv_decb),
                                   [
                                     Variable
@@ -1413,7 +1509,7 @@ Value
       ((me, [ ], [ ], Type (bool)),
         Apply
           ((39, Effect ([ ], .)),
-            Variable ((39, Effect ([ ], .)), OCaml.List.mem),
+            Variable ((39, Effect ([ ], . -> . -> .)), OCaml.List.mem),
             [
               Constant ((39, Effect ([ ], .)), Int(2));
               Variable ((39, Effect ([ ], .)), l2)
@@ -1424,9 +1520,9 @@ Value
 Value
   (non_rec, @.,
     [
-      ((fin, [ A ], [ (x_1, A) ], Type (Z)),
+      ((fin, [ A ], [ (x_1, A) ], Monad ([ Type (OCaml.Not_found) ], Type (Z))),
         Match
-          ((?, Effect ([ OCaml.Not_found ], .)),
+          ((?, Effect ([ Type (OCaml.Not_found) ], .)),
             Variable ((?, Effect ([ ], .)), x_1),
             [
               (Any,
@@ -1434,7 +1530,8 @@ Value
                   ((43,
                     Effect
                       ([
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Variable
@@ -1446,7 +1543,8 @@ Value
                               ->
                               .
                                 -[
-                                  OCaml.Not_found
+                                  Type
+                                    (OCaml.Not_found)
                                 ]->
                                 .)),
                         OCaml.List.find),
@@ -1471,7 +1569,11 @@ Value
                                   Effect
                                     ([
                                     ],
-                                      .)),
+                                      .
+                                        ->
+                                        .
+                                          ->
+                                          .)),
                                   equiv_decb),
                               [
                                 Variable
@@ -1507,7 +1609,7 @@ Value
       ((fil, [ ], [ ], Type (list, Type (Z))),
         Apply
           ((44, Effect ([ ], .)),
-            Variable ((44, Effect ([ ], .)), OCaml.List.filter),
+            Variable ((44, Effect ([ ], . -> . -> .)), OCaml.List.filter),
             [
               Function
                 ((44, Effect ([ ], . -> .)), x,
@@ -1522,7 +1624,11 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .
+                                  ->
+                                  .)),
                           OCaml.Pervasives.ge),
                       [
                         Variable
@@ -1551,7 +1657,8 @@ Value
       ((fina, [ ], [ ], Type (list, Type (Z))),
         Apply
           ((45, Effect ([ ], .)),
-            Variable ((45, Effect ([ ], .)), OCaml.List.find_all),
+            Variable
+              ((45, Effect ([ ], . -> . -> .)), OCaml.List.find_all),
             [
               Function
                 ((45, Effect ([ ], . -> .)), x,
@@ -1566,7 +1673,11 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .
+                                  ->
+                                  .)),
                           OCaml.Pervasives.ge),
                       [
                         Variable
@@ -1595,7 +1706,8 @@ Value
       ((par, [ ], [ ], (Type (list, Type (Z)) * Type (list, Type (Z)))),
         Apply
           ((46, Effect ([ ], .)),
-            Variable ((46, Effect ([ ], .)), OCaml.List.partition),
+            Variable
+              ((46, Effect ([ ], . -> . -> .)), OCaml.List.partition),
             [
               Function
                 ((46, Effect ([ ], . -> .)), x,
@@ -1610,7 +1722,11 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .
+                                  ->
+                                  .)),
                           OCaml.Pervasives.gt),
                       [
                         Variable
@@ -1636,9 +1752,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((asso, [ A ], [ (x_1, A) ], Type (string)),
+      ((asso, [ A ], [ (x_1, A) ],
+        Monad ([ Type (OCaml.Not_found) ], Type (string))),
         Match
-          ((?, Effect ([ OCaml.Not_found ], .)),
+          ((?, Effect ([ Type (OCaml.Not_found) ], .)),
             Variable ((?, Effect ([ ], .)), x_1),
             [
               (Any,
@@ -1646,7 +1763,8 @@ Value
                   ((49,
                     Effect
                       ([
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Variable
@@ -1658,7 +1776,8 @@ Value
                               ->
                               .
                                 -[
-                                  OCaml.Not_found
+                                  Type
+                                    (OCaml.Not_found)
                                 ]->
                                 .)),
                         OCaml.List.assoc),
@@ -1697,7 +1816,11 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .
+                                ->
+                                .)),
                         OCaml.List.mem_assoc),
                     [
                       Constant
@@ -1734,7 +1857,11 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .
+                                ->
+                                .)),
                         OCaml.List.remove_assoc),
                     [
                       Constant
@@ -1762,7 +1889,7 @@ Value
       ((sp, [ ], [ ], (Type (list, Type (Z)) * Type (list, Type (string)))),
         Apply
           ((57, Effect ([ ], .)),
-            Variable ((57, Effect ([ ], .)), OCaml.List.split),
+            Variable ((57, Effect ([ ], . -> .)), OCaml.List.split),
             [ Variable ((57, Effect ([ ], .)), l3) ]))
     ])
 
@@ -1770,9 +1897,12 @@ Value
 Value
   (non_rec, @.,
     [
-      ((com, [ A ], [ (x_1, A) ], Type (list, (Type (Z) * Type (Z)))),
+      ((com, [ A ], [ (x_1, A) ],
+        Monad
+          ([ Type (OCaml.Invalid_argument) ],
+            Type (list, (Type (Z) * Type (Z))))),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument ], .)),
+          ((?, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable ((?, Effect ([ ], .)), x_1),
             [
               (Any,
@@ -1780,7 +1910,8 @@ Value
                   ((58,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -1792,7 +1923,8 @@ Value
                               ->
                               .
                                 -[
-                                  OCaml.Invalid_argument
+                                  Type
+                                    (OCaml.Invalid_argument)
                                 ]->
                                 .)),
                         OCaml.List.combine),
@@ -1819,9 +1951,11 @@ Value
 Value
   (non_rec, @.,
     [
-      ((so, [ A ], [ (x_1, A) ], Type (list, Type (Z))),
+      ((so, [ A ], [ (x_1, A) ],
+        Monad
+          ([ Type (Counter); Type (NonTermination) ], Type (list, Type (Z)))),
         Match
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), x_1),
             [
               (Any,
@@ -1829,8 +1963,10 @@ Value
                   ((61,
                     Effect
                       ([
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -1842,8 +1978,10 @@ Value
                               ->
                               .
                                 -[
-                                  Counter;
-                                  NonTermination
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination)
                                 ]->
                                 .)),
                         OCaml.List.sort),
@@ -1879,7 +2017,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       Z.sub),
                                   [
                                     Variable
@@ -1912,9 +2054,11 @@ Value
 Value
   (non_rec, @.,
     [
-      ((sso, [ A ], [ (x_1, A) ], Type (list, Type (Z))),
+      ((sso, [ A ], [ (x_1, A) ],
+        Monad
+          ([ Type (Counter); Type (NonTermination) ], Type (list, Type (Z)))),
         Match
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), x_1),
             [
               (Any,
@@ -1922,8 +2066,10 @@ Value
                   ((62,
                     Effect
                       ([
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -1935,8 +2081,10 @@ Value
                               ->
                               .
                                 -[
-                                  Counter;
-                                  NonTermination
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination)
                                 ]->
                                 .)),
                         OCaml.List.stable_sort),
@@ -1972,7 +2120,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       Z.sub),
                                   [
                                     Variable
@@ -2005,9 +2157,11 @@ Value
 Value
   (non_rec, @.,
     [
-      ((fso, [ A ], [ (x_1, A) ], Type (list, Type (Z))),
+      ((fso, [ A ], [ (x_1, A) ],
+        Monad
+          ([ Type (Counter); Type (NonTermination) ], Type (list, Type (Z)))),
         Match
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), x_1),
             [
               (Any,
@@ -2015,8 +2169,10 @@ Value
                   ((63,
                     Effect
                       ([
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -2028,8 +2184,10 @@ Value
                               ->
                               .
                                 -[
-                                  Counter;
-                                  NonTermination
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination)
                                 ]->
                                 .)),
                         OCaml.List.fast_sort),
@@ -2065,7 +2223,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       Z.sub),
                                   [
                                     Variable
@@ -2101,7 +2263,8 @@ Value
       ((mer, [ ], [ ], Type (list, Type (Z))),
         Apply
           ((64, Effect ([ ], .)),
-            Variable ((64, Effect ([ ], .)), OCaml.List.merge),
+            Variable
+              ((64, Effect ([ ], . -> . -> . -> .)), OCaml.List.merge),
             [
               Function
                 ((64, Effect ([ ], . -> . -> .)), x,
@@ -2125,7 +2288,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               Z.sub),
                           [
                             Variable

--- a/tests/ex25.monadise
+++ b/tests/ex25.monadise
@@ -56,7 +56,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((h, [ A ], [ (x, A) ], Monad ([ OCaml.Failure ], Type (Z))),
+      ((h, [ A ], [ (x, A) ], Monad ([ Type (OCaml.Failure) ], Type (Z))),
         Match
           (?, Variable (?, x),
             [
@@ -78,7 +78,8 @@ Value
 Value
   (non_rec, @.,
     [
-      ((t, [ A ], [ (x, A) ], Monad ([ OCaml.Failure ], Type (list, Type (Z)))),
+      ((t, [ A ], [ (x, A) ],
+        Monad ([ Type (OCaml.Failure) ], Type (list, Type (Z)))),
         Match
           (?, Variable (?, x),
             [
@@ -101,7 +102,8 @@ Value
   (non_rec, @.,
     [
       ((x, [ A ], [ (x, A) ],
-        Monad ([ OCaml.Failure; OCaml.Invalid_argument ], Type (Z))),
+        Monad
+          ([ Type (OCaml.Failure); Type (OCaml.Invalid_argument) ], Type (Z))),
         Match
           (?, Variable (?, x),
             [
@@ -369,7 +371,7 @@ Value
   (non_rec, @.,
     [
       ((m2, [ A ], [ (x_1, A) ],
-        Monad ([ OCaml.Invalid_argument ], Type (list, Type (Z)))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (list, Type (Z)))),
         Match
           (?, Variable (?, x_1),
             [
@@ -414,7 +416,7 @@ Value
   (non_rec, @.,
     [
       ((rm2, [ A ], [ (x_1, A) ],
-        Monad ([ OCaml.Invalid_argument ], Type (list, Type (Z)))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (list, Type (Z)))),
         Match
           (?, Variable (?, x_1),
             [
@@ -458,7 +460,8 @@ Value
 Value
   (non_rec, @.,
     [
-      ((fl2, [ A ], [ (x_1, A) ], Monad ([ OCaml.Invalid_argument ], Type (Z))),
+      ((fl2, [ A ], [ (x_1, A) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (Z))),
         Match
           (?, Variable (?, x_1),
             [
@@ -518,7 +521,8 @@ Value
 Value
   (non_rec, @.,
     [
-      ((fr2, [ A ], [ (x_1, A) ], Monad ([ OCaml.Invalid_argument ], Type (Z))),
+      ((fr2, [ A ], [ (x_1, A) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (Z))),
         Match
           (?, Variable (?, x_1),
             [
@@ -633,7 +637,7 @@ Value
   (non_rec, @.,
     [
       ((all2, [ A ], [ (x_1, A) ],
-        Monad ([ OCaml.Invalid_argument ], Type (bool))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (bool))),
         Match
           (?, Variable (?, x_1),
             [
@@ -678,7 +682,7 @@ Value
   (non_rec, @.,
     [
       ((ex2, [ A ], [ (x_1, A) ],
-        Monad ([ OCaml.Invalid_argument ], Type (bool))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (bool))),
         Match
           (?, Variable (?, x_1),
             [
@@ -732,7 +736,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((fin, [ A ], [ (x_1, A) ], Monad ([ OCaml.Not_found ], Type (Z))),
+      ((fin, [ A ], [ (x_1, A) ], Monad ([ Type (OCaml.Not_found) ], Type (Z))),
         Match
           (?, Variable (?, x_1),
             [
@@ -851,7 +855,8 @@ Value
 Value
   (non_rec, @.,
     [
-      ((asso, [ A ], [ (x_1, A) ], Monad ([ OCaml.Not_found ], Type (string))),
+      ((asso, [ A ], [ (x_1, A) ],
+        Monad ([ Type (OCaml.Not_found) ], Type (string))),
         Match
           (?, Variable (?, x_1),
             [
@@ -935,7 +940,9 @@ Value
   (non_rec, @.,
     [
       ((com, [ A ], [ (x_1, A) ],
-        Monad ([ OCaml.Invalid_argument ], Type (list, (Type (Z) * Type (Z))))),
+        Monad
+          ([ Type (OCaml.Invalid_argument) ],
+            Type (list, (Type (Z) * Type (Z))))),
         Match
           (?, Variable (?, x_1),
             [
@@ -961,7 +968,8 @@ Value
   (non_rec, @.,
     [
       ((so, [ A ], [ (x_1, A) ],
-        Monad ([ Counter; NonTermination ], Type (list, Type (Z)))),
+        Monad
+          ([ Type (Counter); Type (NonTermination) ], Type (list, Type (Z)))),
         Match
           (?, Variable (?, x_1),
             [
@@ -1003,7 +1011,8 @@ Value
   (non_rec, @.,
     [
       ((sso, [ A ], [ (x_1, A) ],
-        Monad ([ Counter; NonTermination ], Type (list, Type (Z)))),
+        Monad
+          ([ Type (Counter); Type (NonTermination) ], Type (list, Type (Z)))),
         Match
           (?, Variable (?, x_1),
             [
@@ -1045,7 +1054,8 @@ Value
   (non_rec, @.,
     [
       ((fso, [ A ], [ (x_1, A) ],
-        Monad ([ Counter; NonTermination ], Type (list, Type (Z)))),
+        Monad
+          ([ Type (Counter); Type (NonTermination) ], Type (list, Type (Z)))),
         Match
           (?, Variable (?, x_1),
             [

--- a/tests/ex26.effects
+++ b/tests/ex26.effects
@@ -22,7 +22,9 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .)),
                             f),
                         [
                           Variable
@@ -56,7 +58,9 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .)),
                               f);
                           Variable
                             ((6,
@@ -75,9 +79,9 @@ Value
     [
       ((f_map2_rec, [ A; B ],
         [ (counter, Type (nat)); (f, (A -> B)); (l, Type (list, A)) ],
-        Type (list, B)),
+        Monad ([ Type (NonTermination) ], Type (list, B))),
         Match
-          ((?, Effect ([ NonTermination ], .)),
+          ((?, Effect ([ Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), counter),
             [
               (Constructor (O),
@@ -85,7 +89,8 @@ Value
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -95,7 +100,8 @@ Value
                           ],
                             .
                               -[
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         not_terminated),
@@ -112,7 +118,8 @@ Value
                   ((10,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -140,7 +147,8 @@ Value
                           ((12,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             cons,
@@ -155,7 +163,9 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .)),
                                     f),
                                 [
                                   Variable
@@ -170,7 +180,8 @@ Value
                               ((12,
                                 Effect
                                   ([
-                                    NonTermination
+                                    Type
+                                      (NonTermination)
                                   ],
                                     .)),
                                 Apply
@@ -182,7 +193,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              NonTermination
+                                              Type
+                                                (NonTermination)
                                             ]->
                                             .)),
                                     Variable
@@ -196,7 +208,8 @@ Value
                                                 ->
                                                 .
                                                   -[
-                                                    NonTermination
+                                                    Type
+                                                      (NonTermination)
                                                   ]->
                                                   .)),
                                         f_map2_rec),
@@ -215,7 +228,9 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .)),
                                       f);
                                   Variable
                                     ((12,
@@ -233,15 +248,18 @@ Value
 Value
   (non_rec, @.,
     [
-      ((f_map2, [ A; B ], [ (f, (A -> B)); (l, Type (list, A)) ], Type (list, B)),
+      ((f_map2, [ A; B ], [ (f, (A -> B)); (l, Type (list, A)) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (list, B))),
         Apply
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable
-              ((?, Effect ([ ], . -> . -> . -[ NonTermination ]-> .)),
+              ((?,
+                Effect
+                  ([ ], . -> . -> . -[ Type (NonTermination) ]-> .)),
                 f_map2_rec),
             [
               Apply
-                ((?, Effect ([ Counter ], .)),
+                ((?, Effect ([ Type (Counter) ], .)),
                   Variable
                     ((?,
                       Effect
@@ -249,7 +267,8 @@ Value
                         ],
                           .
                             -[
-                              Counter
+                              Type
+                                (Counter)
                             ]->
                             .)),
                       read_counter),
@@ -261,7 +280,7 @@ Value
                           ],
                             .)))
                   ]);
-              Variable ((?, Effect ([ ], .)), f);
+              Variable ((?, Effect ([ ], . -> .)), f);
               Variable ((?, Effect ([ ], .)), l)
             ]))
     ])
@@ -310,7 +329,11 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .
+                                        ->
+                                        .)),
                                 Z.add),
                             [
                               Variable
@@ -402,9 +425,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((n2, [ A ], [ (x, A) ], Type (Z)),
+      ((n2, [ A ], [ (x, A) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (Z))),
         Match
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Any,
@@ -412,8 +436,10 @@ Value
                   (23,
                     Effect
                       ([
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .))
                   (rec, @.,
@@ -431,13 +457,19 @@ Value
                                 Type
                                   (Z)))
                         ],
-                        Type
-                          (Z)),
+                        Monad
+                          ([
+                            Type
+                              (NonTermination)
+                          ],
+                            Type
+                              (Z))),
                         Match
                           ((?,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Variable
@@ -454,7 +486,8 @@ Value
                                   ((?,
                                     Effect
                                       ([
-                                        NonTermination
+                                        Type
+                                          (NonTermination)
                                       ],
                                         .)),
                                     Variable
@@ -464,7 +497,8 @@ Value
                                           ],
                                             .
                                               -[
-                                                NonTermination
+                                                Type
+                                                  (NonTermination)
                                               ]->
                                               .)),
                                         not_terminated),
@@ -483,7 +517,8 @@ Value
                                   ((24,
                                     Effect
                                       ([
-                                        NonTermination
+                                        Type
+                                          (NonTermination)
                                       ],
                                         .)),
                                     Variable
@@ -511,7 +546,8 @@ Value
                                           ((26,
                                             Effect
                                               ([
-                                                NonTermination
+                                                Type
+                                                  (NonTermination)
                                               ],
                                                 .)),
                                             Variable
@@ -519,7 +555,11 @@ Value
                                                 Effect
                                                   ([
                                                   ],
-                                                    .)),
+                                                    .
+                                                      ->
+                                                      .
+                                                        ->
+                                                        .)),
                                                 Z.add),
                                             [
                                               Variable
@@ -533,7 +573,8 @@ Value
                                                 ((26,
                                                   Effect
                                                     ([
-                                                      NonTermination
+                                                      Type
+                                                        (NonTermination)
                                                     ],
                                                       .)),
                                                   Apply
@@ -543,7 +584,8 @@ Value
                                                         ],
                                                           .
                                                             -[
-                                                              NonTermination
+                                                              Type
+                                                                (NonTermination)
                                                             ]->
                                                             .)),
                                                       Variable
@@ -555,7 +597,8 @@ Value
                                                                 ->
                                                                 .
                                                                   -[
-                                                                    NonTermination
+                                                                    Type
+                                                                      (NonTermination)
                                                                   ]->
                                                                   .)),
                                                           sum_rec),
@@ -586,8 +629,10 @@ Value
                   (23,
                     Effect
                       ([
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .))
                   (non_rec, @.,
@@ -604,14 +649,23 @@ Value
                                 Type
                                   (Z)))
                         ],
-                        Type
-                          (Z)),
+                        Monad
+                          ([
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination)
+                          ],
+                            Type
+                              (Z))),
                         Apply
                           ((?,
                             Effect
                               ([
-                                Counter;
-                                NonTermination
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Variable
@@ -623,7 +677,8 @@ Value
                                       ->
                                       .
                                         -[
-                                          NonTermination
+                                          Type
+                                            (NonTermination)
                                         ]->
                                         .)),
                                 sum_rec),
@@ -632,7 +687,8 @@ Value
                                 ((?,
                                   Effect
                                     ([
-                                      Counter
+                                      Type
+                                        (Counter)
                                     ],
                                       .)),
                                   Variable
@@ -642,7 +698,8 @@ Value
                                         ],
                                           .
                                             -[
-                                              Counter
+                                              Type
+                                                (Counter)
                                             ]->
                                             .)),
                                       read_counter),
@@ -668,8 +725,10 @@ Value
                   ((27,
                     Effect
                       ([
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -679,8 +738,10 @@ Value
                           ],
                             .
                               -[
-                                Counter;
-                                NonTermination
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         sum_1),

--- a/tests/ex26.monadise
+++ b/tests/ex26.monadise
@@ -42,7 +42,7 @@ Value
     [
       ((f_map2_rec, [ A; B ],
         [ (counter, Type (nat)); (f, (A -> B)); (l, Type (list, A)) ],
-        Monad ([ NonTermination ], Type (list, B))),
+        Monad ([ Type (NonTermination) ], Type (list, B))),
         Match
           (?, Variable (?, counter),
             [
@@ -122,15 +122,17 @@ Value
   (non_rec, @.,
     [
       ((f_map2, [ A; B ], [ (f, (A -> B)); (l, Type (list, A)) ],
-        Monad ([ Counter; NonTermination ], Type (list, B))),
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (list, B))),
         Bind
           (?,
             Lift
-              (?, [ Counter ], [ Counter; NonTermination ],
+              (?, [ Type (Counter) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply (?, Variable (?, read_counter), [ Tuple (?) ])),
             Some x,
             Lift
-              (?, [ NonTermination ], [ Counter; NonTermination ],
+              (?, [ Type (NonTermination) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply
                   (?, Variable (?, f_map2_rec),
                     [
@@ -211,7 +213,8 @@ Value
 Value
   (non_rec, @.,
     [
-      ((n2, [ A ], [ (x, A) ], Monad ([ Counter; NonTermination ], Type (Z))),
+      ((n2, [ A ], [ (x, A) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (Z))),
         Match
           (?, Variable (?, x),
             [
@@ -234,7 +237,8 @@ Value
                         ],
                         Monad
                           ([
-                            NonTermination
+                            Type
+                              (NonTermination)
                           ],
                             Type
                               (Z))),
@@ -332,8 +336,10 @@ Value
                         ],
                         Monad
                           ([
-                            Counter;
-                            NonTermination
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination)
                           ],
                             Type
                               (Z))),
@@ -342,11 +348,14 @@ Value
                             Lift
                               (?,
                                 [
-                                  Counter
+                                  Type
+                                    (Counter)
                                 ],
                                 [
-                                  Counter;
-                                  NonTermination
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination)
                                 ],
                                 Apply
                                   (?,
@@ -362,11 +371,14 @@ Value
                             Lift
                               (?,
                                 [
-                                  NonTermination
+                                  Type
+                                    (NonTermination)
                                 ],
                                 [
-                                  Counter;
-                                  NonTermination
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination)
                                 ],
                                 Apply
                                   (?,

--- a/tests/ex27.effects
+++ b/tests/ex27.effects
@@ -33,7 +33,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               Z.add),
                           [
                             Variable
@@ -80,9 +84,9 @@ Value
 Value
   (non_rec, @.,
     [
-      ((hd, [ A ], [ (x, Type (list, A)) ], A),
+      ((hd, [ A ], [ (x, Type (list, A)) ], Monad ([ Type (OCaml.Failure) ], A)),
         Match
-          ((?, Effect ([ OCaml.Failure ], .)),
+          ((?, Effect ([ Type (OCaml.Failure) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor ([]),
@@ -90,7 +94,8 @@ Value
                   ((24,
                     Effect
                       ([
-                        OCaml.Failure
+                        Type
+                          (OCaml.Failure)
                       ],
                         .)),
                     Variable
@@ -100,7 +105,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Failure
+                                Type
+                                  (OCaml.Failure)
                               ]->
                               .)),
                         OCaml.Pervasives.failwith),
@@ -122,9 +128,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((tl, [ A ], [ (x, Type (list, A)) ], Type (list, A)),
+      ((tl, [ A ], [ (x, Type (list, A)) ],
+        Monad ([ Type (OCaml.Failure) ], Type (list, A))),
         Match
-          ((?, Effect ([ OCaml.Failure ], .)),
+          ((?, Effect ([ Type (OCaml.Failure) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor ([]),
@@ -132,7 +139,8 @@ Value
                   ((28,
                     Effect
                       ([
-                        OCaml.Failure
+                        Type
+                          (OCaml.Failure)
                       ],
                         .)),
                     Variable
@@ -142,7 +150,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Failure
+                                Type
+                                  (OCaml.Failure)
                               ]->
                               .)),
                         OCaml.Pervasives.failwith),
@@ -164,29 +173,36 @@ Value
 Value
   (non_rec, @.,
     [
-      ((nth, [ A ], [ (l, Type (list, A)); (n, Type (Z)) ], A),
+      ((nth, [ A ], [ (l, Type (list, A)); (n, Type (Z)) ],
+        Monad ([ Type (OCaml.Failure); Type (OCaml.Invalid_argument) ], A)),
         IfThenElse
-          ((32, Effect ([ OCaml.Failure; OCaml.Invalid_argument ], .)),
+          ((32,
+            Effect
+              ([ Type (OCaml.Failure); Type (OCaml.Invalid_argument) ],
+                .)),
             Apply
               ((32, Effect ([ ], .)),
-                Variable ((32, Effect ([ ], .)), OCaml.Pervasives.lt),
+                Variable
+                  ((32, Effect ([ ], . -> . -> .)),
+                    OCaml.Pervasives.lt),
                 [
                   Variable ((32, Effect ([ ], .)), n);
                   Constant ((32, Effect ([ ], .)), Int(0))
                 ]),
             Apply
-              ((32, Effect ([ OCaml.Invalid_argument ], .)),
+              ((32, Effect ([ Type (OCaml.Invalid_argument) ], .)),
                 Variable
                   ((32,
                     Effect
-                      ([ ], . -[ OCaml.Invalid_argument ]-> .)),
-                    OCaml.Pervasives.invalid_arg),
+                      ([ ],
+                        . -[ Type (OCaml.Invalid_argument) ]->
+                          .)), OCaml.Pervasives.invalid_arg),
                 [
                   Constant
                     ((32, Effect ([ ], .)),
                       String("List.nth"))
                 ]),
-            LetFun (33, Effect ([ OCaml.Failure ], .))
+            LetFun (33, Effect ([ Type (OCaml.Failure) ], .))
               (rec, @coq_rec,
                 [
                   ((nth_aux_coq_rec, [ B ],
@@ -198,12 +214,19 @@ Value
                       (n,
                         Type
                           (Z))
-                    ], B),
+                    ],
+                    Monad
+                      ([
+                        Type
+                          (OCaml.Failure)
+                      ],
+                        B)),
                     Match
                       ((34,
                         Effect
                           ([
-                            OCaml.Failure
+                            Type
+                              (OCaml.Failure)
                           ],
                             .)),
                         Variable
@@ -220,7 +243,8 @@ Value
                               ((35,
                                 Effect
                                   ([
-                                    OCaml.Failure
+                                    Type
+                                      (OCaml.Failure)
                                   ],
                                     .)),
                                 Variable
@@ -230,7 +254,8 @@ Value
                                       ],
                                         .
                                           -[
-                                            OCaml.Failure
+                                            Type
+                                              (OCaml.Failure)
                                           ]->
                                           .)),
                                     OCaml.Pervasives.failwith),
@@ -251,7 +276,8 @@ Value
                               ((36,
                                 Effect
                                   ([
-                                    OCaml.Failure
+                                    Type
+                                      (OCaml.Failure)
                                   ],
                                     .)),
                                 Apply
@@ -265,7 +291,11 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         equiv_decb),
                                     [
                                       Variable
@@ -294,7 +324,8 @@ Value
                                   ((36,
                                     Effect
                                       ([
-                                        OCaml.Failure
+                                        Type
+                                          (OCaml.Failure)
                                       ],
                                         .)),
                                     Variable
@@ -306,7 +337,8 @@ Value
                                               ->
                                               .
                                                 -[
-                                                  OCaml.Failure
+                                                  Type
+                                                    (OCaml.Failure)
                                                 ]->
                                                 .)),
                                         nth_aux_coq_rec),
@@ -329,7 +361,11 @@ Value
                                               Effect
                                                 ([
                                                 ],
-                                                  .)),
+                                                  .
+                                                    ->
+                                                    .
+                                                      ->
+                                                      .)),
                                               Z.sub),
                                           [
                                             Variable
@@ -351,9 +387,11 @@ Value
                         ]))
                 ]) in
             Apply
-              ((37, Effect ([ OCaml.Failure ], .)),
+              ((37, Effect ([ Type (OCaml.Failure) ], .)),
                 Variable
-                  ((37, Effect ([ ], . -> . -[ OCaml.Failure ]-> .)),
+                  ((37,
+                    Effect
+                      ([ ], . -> . -[ Type (OCaml.Failure) ]-> .)),
                     nth_aux_coq_rec),
                 [
                   Variable ((37, Effect ([ ], .)), l);
@@ -367,7 +405,7 @@ Value
     [
       ((append, [ A ], [ ],
         (Type (list, A) -> (Type (list, A) -> Type (list, A)))),
-        Variable ((39, Effect ([ ], .)), OCaml.Pervasives.app))
+        Variable ((39, Effect ([ ], . -> . -> .)), OCaml.Pervasives.app))
     ])
 
 41
@@ -459,7 +497,11 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .
+                                ->
+                                .)),
                         OCaml.Pervasives.app),
                     [
                       Variable
@@ -528,7 +570,9 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .)),
                           f),
                       [
                         Variable
@@ -573,7 +617,9 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .)),
                               f);
                           Variable
                             ((58,
@@ -611,7 +657,11 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .
+                                  ->
+                                  .)),
                           f),
                       [
                         Variable
@@ -671,7 +721,11 @@ Value
                                   Effect
                                     ([
                                     ],
-                                      .)),
+                                      .
+                                        ->
+                                        .
+                                          ->
+                                          .)),
                                   Z.add),
                               [
                                 Variable
@@ -694,7 +748,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               f);
                           Variable
                             ((63,
@@ -718,7 +776,7 @@ Value
             Variable ((66, Effect ([ ], . -> . -> . -> .)), mapi_aux),
             [
               Constant ((66, Effect ([ ], .)), Int(0));
-              Variable ((66, Effect ([ ], .)), f);
+              Variable ((66, Effect ([ ], . -> . -> .)), f);
               Variable ((66, Effect ([ ], .)), l)
             ]))
     ])
@@ -796,7 +854,9 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .)),
                                           f),
                                       [
                                         Variable
@@ -857,7 +917,9 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .)),
                             f),
                         [
                           Variable
@@ -891,7 +953,9 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .)),
                               f);
                           Variable
                             ((76,
@@ -930,7 +994,11 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .
+                                    ->
+                                    .)),
                             f),
                         [
                           Variable
@@ -979,7 +1047,11 @@ Value
                                   Effect
                                     ([
                                     ],
-                                      .)),
+                                      .
+                                        ->
+                                        .
+                                          ->
+                                          .)),
                                   Z.add),
                               [
                                 Variable
@@ -1002,7 +1074,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               f);
                           Variable
                             ((81,
@@ -1026,7 +1102,7 @@ Value
             Variable ((84, Effect ([ ], . -> . -> . -> .)), iteri_aux),
             [
               Constant ((84, Effect ([ ], .)), Int(0));
-              Variable ((84, Effect ([ ], .)), f);
+              Variable ((84, Effect ([ ], . -> . -> .)), f);
               Variable ((84, Effect ([ ], .)), l)
             ]))
     ])
@@ -1063,7 +1139,11 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .
+                                  ->
+                                  .)),
                           f);
                       Apply
                         ((89,
@@ -1076,7 +1156,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               f),
                           [
                             Variable
@@ -1123,7 +1207,11 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .
+                                ->
+                                .)),
                         f),
                     [
                       Variable
@@ -1158,7 +1246,11 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .
+                                        ->
+                                        .)),
                                 f);
                             Variable
                               ((95,
@@ -1185,9 +1277,9 @@ Value
     [
       ((map2, [ A; B; C ],
         [ (f, (A -> (B -> C))); (l1, Type (list, A)); (l2, Type (list, B)) ],
-        Type (list, C)),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (list, C))),
         Match
-          ((99, Effect ([ OCaml.Invalid_argument ], .)),
+          ((99, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Tuple
               ((99, Effect ([ ], .)),
                 Variable ((99, Effect ([ ], .)), l1),
@@ -1205,7 +1297,8 @@ Value
                   (101,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .))
                   r =
@@ -1220,7 +1313,11 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .
+                                  ->
+                                  .)),
                           f),
                       [
                         Variable
@@ -1243,7 +1340,8 @@ Value
                   ((101,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     cons,
@@ -1258,7 +1356,8 @@ Value
                       ((101,
                         Effect
                           ([
-                            OCaml.Invalid_argument
+                            Type
+                              (OCaml.Invalid_argument)
                           ],
                             .)),
                         Variable
@@ -1272,7 +1371,8 @@ Value
                                     ->
                                     .
                                       -[
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ]->
                                       .)),
                             map2),
@@ -1282,7 +1382,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               f);
                           Variable
                             ((101,
@@ -1304,7 +1408,8 @@ Value
                   ((102,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -1314,7 +1419,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ]->
                               .)),
                         OCaml.Pervasives.invalid_arg),
@@ -1336,8 +1442,8 @@ Value
     [
       ((rev_map2, [ A; B; C ],
         [ (f, (A -> (B -> C))); (l1, Type (list, A)); (l2, Type (list, B)) ],
-        Type (list, C)),
-        LetFun (106, Effect ([ OCaml.Invalid_argument ], .))
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (list, C))),
+        LetFun (106, Effect ([ Type (OCaml.Invalid_argument) ], .))
           (rec, @coq_rec,
             [
               ((rmap2_f_coq_rec, [ ],
@@ -1345,12 +1451,18 @@ Value
                   (accu, Type (list, C));
                   (l1, Type (list, A));
                   (l2, Type (list, B))
-                ], Type (list, C)),
+                ],
+                Monad
+                  ([
+                    Type
+                      (OCaml.Invalid_argument)
+                  ], Type (list, C))),
                 Match
                   ((107,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Tuple
@@ -1399,7 +1511,8 @@ Value
                           ((109,
                             Effect
                               ([
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Variable
@@ -1413,7 +1526,8 @@ Value
                                         ->
                                         .
                                           -[
-                                            OCaml.Invalid_argument
+                                            Type
+                                              (OCaml.Invalid_argument)
                                           ]->
                                           .)),
                                 rmap2_f_coq_rec),
@@ -1436,7 +1550,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           f),
                                       [
                                         Variable
@@ -1483,7 +1601,8 @@ Value
                           ((110,
                             Effect
                               ([
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Variable
@@ -1493,7 +1612,8 @@ Value
                                   ],
                                     .
                                       -[
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ]->
                                       .)),
                                 OCaml.Pervasives.invalid_arg),
@@ -1509,12 +1629,15 @@ Value
                     ]))
             ]) in
         Apply
-          ((111, Effect ([ OCaml.Invalid_argument ], .)),
+          ((111, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable
               ((111,
                 Effect
-                  ([ ], . -> . -> . -[ OCaml.Invalid_argument ]-> .)),
-                rmap2_f_coq_rec),
+                  ([ ],
+                    . ->
+                      . ->
+                        . -[ Type (OCaml.Invalid_argument) ]->
+                          .)), rmap2_f_coq_rec),
             [
               Constructor ((111, Effect ([ ], .)), []);
               Variable ((111, Effect ([ ], .)), l1);
@@ -1528,9 +1651,9 @@ Value
     [
       ((iter2, [ A; B; C ],
         [ (f, (A -> (B -> C))); (l1, Type (list, A)); (l2, Type (list, B)) ],
-        Type (unit)),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (unit))),
         Match
-          ((114, Effect ([ OCaml.Invalid_argument ], .)),
+          ((114, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Tuple
               ((114, Effect ([ ], .)),
                 Variable ((114, Effect ([ ], .)), l1),
@@ -1548,7 +1671,8 @@ Value
                   ((116,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Apply
@@ -1562,7 +1686,11 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .
+                                    ->
+                                    .)),
                             f),
                         [
                           Variable
@@ -1584,7 +1712,8 @@ Value
                       ((116,
                         Effect
                           ([
-                            OCaml.Invalid_argument
+                            Type
+                              (OCaml.Invalid_argument)
                           ],
                             .)),
                         Variable
@@ -1598,7 +1727,8 @@ Value
                                     ->
                                     .
                                       -[
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ]->
                                       .)),
                             iter2),
@@ -1608,7 +1738,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               f);
                           Variable
                             ((116,
@@ -1630,7 +1764,8 @@ Value
                   ((117,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -1640,7 +1775,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ]->
                               .)),
                         OCaml.Pervasives.invalid_arg),
@@ -1666,9 +1802,9 @@ Value
           (accu, A);
           (l1, Type (list, B));
           (l2, Type (list, C))
-        ], A),
+        ], Monad ([ Type (OCaml.Invalid_argument) ], A)),
         Match
-          ((121, Effect ([ OCaml.Invalid_argument ], .)),
+          ((121, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Tuple
               ((121, Effect ([ ], .)),
                 Variable ((121, Effect ([ ], .)), l1),
@@ -1686,7 +1822,8 @@ Value
                   ((123,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -1702,7 +1839,8 @@ Value
                                   ->
                                   .
                                     -[
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ]->
                                     .)),
                         fold_left2),
@@ -1712,7 +1850,13 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .
+                                  ->
+                                  .
+                                    ->
+                                    .)),
                           f);
                       Apply
                         ((123,
@@ -1725,7 +1869,13 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .
+                                        ->
+                                        .)),
                               f),
                           [
                             Variable
@@ -1770,7 +1920,8 @@ Value
                   ((124,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -1780,7 +1931,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ]->
                               .)),
                         OCaml.Pervasives.invalid_arg),
@@ -1806,9 +1958,9 @@ Value
           (l1, Type (list, A));
           (l2, Type (list, B));
           (accu, C)
-        ], C),
+        ], Monad ([ Type (OCaml.Invalid_argument) ], C)),
         Match
-          ((128, Effect ([ OCaml.Invalid_argument ], .)),
+          ((128, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Tuple
               ((128, Effect ([ ], .)),
                 Variable ((128, Effect ([ ], .)), l1),
@@ -1826,7 +1978,8 @@ Value
                   ((130,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -1834,7 +1987,13 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .
+                                ->
+                                .
+                                  ->
+                                  .)),
                         f),
                     [
                       Variable
@@ -1855,7 +2014,8 @@ Value
                         ((130,
                           Effect
                             ([
-                              OCaml.Invalid_argument
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                               .)),
                           Variable
@@ -1871,7 +2031,8 @@ Value
                                         ->
                                         .
                                           -[
-                                            OCaml.Invalid_argument
+                                            Type
+                                              (OCaml.Invalid_argument)
                                           ]->
                                           .)),
                               fold_right2),
@@ -1881,7 +2042,13 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .
+                                        ->
+                                        .
+                                          ->
+                                          .)),
                                 f);
                             Variable
                               ((130,
@@ -1911,7 +2078,8 @@ Value
                   ((131,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -1921,7 +2089,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ]->
                               .)),
                         OCaml.Pervasives.invalid_arg),
@@ -1958,7 +2127,11 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .
+                                ->
+                                .)),
                         andb),
                     [
                       Apply
@@ -1972,7 +2145,9 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .)),
                               p),
                           [
                             Variable
@@ -2006,7 +2181,9 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .)),
                                 p);
                             Variable
                               ((136,
@@ -2041,7 +2218,11 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .
+                                ->
+                                .)),
                         orb),
                     [
                       Apply
@@ -2055,7 +2236,9 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .)),
                               p),
                           [
                             Variable
@@ -2089,7 +2272,9 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .)),
                                 p);
                             Variable
                               ((141,
@@ -2112,9 +2297,9 @@ Value
           (p, (A -> (B -> Type (bool))));
           (l1, Type (list, A));
           (l2, Type (list, B))
-        ], Type (bool)),
+        ], Monad ([ Type (OCaml.Invalid_argument) ], Type (bool))),
         Match
-          ((145, Effect ([ OCaml.Invalid_argument ], .)),
+          ((145, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Tuple
               ((145, Effect ([ ], .)),
                 Variable ((145, Effect ([ ], .)), l1),
@@ -2134,7 +2319,8 @@ Value
                   ((147,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -2142,7 +2328,11 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .
+                                ->
+                                .)),
                         andb),
                     [
                       Apply
@@ -2156,7 +2346,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               p),
                           [
                             Variable
@@ -2178,7 +2372,8 @@ Value
                         ((147,
                           Effect
                             ([
-                              OCaml.Invalid_argument
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                               .)),
                           Variable
@@ -2192,7 +2387,8 @@ Value
                                       ->
                                       .
                                         -[
-                                          OCaml.Invalid_argument
+                                          Type
+                                            (OCaml.Invalid_argument)
                                         ]->
                                         .)),
                               for_all2),
@@ -2202,7 +2398,11 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .
+                                        ->
+                                        .)),
                                 p);
                             Variable
                               ((147,
@@ -2225,7 +2425,8 @@ Value
                   ((148,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -2235,7 +2436,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ]->
                               .)),
                         OCaml.Pervasives.invalid_arg),
@@ -2260,9 +2462,9 @@ Value
           (p, (A -> (B -> Type (bool))));
           (l1, Type (list, A));
           (l2, Type (list, B))
-        ], Type (bool)),
+        ], Monad ([ Type (OCaml.Invalid_argument) ], Type (bool))),
         Match
-          ((152, Effect ([ OCaml.Invalid_argument ], .)),
+          ((152, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Tuple
               ((152, Effect ([ ], .)),
                 Variable ((152, Effect ([ ], .)), l1),
@@ -2282,7 +2484,8 @@ Value
                   ((154,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -2290,7 +2493,11 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .
+                                ->
+                                .)),
                         orb),
                     [
                       Apply
@@ -2304,7 +2511,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               p),
                           [
                             Variable
@@ -2326,7 +2537,8 @@ Value
                         ((154,
                           Effect
                             ([
-                              OCaml.Invalid_argument
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                               .)),
                           Variable
@@ -2340,7 +2552,8 @@ Value
                                       ->
                                       .
                                         -[
-                                          OCaml.Invalid_argument
+                                          Type
+                                            (OCaml.Invalid_argument)
                                         ]->
                                         .)),
                               _exists2),
@@ -2350,7 +2563,11 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .
+                                        ->
+                                        .)),
                                 p);
                             Variable
                               ((154,
@@ -2373,7 +2590,8 @@ Value
                   ((155,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -2383,7 +2601,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ]->
                               .)),
                         OCaml.Pervasives.invalid_arg),
@@ -2403,9 +2622,10 @@ Value
 Value
   (rec, @coq_rec,
     [
-      ((find, [ A ], [ (p, (A -> Type (bool))); (x, Type (list, A)) ], A),
+      ((find, [ A ], [ (p, (A -> Type (bool))); (x, Type (list, A)) ],
+        Monad ([ Type (OCaml.Not_found) ], A)),
         Match
-          ((?, Effect ([ OCaml.Not_found ], .)),
+          ((?, Effect ([ Type (OCaml.Not_found) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor ([]),
@@ -2413,7 +2633,8 @@ Value
                   ((192,
                     Effect
                       ([
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Variable
@@ -2423,7 +2644,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Not_found
+                                Type
+                                  (OCaml.Not_found)
                               ]->
                               .)),
                         OCaml.raise_Not_found),
@@ -2440,7 +2662,8 @@ Value
                   ((193,
                     Effect
                       ([
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Apply
@@ -2454,7 +2677,9 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .)),
                             p),
                         [
                           Variable
@@ -2476,7 +2701,8 @@ Value
                       ((193,
                         Effect
                           ([
-                            OCaml.Not_found
+                            Type
+                              (OCaml.Not_found)
                           ],
                             .)),
                         Variable
@@ -2488,7 +2714,8 @@ Value
                                   ->
                                   .
                                     -[
-                                      OCaml.Not_found
+                                      Type
+                                        (OCaml.Not_found)
                                     ]->
                                     .)),
                             find),
@@ -2498,7 +2725,9 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .)),
                               p);
                           Variable
                             ((193,
@@ -2582,7 +2811,9 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .)),
                                     p),
                                 [
                                   Variable
@@ -2792,7 +3023,9 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .)),
                                     p),
                                 [
                                   Variable
@@ -3041,9 +3274,9 @@ Value
   (rec, @coq_rec,
     [
       ((combine, [ A; B ], [ (l1, Type (list, A)); (l2, Type (list, B)) ],
-        Type (list, (A * B))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (list, (A * B)))),
         Match
-          ((221, Effect ([ OCaml.Invalid_argument ], .)),
+          ((221, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Tuple
               ((221, Effect ([ ], .)),
                 Variable ((221, Effect ([ ], .)), l1),
@@ -3061,7 +3294,8 @@ Value
                   ((223,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     cons,
@@ -3089,7 +3323,8 @@ Value
                       ((223,
                         Effect
                           ([
-                            OCaml.Invalid_argument
+                            Type
+                              (OCaml.Invalid_argument)
                           ],
                             .)),
                         Variable
@@ -3101,7 +3336,8 @@ Value
                                   ->
                                   .
                                     -[
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ]->
                                     .)),
                             combine),
@@ -3126,7 +3362,8 @@ Value
                   ((224,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -3136,7 +3373,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ]->
                               .)),
                         OCaml.Pervasives.invalid_arg),
@@ -3238,7 +3476,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     OCaml.Pervasives.le),
                                 [
                                   Apply
@@ -3252,7 +3494,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           cmp),
                                       [
                                         Variable
@@ -3317,7 +3563,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           cmp);
                                       Variable
                                         ((235,
@@ -3384,18 +3634,20 @@ Value
 Value
   (rec, @coq_rec,
     [
-      ((chop, [ A ], [ (k, Type (Z)); (l, Type (list, A)) ], Type (list, A)),
+      ((chop, [ A ], [ (k, Type (Z)); (l, Type (list, A)) ],
+        Monad ([ Type (OCaml.Assert_failure) ], Type (list, A))),
         IfThenElse
-          ((241, Effect ([ OCaml.Assert_failure ], .)),
+          ((241, Effect ([ Type (OCaml.Assert_failure) ], .)),
             Apply
               ((241, Effect ([ ], .)),
-                Variable ((241, Effect ([ ], .)), equiv_decb),
+                Variable
+                  ((241, Effect ([ ], . -> . -> .)), equiv_decb),
                 [
                   Variable ((241, Effect ([ ], .)), k);
                   Constant ((241, Effect ([ ], .)), Int(0))
                 ]), Variable ((241, Effect ([ ], .)), l),
             Match
-              ((241, Effect ([ OCaml.Assert_failure ], .)),
+              ((241, Effect ([ Type (OCaml.Assert_failure) ], .)),
                 Variable ((242, Effect ([ ], .)), l),
                 [
                   (Constructor (cons, x, t),
@@ -3403,7 +3655,8 @@ Value
                       ((243,
                         Effect
                           ([
-                            OCaml.Assert_failure
+                            Type
+                              (OCaml.Assert_failure)
                           ],
                             .)),
                         Variable
@@ -3415,7 +3668,8 @@ Value
                                   ->
                                   .
                                     -[
-                                      OCaml.Assert_failure
+                                      Type
+                                        (OCaml.Assert_failure)
                                     ]->
                                     .)),
                             chop),
@@ -3431,7 +3685,11 @@ Value
                                   Effect
                                     ([
                                     ],
-                                      .)),
+                                      .
+                                        ->
+                                        .
+                                          ->
+                                          .)),
                                   Z.sub),
                               [
                                 Variable
@@ -3462,7 +3720,8 @@ Value
                       ((244,
                         Effect
                           ([
-                            OCaml.Assert_failure
+                            Type
+                              (OCaml.Assert_failure)
                           ],
                             .)),
                         Variable
@@ -3472,7 +3731,8 @@ Value
                               ],
                                 .
                                   -[
-                                    OCaml.Assert_failure
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ]->
                                   .)),
                             OCaml.assert),
@@ -3641,7 +3901,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       OCaml.Pervasives.le),
                                   [
                                     Apply
@@ -3655,7 +3919,11 @@ Value
                                             Effect
                                               ([
                                               ],
-                                                .)),
+                                                .
+                                                  ->
+                                                  .
+                                                    ->
+                                                    .)),
                                             StableSort/cmp),
                                         [
                                           Variable
@@ -3708,7 +3976,11 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         StableSort/cmp);
                                     Variable
                                       ((256,
@@ -3960,7 +4232,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       OCaml.Pervasives.gt),
                                   [
                                     Apply
@@ -3974,7 +4250,11 @@ Value
                                             Effect
                                               ([
                                               ],
-                                                .)),
+                                                .
+                                                  ->
+                                                  .
+                                                    ->
+                                                    .)),
                                             StableSort/cmp),
                                         [
                                           Variable
@@ -4027,7 +4307,11 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         StableSort/cmp);
                                     Variable
                                       ((268,
@@ -4137,9 +4421,17 @@ Value
             (cmp, (A -> (A -> Type (Z))));
             (n, Type (Z));
             (l, Type (list, A))
-          ], Type (list, A)),
+          ],
+          Monad
+            ([ Type (NonTermination); Type (OCaml.Assert_failure) ],
+              Type (list, A))),
           Match
-            ((?, Effect ([ NonTermination; OCaml.Assert_failure ], .)),
+            ((?,
+              Effect
+                ([
+                  Type (NonTermination);
+                  Type (OCaml.Assert_failure)
+                ], .)),
               Variable ((?, Effect ([ ], .)), StableSort/counter),
               [
                 (Constructor (O),
@@ -4147,7 +4439,8 @@ Value
                     ((?,
                       Effect
                         ([
-                          NonTermination
+                          Type
+                            (NonTermination)
                         ],
                           .)),
                       Variable
@@ -4157,7 +4450,8 @@ Value
                             ],
                               .
                                 -[
-                                  NonTermination
+                                  Type
+                                    (NonTermination)
                                 ]->
                                 .)),
                           not_terminated),
@@ -4174,8 +4468,10 @@ Value
                     ((274,
                       Effect
                         ([
-                          NonTermination;
-                          OCaml.Assert_failure
+                          Type
+                            (NonTermination);
+                          Type
+                            (OCaml.Assert_failure)
                         ],
                           .)),
                       Tuple
@@ -4225,7 +4521,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       OCaml.Pervasives.le),
                                   [
                                     Apply
@@ -4239,7 +4539,11 @@ Value
                                             Effect
                                               ([
                                               ],
-                                                .)),
+                                                .
+                                                  ->
+                                                  .
+                                                    ->
+                                                    .)),
                                             StableSort/cmp),
                                         [
                                           Variable
@@ -4364,7 +4668,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       OCaml.Pervasives.le),
                                   [
                                     Apply
@@ -4378,7 +4686,11 @@ Value
                                             Effect
                                               ([
                                               ],
-                                                .)),
+                                                .
+                                                  ->
+                                                  .
+                                                    ->
+                                                    .)),
                                             StableSort/cmp),
                                         [
                                           Variable
@@ -4421,7 +4733,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           OCaml.Pervasives.le),
                                       [
                                         Apply
@@ -4435,7 +4751,11 @@ Value
                                                 Effect
                                                   ([
                                                   ],
-                                                    .)),
+                                                    .
+                                                      ->
+                                                      .
+                                                        ->
+                                                        .)),
                                                 StableSort/cmp),
                                             [
                                               Variable
@@ -4527,7 +4847,11 @@ Value
                                               Effect
                                                 ([
                                                 ],
-                                                  .)),
+                                                  .
+                                                    ->
+                                                    .
+                                                      ->
+                                                      .)),
                                               OCaml.Pervasives.le),
                                           [
                                             Apply
@@ -4541,7 +4865,11 @@ Value
                                                     Effect
                                                       ([
                                                       ],
-                                                        .)),
+                                                        .
+                                                          ->
+                                                          .
+                                                            ->
+                                                            .)),
                                                     StableSort/cmp),
                                                 [
                                                   Variable
@@ -4682,7 +5010,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           OCaml.Pervasives.le),
                                       [
                                         Apply
@@ -4696,7 +5028,11 @@ Value
                                                 Effect
                                                   ([
                                                   ],
-                                                    .)),
+                                                    .
+                                                      ->
+                                                      .
+                                                        ->
+                                                        .)),
                                                 StableSort/cmp),
                                             [
                                               Variable
@@ -4788,7 +5124,11 @@ Value
                                               Effect
                                                 ([
                                                 ],
-                                                  .)),
+                                                  .
+                                                    ->
+                                                    .
+                                                      ->
+                                                      .)),
                                               OCaml.Pervasives.le),
                                           [
                                             Apply
@@ -4802,7 +5142,11 @@ Value
                                                     Effect
                                                       ([
                                                       ],
-                                                        .)),
+                                                        .
+                                                          ->
+                                                          .
+                                                            ->
+                                                            .)),
                                                     StableSort/cmp),
                                                 [
                                                   Variable
@@ -4933,8 +5277,10 @@ Value
                             (288,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             n1
@@ -4950,7 +5296,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     Z.div),
                                 [
                                   Variable
@@ -4973,8 +5323,10 @@ Value
                             (289,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             n2
@@ -4990,7 +5342,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     Z.sub),
                                 [
                                   Variable
@@ -5013,8 +5369,10 @@ Value
                             (290,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             l2
@@ -5023,7 +5381,8 @@ Value
                               ((290,
                                 Effect
                                   ([
-                                    OCaml.Assert_failure
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                     .)),
                                 Variable
@@ -5035,7 +5394,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              OCaml.Assert_failure
+                                              Type
+                                                (OCaml.Assert_failure)
                                             ]->
                                             .)),
                                     chop),
@@ -5060,8 +5420,10 @@ Value
                             (291,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             s1
@@ -5070,8 +5432,10 @@ Value
                               ((291,
                                 Effect
                                   ([
-                                    NonTermination;
-                                    OCaml.Assert_failure
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                     .)),
                                 Apply
@@ -5085,8 +5449,10 @@ Value
                                             ->
                                             .
                                               -[
-                                                NonTermination;
-                                                OCaml.Assert_failure
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Assert_failure)
                                               ]->
                                               .)),
                                     Variable
@@ -5102,8 +5468,10 @@ Value
                                                   ->
                                                   .
                                                     -[
-                                                      NonTermination;
-                                                      OCaml.Assert_failure
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Assert_failure)
                                                     ]->
                                                     .)),
                                         StableSort/rev_sort_rec),
@@ -5122,7 +5490,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       StableSort/cmp);
                                   Variable
                                     ((291,
@@ -5144,8 +5516,10 @@ Value
                             (292,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             s2
@@ -5154,8 +5528,10 @@ Value
                               ((292,
                                 Effect
                                   ([
-                                    NonTermination;
-                                    OCaml.Assert_failure
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                     .)),
                                 Apply
@@ -5169,8 +5545,10 @@ Value
                                             ->
                                             .
                                               -[
-                                                NonTermination;
-                                                OCaml.Assert_failure
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Assert_failure)
                                               ]->
                                               .)),
                                     Variable
@@ -5186,8 +5564,10 @@ Value
                                                   ->
                                                   .
                                                     -[
-                                                      NonTermination;
-                                                      OCaml.Assert_failure
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Assert_failure)
                                                     ]->
                                                     .)),
                                         StableSort/rev_sort_rec),
@@ -5206,7 +5586,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       StableSort/cmp);
                                   Variable
                                     ((292,
@@ -5251,7 +5635,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     StableSort/cmp);
                                 Variable
                                   ((293,
@@ -5283,9 +5671,17 @@ Value
             (cmp, (A -> (A -> Type (Z))));
             (n, Type (Z));
             (l, Type (list, A))
-          ], Type (list, A)),
+          ],
+          Monad
+            ([ Type (NonTermination); Type (OCaml.Assert_failure) ],
+              Type (list, A))),
           Match
-            ((?, Effect ([ NonTermination; OCaml.Assert_failure ], .)),
+            ((?,
+              Effect
+                ([
+                  Type (NonTermination);
+                  Type (OCaml.Assert_failure)
+                ], .)),
               Variable ((?, Effect ([ ], .)), StableSort/counter),
               [
                 (Constructor (O),
@@ -5293,7 +5689,8 @@ Value
                     ((?,
                       Effect
                         ([
-                          NonTermination
+                          Type
+                            (NonTermination)
                         ],
                           .)),
                       Variable
@@ -5303,7 +5700,8 @@ Value
                             ],
                               .
                                 -[
-                                  NonTermination
+                                  Type
+                                    (NonTermination)
                                 ]->
                                 .)),
                           not_terminated),
@@ -5320,8 +5718,10 @@ Value
                     ((296,
                       Effect
                         ([
-                          NonTermination;
-                          OCaml.Assert_failure
+                          Type
+                            (NonTermination);
+                          Type
+                            (OCaml.Assert_failure)
                         ],
                           .)),
                       Tuple
@@ -5371,7 +5771,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       OCaml.Pervasives.gt),
                                   [
                                     Apply
@@ -5385,7 +5789,11 @@ Value
                                             Effect
                                               ([
                                               ],
-                                                .)),
+                                                .
+                                                  ->
+                                                  .
+                                                    ->
+                                                    .)),
                                             StableSort/cmp),
                                         [
                                           Variable
@@ -5510,7 +5918,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       OCaml.Pervasives.gt),
                                   [
                                     Apply
@@ -5524,7 +5936,11 @@ Value
                                             Effect
                                               ([
                                               ],
-                                                .)),
+                                                .
+                                                  ->
+                                                  .
+                                                    ->
+                                                    .)),
                                             StableSort/cmp),
                                         [
                                           Variable
@@ -5567,7 +5983,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           OCaml.Pervasives.gt),
                                       [
                                         Apply
@@ -5581,7 +6001,11 @@ Value
                                                 Effect
                                                   ([
                                                   ],
-                                                    .)),
+                                                    .
+                                                      ->
+                                                      .
+                                                        ->
+                                                        .)),
                                                 StableSort/cmp),
                                             [
                                               Variable
@@ -5673,7 +6097,11 @@ Value
                                               Effect
                                                 ([
                                                 ],
-                                                  .)),
+                                                  .
+                                                    ->
+                                                    .
+                                                      ->
+                                                      .)),
                                               OCaml.Pervasives.gt),
                                           [
                                             Apply
@@ -5687,7 +6115,11 @@ Value
                                                     Effect
                                                       ([
                                                       ],
-                                                        .)),
+                                                        .
+                                                          ->
+                                                          .
+                                                            ->
+                                                            .)),
                                                     StableSort/cmp),
                                                 [
                                                   Variable
@@ -5828,7 +6260,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           OCaml.Pervasives.gt),
                                       [
                                         Apply
@@ -5842,7 +6278,11 @@ Value
                                                 Effect
                                                   ([
                                                   ],
-                                                    .)),
+                                                    .
+                                                      ->
+                                                      .
+                                                        ->
+                                                        .)),
                                                 StableSort/cmp),
                                             [
                                               Variable
@@ -5934,7 +6374,11 @@ Value
                                               Effect
                                                 ([
                                                 ],
-                                                  .)),
+                                                  .
+                                                    ->
+                                                    .
+                                                      ->
+                                                      .)),
                                               OCaml.Pervasives.gt),
                                           [
                                             Apply
@@ -5948,7 +6392,11 @@ Value
                                                     Effect
                                                       ([
                                                       ],
-                                                        .)),
+                                                        .
+                                                          ->
+                                                          .
+                                                            ->
+                                                            .)),
                                                     StableSort/cmp),
                                                 [
                                                   Variable
@@ -6079,8 +6527,10 @@ Value
                             (310,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             n1
@@ -6096,7 +6546,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     Z.div),
                                 [
                                   Variable
@@ -6119,8 +6573,10 @@ Value
                             (311,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             n2
@@ -6136,7 +6592,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     Z.sub),
                                 [
                                   Variable
@@ -6159,8 +6619,10 @@ Value
                             (312,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             l2
@@ -6169,7 +6631,8 @@ Value
                               ((312,
                                 Effect
                                   ([
-                                    OCaml.Assert_failure
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                     .)),
                                 Variable
@@ -6181,7 +6644,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              OCaml.Assert_failure
+                                              Type
+                                                (OCaml.Assert_failure)
                                             ]->
                                             .)),
                                     chop),
@@ -6206,8 +6670,10 @@ Value
                             (313,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             s1
@@ -6216,8 +6682,10 @@ Value
                               ((313,
                                 Effect
                                   ([
-                                    NonTermination;
-                                    OCaml.Assert_failure
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                     .)),
                                 Apply
@@ -6231,8 +6699,10 @@ Value
                                             ->
                                             .
                                               -[
-                                                NonTermination;
-                                                OCaml.Assert_failure
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Assert_failure)
                                               ]->
                                               .)),
                                     Variable
@@ -6248,8 +6718,10 @@ Value
                                                   ->
                                                   .
                                                     -[
-                                                      NonTermination;
-                                                      OCaml.Assert_failure
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Assert_failure)
                                                     ]->
                                                     .)),
                                         StableSort/sort_rec),
@@ -6268,7 +6740,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       StableSort/cmp);
                                   Variable
                                     ((313,
@@ -6290,8 +6766,10 @@ Value
                             (314,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             s2
@@ -6300,8 +6778,10 @@ Value
                               ((314,
                                 Effect
                                   ([
-                                    NonTermination;
-                                    OCaml.Assert_failure
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                     .)),
                                 Apply
@@ -6315,8 +6795,10 @@ Value
                                             ->
                                             .
                                               -[
-                                                NonTermination;
-                                                OCaml.Assert_failure
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Assert_failure)
                                               ]->
                                               .)),
                                     Variable
@@ -6332,8 +6814,10 @@ Value
                                                   ->
                                                   .
                                                     -[
-                                                      NonTermination;
-                                                      OCaml.Assert_failure
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Assert_failure)
                                                     ]->
                                                     .)),
                                         StableSort/sort_rec),
@@ -6352,7 +6836,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       StableSort/cmp);
                                   Variable
                                     ((314,
@@ -6397,7 +6885,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     StableSort/cmp);
                                 Variable
                                   ((315,
@@ -6434,14 +6926,20 @@ Value
             (cmp, (A -> (A -> Type (Z))));
             (n, Type (Z));
             (l, Type (list, A))
-          ], Type (list, A)),
+          ],
+          Monad
+            ([
+              Type (Counter);
+              Type (NonTermination);
+              Type (OCaml.Assert_failure)
+            ], Type (list, A))),
           Apply
             ((?,
               Effect
                 ([
-                  Counter;
-                  NonTermination;
-                  OCaml.Assert_failure
+                  Type (Counter);
+                  Type (NonTermination);
+                  Type (OCaml.Assert_failure)
                 ], .)),
               Variable
                 ((?,
@@ -6452,8 +6950,10 @@ Value
                           . ->
                             .
                               -[
-                                NonTermination;
-                                OCaml.Assert_failure
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Assert_failure)
                               ]-> .)),
                   StableSort/sort_rec),
               [
@@ -6461,7 +6961,8 @@ Value
                   ((?,
                     Effect
                       ([
-                        Counter
+                        Type
+                          (Counter)
                       ],
                         .)),
                     Variable
@@ -6471,7 +6972,8 @@ Value
                           ],
                             .
                               -[
-                                Counter
+                                Type
+                                  (Counter)
                               ]->
                               .)),
                         read_counter),
@@ -6483,7 +6985,17 @@ Value
                             ],
                               .)))
                     ]);
-                Variable ((?, Effect ([ ], .)), StableSort/cmp);
+                Variable
+                  ((?,
+                    Effect
+                      ([
+                      ],
+                        .
+                          ->
+                          .
+                            ->
+                            .)),
+                    StableSort/cmp);
                 Variable ((?, Effect ([ ], .)), StableSort/n);
                 Variable ((?, Effect ([ ], .)), StableSort/l)
               ]))
@@ -6498,14 +7010,20 @@ Value
             (cmp, (A -> (A -> Type (Z))));
             (n, Type (Z));
             (l, Type (list, A))
-          ], Type (list, A)),
+          ],
+          Monad
+            ([
+              Type (Counter);
+              Type (NonTermination);
+              Type (OCaml.Assert_failure)
+            ], Type (list, A))),
           Apply
             ((?,
               Effect
                 ([
-                  Counter;
-                  NonTermination;
-                  OCaml.Assert_failure
+                  Type (Counter);
+                  Type (NonTermination);
+                  Type (OCaml.Assert_failure)
                 ], .)),
               Variable
                 ((?,
@@ -6516,8 +7034,10 @@ Value
                           . ->
                             .
                               -[
-                                NonTermination;
-                                OCaml.Assert_failure
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Assert_failure)
                               ]-> .)),
                   StableSort/rev_sort_rec),
               [
@@ -6525,7 +7045,8 @@ Value
                   ((?,
                     Effect
                       ([
-                        Counter
+                        Type
+                          (Counter)
                       ],
                         .)),
                     Variable
@@ -6535,7 +7056,8 @@ Value
                           ],
                             .
                               -[
-                                Counter
+                                Type
+                                  (Counter)
                               ]->
                               .)),
                         read_counter),
@@ -6547,7 +7069,17 @@ Value
                             ],
                               .)))
                     ]);
-                Variable ((?, Effect ([ ], .)), StableSort/cmp);
+                Variable
+                  ((?,
+                    Effect
+                      ([
+                      ],
+                        .
+                          ->
+                          .
+                            ->
+                            .)),
+                    StableSort/cmp);
                 Variable ((?, Effect ([ ], .)), StableSort/n);
                 Variable ((?, Effect ([ ], .)), StableSort/l)
               ]))
@@ -6558,21 +7090,38 @@ Value
   (non_rec, @.,
     [
       ((stable_sort, [ A ],
-        [ (cmp, (A -> (A -> Type (Z)))); (l, Type (list, A)) ], Type (list, A)),
+        [ (cmp, (A -> (A -> Type (Z)))); (l, Type (list, A)) ],
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Assert_failure)
+          ], Type (list, A))),
         LetVar
           (319,
-            Effect ([ Counter; NonTermination; OCaml.Assert_failure ], .))
-          len =
+            Effect
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Assert_failure)
+              ], .)) len =
           Apply
             ((319, Effect ([ ], .)),
               Variable ((319, Effect ([ ], . -> .)), length),
               [ Variable ((319, Effect ([ ], .)), l) ]) in
         IfThenElse
           ((320,
-            Effect ([ Counter; NonTermination; OCaml.Assert_failure ], .)),
+            Effect
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Assert_failure)
+              ], .)),
             Apply
               ((320, Effect ([ ], .)),
-                Variable ((320, Effect ([ ], .)), OCaml.Pervasives.lt),
+                Variable
+                  ((320, Effect ([ ], . -> . -> .)),
+                    OCaml.Pervasives.lt),
                 [
                   Variable ((320, Effect ([ ], .)), len);
                   Constant ((320, Effect ([ ], .)), Int(2))
@@ -6580,8 +7129,11 @@ Value
             Apply
               ((320,
                 Effect
-                  ([ Counter; NonTermination; OCaml.Assert_failure ],
-                    .)),
+                  ([
+                    Type (Counter);
+                    Type (NonTermination);
+                    Type (OCaml.Assert_failure)
+                  ], .)),
                 Variable
                   ((320,
                     Effect
@@ -6590,12 +7142,13 @@ Value
                           . ->
                             .
                               -[
-                                Counter;
-                                NonTermination;
-                                OCaml.Assert_failure
+                                Type (Counter);
+                                Type (NonTermination);
+                                Type
+                                  (OCaml.Assert_failure)
                               ]-> .)), StableSort.sort),
                 [
-                  Variable ((320, Effect ([ ], .)), cmp);
+                  Variable ((320, Effect ([ ], . -> . -> .)), cmp);
                   Variable ((320, Effect ([ ], .)), len);
                   Variable ((320, Effect ([ ], .)), l)
                 ])))
@@ -6606,7 +7159,14 @@ Value
   (non_rec, @.,
     [
       ((sort, [ A ], [ ],
-        ((A -> (A -> Type (Z))) -> (Type (list, A) -> Type (list, A)))),
+        ((A -> (A -> Type (Z))) ->
+          (Type (list, A) ->
+            Monad
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Assert_failure)
+              ], Type (list, A))))),
         Variable
           ((322,
             Effect
@@ -6614,9 +7174,9 @@ Value
                 . ->
                   .
                     -[
-                      Counter;
-                      NonTermination;
-                      OCaml.Assert_failure
+                      Type (Counter);
+                      Type (NonTermination);
+                      Type (OCaml.Assert_failure)
                     ]-> .)), stable_sort))
     ])
 
@@ -6625,7 +7185,14 @@ Value
   (non_rec, @.,
     [
       ((fast_sort, [ A ], [ ],
-        ((A -> (A -> Type (Z))) -> (Type (list, A) -> Type (list, A)))),
+        ((A -> (A -> Type (Z))) ->
+          (Type (list, A) ->
+            Monad
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Assert_failure)
+              ], Type (list, A))))),
         Variable
           ((323,
             Effect
@@ -6633,9 +7200,9 @@ Value
                 . ->
                   .
                     -[
-                      Counter;
-                      NonTermination;
-                      OCaml.Assert_failure
+                      Type (Counter);
+                      Type (NonTermination);
+                      Type (OCaml.Assert_failure)
                     ]-> .)), stable_sort))
     ])
 
@@ -6794,7 +7361,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     SortUniq/cmp),
                                 [
                                   Variable
@@ -6830,7 +7401,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       equiv_decb),
                                   [
                                     Variable
@@ -6875,7 +7450,11 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         SortUniq/cmp);
                                     Variable
                                       ((334,
@@ -6930,7 +7509,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           OCaml.Pervasives.lt),
                                       [
                                         Variable
@@ -6975,7 +7558,11 @@ Value
                                             Effect
                                               ([
                                               ],
-                                                .)),
+                                                .
+                                                  ->
+                                                  .
+                                                    ->
+                                                    .)),
                                             SortUniq/cmp);
                                         Variable
                                           ((336,
@@ -7227,7 +7814,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     SortUniq/cmp),
                                 [
                                   Variable
@@ -7263,7 +7854,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       equiv_decb),
                                   [
                                     Variable
@@ -7308,7 +7903,11 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         SortUniq/cmp);
                                     Variable
                                       ((348,
@@ -7363,7 +7962,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           OCaml.Pervasives.gt),
                                       [
                                         Variable
@@ -7408,7 +8011,11 @@ Value
                                             Effect
                                               ([
                                               ],
-                                                .)),
+                                                .
+                                                  ->
+                                                  .
+                                                    ->
+                                                    .)),
                                             SortUniq/cmp);
                                         Variable
                                           ((350,
@@ -7516,9 +8123,17 @@ Value
             (cmp, (A -> (A -> Type (Z))));
             (n, Type (Z));
             (l, Type (list, A))
-          ], Type (list, A)),
+          ],
+          Monad
+            ([ Type (NonTermination); Type (OCaml.Assert_failure) ],
+              Type (list, A))),
           Match
-            ((?, Effect ([ NonTermination; OCaml.Assert_failure ], .)),
+            ((?,
+              Effect
+                ([
+                  Type (NonTermination);
+                  Type (OCaml.Assert_failure)
+                ], .)),
               Variable ((?, Effect ([ ], .)), SortUniq/counter),
               [
                 (Constructor (O),
@@ -7526,7 +8141,8 @@ Value
                     ((?,
                       Effect
                         ([
-                          NonTermination
+                          Type
+                            (NonTermination)
                         ],
                           .)),
                       Variable
@@ -7536,7 +8152,8 @@ Value
                             ],
                               .
                                 -[
-                                  NonTermination
+                                  Type
+                                    (NonTermination)
                                 ]->
                                 .)),
                           not_terminated),
@@ -7553,8 +8170,10 @@ Value
                     ((356,
                       Effect
                         ([
-                          NonTermination;
-                          OCaml.Assert_failure
+                          Type
+                            (NonTermination);
+                          Type
+                            (OCaml.Assert_failure)
                         ],
                           .)),
                       Tuple
@@ -7606,7 +8225,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     SortUniq/cmp),
                                 [
                                   Variable
@@ -7642,7 +8265,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       equiv_decb),
                                   [
                                     Variable
@@ -7698,7 +8325,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           OCaml.Pervasives.lt),
                                       [
                                         Variable
@@ -7817,7 +8448,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     SortUniq/cmp),
                                 [
                                   Variable
@@ -7853,7 +8488,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       equiv_decb),
                                   [
                                     Variable
@@ -7890,7 +8529,11 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         SortUniq/cmp),
                                     [
                                       Variable
@@ -7926,7 +8569,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           equiv_decb),
                                       [
                                         Variable
@@ -7982,7 +8629,11 @@ Value
                                               Effect
                                                 ([
                                                 ],
-                                                  .)),
+                                                  .
+                                                    ->
+                                                    .
+                                                      ->
+                                                      .)),
                                               OCaml.Pervasives.lt),
                                           [
                                             Variable
@@ -8087,7 +8738,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           OCaml.Pervasives.lt),
                                       [
                                         Variable
@@ -8124,7 +8779,11 @@ Value
                                             Effect
                                               ([
                                               ],
-                                                .)),
+                                                .
+                                                  ->
+                                                  .
+                                                    ->
+                                                    .)),
                                             SortUniq/cmp),
                                         [
                                           Variable
@@ -8160,7 +8819,11 @@ Value
                                               Effect
                                                 ([
                                                 ],
-                                                  .)),
+                                                  .
+                                                    ->
+                                                    .
+                                                      ->
+                                                      .)),
                                               equiv_decb),
                                           [
                                             Variable
@@ -8230,7 +8893,11 @@ Value
                                                   Effect
                                                     ([
                                                     ],
-                                                      .)),
+                                                      .
+                                                        ->
+                                                        .
+                                                          ->
+                                                          .)),
                                                   OCaml.Pervasives.lt),
                                               [
                                                 Variable
@@ -8316,7 +8983,11 @@ Value
                                                     Effect
                                                       ([
                                                       ],
-                                                        .)),
+                                                        .
+                                                          ->
+                                                          .
+                                                            ->
+                                                            .)),
                                                     SortUniq/cmp),
                                                 [
                                                   Variable
@@ -8352,7 +9023,11 @@ Value
                                                       Effect
                                                         ([
                                                         ],
-                                                          .)),
+                                                          .
+                                                            ->
+                                                            .
+                                                              ->
+                                                              .)),
                                                       equiv_decb),
                                                   [
                                                     Variable
@@ -8422,7 +9097,11 @@ Value
                                                           Effect
                                                             ([
                                                             ],
-                                                              .)),
+                                                              .
+                                                                ->
+                                                                .
+                                                                  ->
+                                                                  .)),
                                                           OCaml.Pervasives.lt),
                                                       [
                                                         Variable
@@ -8557,7 +9236,11 @@ Value
                                             Effect
                                               ([
                                               ],
-                                                .)),
+                                                .
+                                                  ->
+                                                  .
+                                                    ->
+                                                    .)),
                                             SortUniq/cmp),
                                         [
                                           Variable
@@ -8593,7 +9276,11 @@ Value
                                               Effect
                                                 ([
                                                 ],
-                                                  .)),
+                                                  .
+                                                    ->
+                                                    .
+                                                      ->
+                                                      .)),
                                               equiv_decb),
                                           [
                                             Variable
@@ -8663,7 +9350,11 @@ Value
                                                   Effect
                                                     ([
                                                     ],
-                                                      .)),
+                                                      .
+                                                        ->
+                                                        .
+                                                          ->
+                                                          .)),
                                                   OCaml.Pervasives.lt),
                                               [
                                                 Variable
@@ -8749,7 +9440,11 @@ Value
                                                     Effect
                                                       ([
                                                       ],
-                                                        .)),
+                                                        .
+                                                          ->
+                                                          .
+                                                            ->
+                                                            .)),
                                                     SortUniq/cmp),
                                                 [
                                                   Variable
@@ -8785,7 +9480,11 @@ Value
                                                       Effect
                                                         ([
                                                         ],
-                                                          .)),
+                                                          .
+                                                            ->
+                                                            .
+                                                              ->
+                                                              .)),
                                                       equiv_decb),
                                                   [
                                                     Variable
@@ -8855,7 +9554,11 @@ Value
                                                           Effect
                                                             ([
                                                             ],
-                                                              .)),
+                                                              .
+                                                                ->
+                                                                .
+                                                                  ->
+                                                                  .)),
                                                           OCaml.Pervasives.lt),
                                                       [
                                                         Variable
@@ -8978,8 +9681,10 @@ Value
                             (385,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             n1
@@ -8995,7 +9700,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     Z.div),
                                 [
                                   Variable
@@ -9018,8 +9727,10 @@ Value
                             (386,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             n2
@@ -9035,7 +9746,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     Z.sub),
                                 [
                                   Variable
@@ -9058,8 +9773,10 @@ Value
                             (387,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             l2
@@ -9068,7 +9785,8 @@ Value
                               ((387,
                                 Effect
                                   ([
-                                    OCaml.Assert_failure
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                     .)),
                                 Variable
@@ -9080,7 +9798,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              OCaml.Assert_failure
+                                              Type
+                                                (OCaml.Assert_failure)
                                             ]->
                                             .)),
                                     chop),
@@ -9105,8 +9824,10 @@ Value
                             (388,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             s1
@@ -9115,8 +9836,10 @@ Value
                               ((388,
                                 Effect
                                   ([
-                                    NonTermination;
-                                    OCaml.Assert_failure
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                     .)),
                                 Apply
@@ -9130,8 +9853,10 @@ Value
                                             ->
                                             .
                                               -[
-                                                NonTermination;
-                                                OCaml.Assert_failure
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Assert_failure)
                                               ]->
                                               .)),
                                     Variable
@@ -9147,8 +9872,10 @@ Value
                                                   ->
                                                   .
                                                     -[
-                                                      NonTermination;
-                                                      OCaml.Assert_failure
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Assert_failure)
                                                     ]->
                                                     .)),
                                         SortUniq/rev_sort_rec),
@@ -9167,7 +9894,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       SortUniq/cmp);
                                   Variable
                                     ((388,
@@ -9189,8 +9920,10 @@ Value
                             (389,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             s2
@@ -9199,8 +9932,10 @@ Value
                               ((389,
                                 Effect
                                   ([
-                                    NonTermination;
-                                    OCaml.Assert_failure
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                     .)),
                                 Apply
@@ -9214,8 +9949,10 @@ Value
                                             ->
                                             .
                                               -[
-                                                NonTermination;
-                                                OCaml.Assert_failure
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Assert_failure)
                                               ]->
                                               .)),
                                     Variable
@@ -9231,8 +9968,10 @@ Value
                                                   ->
                                                   .
                                                     -[
-                                                      NonTermination;
-                                                      OCaml.Assert_failure
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Assert_failure)
                                                     ]->
                                                     .)),
                                         SortUniq/rev_sort_rec),
@@ -9251,7 +9990,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       SortUniq/cmp);
                                   Variable
                                     ((389,
@@ -9296,7 +10039,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     SortUniq/cmp);
                                 Variable
                                   ((390,
@@ -9328,9 +10075,17 @@ Value
             (cmp, (A -> (A -> Type (Z))));
             (n, Type (Z));
             (l, Type (list, A))
-          ], Type (list, A)),
+          ],
+          Monad
+            ([ Type (NonTermination); Type (OCaml.Assert_failure) ],
+              Type (list, A))),
           Match
-            ((?, Effect ([ NonTermination; OCaml.Assert_failure ], .)),
+            ((?,
+              Effect
+                ([
+                  Type (NonTermination);
+                  Type (OCaml.Assert_failure)
+                ], .)),
               Variable ((?, Effect ([ ], .)), SortUniq/counter),
               [
                 (Constructor (O),
@@ -9338,7 +10093,8 @@ Value
                     ((?,
                       Effect
                         ([
-                          NonTermination
+                          Type
+                            (NonTermination)
                         ],
                           .)),
                       Variable
@@ -9348,7 +10104,8 @@ Value
                             ],
                               .
                                 -[
-                                  NonTermination
+                                  Type
+                                    (NonTermination)
                                 ]->
                                 .)),
                           not_terminated),
@@ -9365,8 +10122,10 @@ Value
                     ((393,
                       Effect
                         ([
-                          NonTermination;
-                          OCaml.Assert_failure
+                          Type
+                            (NonTermination);
+                          Type
+                            (OCaml.Assert_failure)
                         ],
                           .)),
                       Tuple
@@ -9418,7 +10177,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     SortUniq/cmp),
                                 [
                                   Variable
@@ -9454,7 +10217,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       equiv_decb),
                                   [
                                     Variable
@@ -9510,7 +10277,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           OCaml.Pervasives.gt),
                                       [
                                         Variable
@@ -9629,7 +10400,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     SortUniq/cmp),
                                 [
                                   Variable
@@ -9665,7 +10440,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       equiv_decb),
                                   [
                                     Variable
@@ -9702,7 +10481,11 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         SortUniq/cmp),
                                     [
                                       Variable
@@ -9738,7 +10521,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           equiv_decb),
                                       [
                                         Variable
@@ -9794,7 +10581,11 @@ Value
                                               Effect
                                                 ([
                                                 ],
-                                                  .)),
+                                                  .
+                                                    ->
+                                                    .
+                                                      ->
+                                                      .)),
                                               OCaml.Pervasives.gt),
                                           [
                                             Variable
@@ -9899,7 +10690,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           OCaml.Pervasives.gt),
                                       [
                                         Variable
@@ -9936,7 +10731,11 @@ Value
                                             Effect
                                               ([
                                               ],
-                                                .)),
+                                                .
+                                                  ->
+                                                  .
+                                                    ->
+                                                    .)),
                                             SortUniq/cmp),
                                         [
                                           Variable
@@ -9972,7 +10771,11 @@ Value
                                               Effect
                                                 ([
                                                 ],
-                                                  .)),
+                                                  .
+                                                    ->
+                                                    .
+                                                      ->
+                                                      .)),
                                               equiv_decb),
                                           [
                                             Variable
@@ -10042,7 +10845,11 @@ Value
                                                   Effect
                                                     ([
                                                     ],
-                                                      .)),
+                                                      .
+                                                        ->
+                                                        .
+                                                          ->
+                                                          .)),
                                                   OCaml.Pervasives.gt),
                                               [
                                                 Variable
@@ -10128,7 +10935,11 @@ Value
                                                     Effect
                                                       ([
                                                       ],
-                                                        .)),
+                                                        .
+                                                          ->
+                                                          .
+                                                            ->
+                                                            .)),
                                                     SortUniq/cmp),
                                                 [
                                                   Variable
@@ -10164,7 +10975,11 @@ Value
                                                       Effect
                                                         ([
                                                         ],
-                                                          .)),
+                                                          .
+                                                            ->
+                                                            .
+                                                              ->
+                                                              .)),
                                                       equiv_decb),
                                                   [
                                                     Variable
@@ -10234,7 +11049,11 @@ Value
                                                           Effect
                                                             ([
                                                             ],
-                                                              .)),
+                                                              .
+                                                                ->
+                                                                .
+                                                                  ->
+                                                                  .)),
                                                           OCaml.Pervasives.gt),
                                                       [
                                                         Variable
@@ -10369,7 +11188,11 @@ Value
                                             Effect
                                               ([
                                               ],
-                                                .)),
+                                                .
+                                                  ->
+                                                  .
+                                                    ->
+                                                    .)),
                                             SortUniq/cmp),
                                         [
                                           Variable
@@ -10405,7 +11228,11 @@ Value
                                               Effect
                                                 ([
                                                 ],
-                                                  .)),
+                                                  .
+                                                    ->
+                                                    .
+                                                      ->
+                                                      .)),
                                               equiv_decb),
                                           [
                                             Variable
@@ -10475,7 +11302,11 @@ Value
                                                   Effect
                                                     ([
                                                     ],
-                                                      .)),
+                                                      .
+                                                        ->
+                                                        .
+                                                          ->
+                                                          .)),
                                                   OCaml.Pervasives.gt),
                                               [
                                                 Variable
@@ -10561,7 +11392,11 @@ Value
                                                     Effect
                                                       ([
                                                       ],
-                                                        .)),
+                                                        .
+                                                          ->
+                                                          .
+                                                            ->
+                                                            .)),
                                                     SortUniq/cmp),
                                                 [
                                                   Variable
@@ -10597,7 +11432,11 @@ Value
                                                       Effect
                                                         ([
                                                         ],
-                                                          .)),
+                                                          .
+                                                            ->
+                                                            .
+                                                              ->
+                                                              .)),
                                                       equiv_decb),
                                                   [
                                                     Variable
@@ -10667,7 +11506,11 @@ Value
                                                           Effect
                                                             ([
                                                             ],
-                                                              .)),
+                                                              .
+                                                                ->
+                                                                .
+                                                                  ->
+                                                                  .)),
                                                           OCaml.Pervasives.gt),
                                                       [
                                                         Variable
@@ -10790,8 +11633,10 @@ Value
                             (422,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             n1
@@ -10807,7 +11652,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     Z.div),
                                 [
                                   Variable
@@ -10830,8 +11679,10 @@ Value
                             (423,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             n2
@@ -10847,7 +11698,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     Z.sub),
                                 [
                                   Variable
@@ -10870,8 +11725,10 @@ Value
                             (424,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             l2
@@ -10880,7 +11737,8 @@ Value
                               ((424,
                                 Effect
                                   ([
-                                    OCaml.Assert_failure
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                     .)),
                                 Variable
@@ -10892,7 +11750,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              OCaml.Assert_failure
+                                              Type
+                                                (OCaml.Assert_failure)
                                             ]->
                                             .)),
                                     chop),
@@ -10917,8 +11776,10 @@ Value
                             (425,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             s1
@@ -10927,8 +11788,10 @@ Value
                               ((425,
                                 Effect
                                   ([
-                                    NonTermination;
-                                    OCaml.Assert_failure
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                     .)),
                                 Apply
@@ -10942,8 +11805,10 @@ Value
                                             ->
                                             .
                                               -[
-                                                NonTermination;
-                                                OCaml.Assert_failure
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Assert_failure)
                                               ]->
                                               .)),
                                     Variable
@@ -10959,8 +11824,10 @@ Value
                                                   ->
                                                   .
                                                     -[
-                                                      NonTermination;
-                                                      OCaml.Assert_failure
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Assert_failure)
                                                     ]->
                                                     .)),
                                         SortUniq/sort_rec),
@@ -10979,7 +11846,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       SortUniq/cmp);
                                   Variable
                                     ((425,
@@ -11001,8 +11872,10 @@ Value
                             (426,
                               Effect
                                 ([
-                                  NonTermination;
-                                  OCaml.Assert_failure
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ],
                                   .))
                             s2
@@ -11011,8 +11884,10 @@ Value
                               ((426,
                                 Effect
                                   ([
-                                    NonTermination;
-                                    OCaml.Assert_failure
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                     .)),
                                 Apply
@@ -11026,8 +11901,10 @@ Value
                                             ->
                                             .
                                               -[
-                                                NonTermination;
-                                                OCaml.Assert_failure
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Assert_failure)
                                               ]->
                                               .)),
                                     Variable
@@ -11043,8 +11920,10 @@ Value
                                                   ->
                                                   .
                                                     -[
-                                                      NonTermination;
-                                                      OCaml.Assert_failure
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Assert_failure)
                                                     ]->
                                                     .)),
                                         SortUniq/sort_rec),
@@ -11063,7 +11942,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       SortUniq/cmp);
                                   Variable
                                     ((426,
@@ -11108,7 +11991,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     SortUniq/cmp);
                                 Variable
                                   ((427,
@@ -11145,14 +12032,20 @@ Value
             (cmp, (A -> (A -> Type (Z))));
             (n, Type (Z));
             (l, Type (list, A))
-          ], Type (list, A)),
+          ],
+          Monad
+            ([
+              Type (Counter);
+              Type (NonTermination);
+              Type (OCaml.Assert_failure)
+            ], Type (list, A))),
           Apply
             ((?,
               Effect
                 ([
-                  Counter;
-                  NonTermination;
-                  OCaml.Assert_failure
+                  Type (Counter);
+                  Type (NonTermination);
+                  Type (OCaml.Assert_failure)
                 ], .)),
               Variable
                 ((?,
@@ -11163,8 +12056,10 @@ Value
                           . ->
                             .
                               -[
-                                NonTermination;
-                                OCaml.Assert_failure
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Assert_failure)
                               ]-> .)),
                   SortUniq/sort_rec),
               [
@@ -11172,7 +12067,8 @@ Value
                   ((?,
                     Effect
                       ([
-                        Counter
+                        Type
+                          (Counter)
                       ],
                         .)),
                     Variable
@@ -11182,7 +12078,8 @@ Value
                           ],
                             .
                               -[
-                                Counter
+                                Type
+                                  (Counter)
                               ]->
                               .)),
                         read_counter),
@@ -11194,7 +12091,17 @@ Value
                             ],
                               .)))
                     ]);
-                Variable ((?, Effect ([ ], .)), SortUniq/cmp);
+                Variable
+                  ((?,
+                    Effect
+                      ([
+                      ],
+                        .
+                          ->
+                          .
+                            ->
+                            .)),
+                    SortUniq/cmp);
                 Variable ((?, Effect ([ ], .)), SortUniq/n);
                 Variable ((?, Effect ([ ], .)), SortUniq/l)
               ]))
@@ -11209,14 +12116,20 @@ Value
             (cmp, (A -> (A -> Type (Z))));
             (n, Type (Z));
             (l, Type (list, A))
-          ], Type (list, A)),
+          ],
+          Monad
+            ([
+              Type (Counter);
+              Type (NonTermination);
+              Type (OCaml.Assert_failure)
+            ], Type (list, A))),
           Apply
             ((?,
               Effect
                 ([
-                  Counter;
-                  NonTermination;
-                  OCaml.Assert_failure
+                  Type (Counter);
+                  Type (NonTermination);
+                  Type (OCaml.Assert_failure)
                 ], .)),
               Variable
                 ((?,
@@ -11227,8 +12140,10 @@ Value
                           . ->
                             .
                               -[
-                                NonTermination;
-                                OCaml.Assert_failure
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Assert_failure)
                               ]-> .)),
                   SortUniq/rev_sort_rec),
               [
@@ -11236,7 +12151,8 @@ Value
                   ((?,
                     Effect
                       ([
-                        Counter
+                        Type
+                          (Counter)
                       ],
                         .)),
                     Variable
@@ -11246,7 +12162,8 @@ Value
                           ],
                             .
                               -[
-                                Counter
+                                Type
+                                  (Counter)
                               ]->
                               .)),
                         read_counter),
@@ -11258,7 +12175,17 @@ Value
                             ],
                               .)))
                     ]);
-                Variable ((?, Effect ([ ], .)), SortUniq/cmp);
+                Variable
+                  ((?,
+                    Effect
+                      ([
+                      ],
+                        .
+                          ->
+                          .
+                            ->
+                            .)),
+                    SortUniq/cmp);
                 Variable ((?, Effect ([ ], .)), SortUniq/n);
                 Variable ((?, Effect ([ ], .)), SortUniq/l)
               ]))
@@ -11269,21 +12196,38 @@ Value
   (non_rec, @.,
     [
       ((sort_uniq, [ A ],
-        [ (cmp, (A -> (A -> Type (Z)))); (l, Type (list, A)) ], Type (list, A)),
+        [ (cmp, (A -> (A -> Type (Z)))); (l, Type (list, A)) ],
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Assert_failure)
+          ], Type (list, A))),
         LetVar
           (431,
-            Effect ([ Counter; NonTermination; OCaml.Assert_failure ], .))
-          len =
+            Effect
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Assert_failure)
+              ], .)) len =
           Apply
             ((431, Effect ([ ], .)),
               Variable ((431, Effect ([ ], . -> .)), length),
               [ Variable ((431, Effect ([ ], .)), l) ]) in
         IfThenElse
           ((432,
-            Effect ([ Counter; NonTermination; OCaml.Assert_failure ], .)),
+            Effect
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Assert_failure)
+              ], .)),
             Apply
               ((432, Effect ([ ], .)),
-                Variable ((432, Effect ([ ], .)), OCaml.Pervasives.lt),
+                Variable
+                  ((432, Effect ([ ], . -> . -> .)),
+                    OCaml.Pervasives.lt),
                 [
                   Variable ((432, Effect ([ ], .)), len);
                   Constant ((432, Effect ([ ], .)), Int(2))
@@ -11291,8 +12235,11 @@ Value
             Apply
               ((432,
                 Effect
-                  ([ Counter; NonTermination; OCaml.Assert_failure ],
-                    .)),
+                  ([
+                    Type (Counter);
+                    Type (NonTermination);
+                    Type (OCaml.Assert_failure)
+                  ], .)),
                 Variable
                   ((432,
                     Effect
@@ -11301,12 +12248,13 @@ Value
                           . ->
                             .
                               -[
-                                Counter;
-                                NonTermination;
-                                OCaml.Assert_failure
+                                Type (Counter);
+                                Type (NonTermination);
+                                Type
+                                  (OCaml.Assert_failure)
                               ]-> .)), SortUniq.sort),
                 [
-                  Variable ((432, Effect ([ ], .)), cmp);
+                  Variable ((432, Effect ([ ], . -> . -> .)), cmp);
                   Variable ((432, Effect ([ ], .)), len);
                   Variable ((432, Effect ([ ], .)), l)
                 ])))

--- a/tests/ex27.monadise
+++ b/tests/ex27.monadise
@@ -48,7 +48,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((hd, [ A ], [ (x, Type (list, A)) ], Monad ([ OCaml.Failure ], A)),
+      ((hd, [ A ], [ (x, Type (list, A)) ], Monad ([ Type (OCaml.Failure) ], A)),
         Match
           (?, Variable (?, x),
             [
@@ -72,7 +72,7 @@ Value
   (non_rec, @.,
     [
       ((tl, [ A ], [ (x, Type (list, A)) ],
-        Monad ([ OCaml.Failure ], Type (list, A))),
+        Monad ([ Type (OCaml.Failure) ], Type (list, A))),
         Match
           (?, Variable (?, x),
             [
@@ -96,21 +96,21 @@ Value
   (non_rec, @.,
     [
       ((nth, [ A ], [ (l, Type (list, A)); (n, Type (Z)) ],
-        Monad ([ OCaml.Failure; OCaml.Invalid_argument ], A)),
+        Monad ([ Type (OCaml.Failure); Type (OCaml.Invalid_argument) ], A)),
         IfThenElse
           (32,
             Apply
               (32, Variable (32, OCaml.Pervasives.lt),
                 [ Variable (32, n); Constant (32, Int(0)) ]),
             Lift
-              (?, [ OCaml.Invalid_argument ],
-                [ OCaml.Failure; OCaml.Invalid_argument ],
+              (?, [ Type (OCaml.Invalid_argument) ],
+                [ Type (OCaml.Failure); Type (OCaml.Invalid_argument) ],
                 Apply
                   (32, Variable (32, OCaml.Pervasives.invalid_arg),
                     [ Constant (32, String("List.nth")) ])),
             Lift
-              (?, [ OCaml.Failure ],
-                [ OCaml.Failure; OCaml.Invalid_argument ],
+              (?, [ Type (OCaml.Failure) ],
+                [ Type (OCaml.Failure); Type (OCaml.Invalid_argument) ],
                 LetFun 33
                   (rec, @coq_rec,
                     [
@@ -126,7 +126,8 @@ Value
                         ],
                         Monad
                           ([
-                            OCaml.Failure
+                            Type
+                              (OCaml.Failure)
                           ],
                             B)),
                         Match
@@ -629,7 +630,7 @@ Value
     [
       ((map2, [ A; B; C ],
         [ (f, (A -> (B -> C))); (l1, Type (list, A)); (l2, Type (list, B)) ],
-        Monad ([ OCaml.Invalid_argument ], Type (list, C))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (list, C))),
         Match
           (99, Tuple (99, Variable (99, l1), Variable (99, l2)),
             [
@@ -707,7 +708,7 @@ Value
     [
       ((rev_map2, [ A; B; C ],
         [ (f, (A -> (B -> C))); (l1, Type (list, A)); (l2, Type (list, B)) ],
-        Monad ([ OCaml.Invalid_argument ], Type (list, C))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (list, C))),
         LetFun 106
           (rec, @coq_rec,
             [
@@ -719,7 +720,8 @@ Value
                 ],
                 Monad
                   ([
-                    OCaml.Invalid_argument
+                    Type
+                      (OCaml.Invalid_argument)
                   ], Type (list, C))),
                 Match
                   (107,
@@ -813,7 +815,7 @@ Value
     [
       ((iter2, [ A; B; C ],
         [ (f, (A -> (B -> C))); (l1, Type (list, A)); (l2, Type (list, B)) ],
-        Monad ([ OCaml.Invalid_argument ], Type (unit))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (unit))),
         Match
           (114, Tuple (114, Variable (114, l1), Variable (114, l2)),
             [
@@ -865,7 +867,7 @@ Value
           (accu, A);
           (l1, Type (list, B));
           (l2, Type (list, C))
-        ], Monad ([ OCaml.Invalid_argument ], A)),
+        ], Monad ([ Type (OCaml.Invalid_argument) ], A)),
         Match
           (121, Tuple (121, Variable (121, l1), Variable (121, l2)),
             [
@@ -933,7 +935,7 @@ Value
           (l1, Type (list, A));
           (l2, Type (list, B));
           (accu, C)
-        ], Monad ([ OCaml.Invalid_argument ], C)),
+        ], Monad ([ Type (OCaml.Invalid_argument) ], C)),
         Match
           (128, Tuple (128, Variable (128, l1), Variable (128, l2)),
             [
@@ -1097,7 +1099,7 @@ Value
           (p, (A -> (B -> Type (bool))));
           (l1, Type (list, A));
           (l2, Type (list, B))
-        ], Monad ([ OCaml.Invalid_argument ], Type (bool))),
+        ], Monad ([ Type (OCaml.Invalid_argument) ], Type (bool))),
         Match
           (145, Tuple (145, Variable (145, l1), Variable (145, l2)),
             [
@@ -1177,7 +1179,7 @@ Value
           (p, (A -> (B -> Type (bool))));
           (l1, Type (list, A));
           (l2, Type (list, B))
-        ], Monad ([ OCaml.Invalid_argument ], Type (bool))),
+        ], Monad ([ Type (OCaml.Invalid_argument) ], Type (bool))),
         Match
           (152, Tuple (152, Variable (152, l1), Variable (152, l2)),
             [
@@ -1253,7 +1255,7 @@ Value
   (rec, @coq_rec,
     [
       ((find, [ A ], [ (p, (A -> Type (bool))); (x, Type (list, A)) ],
-        Monad ([ OCaml.Not_found ], A)),
+        Monad ([ Type (OCaml.Not_found) ], A)),
         Match
           (?, Variable (?, x),
             [
@@ -1569,7 +1571,7 @@ Value
   (rec, @coq_rec,
     [
       ((combine, [ A; B ], [ (l1, Type (list, A)); (l2, Type (list, B)) ],
-        Monad ([ OCaml.Invalid_argument ], Type (list, (A * B)))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (list, (A * B)))),
         Match
           (221, Tuple (221, Variable (221, l1), Variable (221, l2)),
             [
@@ -1752,7 +1754,7 @@ Value
   (rec, @coq_rec,
     [
       ((chop, [ A ], [ (k, Type (Z)); (l, Type (list, A)) ],
-        Monad ([ OCaml.Assert_failure ], Type (list, A))),
+        Monad ([ Type (OCaml.Assert_failure) ], Type (list, A))),
         IfThenElse
           (241,
             Apply
@@ -2128,7 +2130,9 @@ Value
             (n, Type (Z));
             (l, Type (list, A))
           ],
-          Monad ([ NonTermination; OCaml.Assert_failure ], Type (list, A))),
+          Monad
+            ([ Type (NonTermination); Type (OCaml.Assert_failure) ],
+              Type (list, A))),
           Match
             (?, Variable (?, StableSort/counter),
               [
@@ -2136,11 +2140,14 @@ Value
                   Lift
                     (?,
                       [
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                       [
-                        NonTermination;
-                        OCaml.Assert_failure
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Assert_failure)
                       ],
                       Apply
                         (?,
@@ -2538,11 +2545,14 @@ Value
                               Lift
                                 (?,
                                   [
-                                    OCaml.Assert_failure
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                   [
-                                    NonTermination;
-                                    OCaml.Assert_failure
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                   Apply
                                     (290,
@@ -2643,7 +2653,9 @@ Value
             (n, Type (Z));
             (l, Type (list, A))
           ],
-          Monad ([ NonTermination; OCaml.Assert_failure ], Type (list, A))),
+          Monad
+            ([ Type (NonTermination); Type (OCaml.Assert_failure) ],
+              Type (list, A))),
           Match
             (?, Variable (?, StableSort/counter),
               [
@@ -2651,11 +2663,14 @@ Value
                   Lift
                     (?,
                       [
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                       [
-                        NonTermination;
-                        OCaml.Assert_failure
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Assert_failure)
                       ],
                       Apply
                         (?,
@@ -3053,11 +3068,14 @@ Value
                               Lift
                                 (?,
                                   [
-                                    OCaml.Assert_failure
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                   [
-                                    NonTermination;
-                                    OCaml.Assert_failure
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                   Apply
                                     (312,
@@ -3164,26 +3182,33 @@ Value
             (l, Type (list, A))
           ],
           Monad
-            ([ Counter; NonTermination; OCaml.Assert_failure ],
-              Type (list, A))),
+            ([
+              Type (Counter);
+              Type (NonTermination);
+              Type (OCaml.Assert_failure)
+            ], Type (list, A))),
           Bind
             (?,
               Lift
-                (?, [ Counter ],
+                (?, [ Type (Counter) ],
                   [
-                    Counter;
-                    NonTermination;
-                    OCaml.Assert_failure
+                    Type (Counter);
+                    Type (NonTermination);
+                    Type (OCaml.Assert_failure)
                   ],
                   Apply
                     (?, Variable (?, read_counter),
                       [ Tuple (?) ])), Some x,
               Lift
-                (?, [ NonTermination; OCaml.Assert_failure ],
+                (?,
                   [
-                    Counter;
-                    NonTermination;
-                    OCaml.Assert_failure
+                    Type (NonTermination);
+                    Type (OCaml.Assert_failure)
+                  ],
+                  [
+                    Type (Counter);
+                    Type (NonTermination);
+                    Type (OCaml.Assert_failure)
                   ],
                   Apply
                     (?,
@@ -3216,26 +3241,33 @@ Value
             (l, Type (list, A))
           ],
           Monad
-            ([ Counter; NonTermination; OCaml.Assert_failure ],
-              Type (list, A))),
+            ([
+              Type (Counter);
+              Type (NonTermination);
+              Type (OCaml.Assert_failure)
+            ], Type (list, A))),
           Bind
             (?,
               Lift
-                (?, [ Counter ],
+                (?, [ Type (Counter) ],
                   [
-                    Counter;
-                    NonTermination;
-                    OCaml.Assert_failure
+                    Type (Counter);
+                    Type (NonTermination);
+                    Type (OCaml.Assert_failure)
                   ],
                   Apply
                     (?, Variable (?, read_counter),
                       [ Tuple (?) ])), Some x,
               Lift
-                (?, [ NonTermination; OCaml.Assert_failure ],
+                (?,
                   [
-                    Counter;
-                    NonTermination;
-                    OCaml.Assert_failure
+                    Type (NonTermination);
+                    Type (OCaml.Assert_failure)
+                  ],
+                  [
+                    Type (Counter);
+                    Type (NonTermination);
+                    Type (OCaml.Assert_failure)
                   ],
                   Apply
                     (?,
@@ -3265,7 +3297,11 @@ Value
       ((stable_sort, [ A ],
         [ (cmp, (A -> (A -> Type (Z)))); (l, Type (list, A)) ],
         Monad
-          ([ Counter; NonTermination; OCaml.Assert_failure ], Type (list, A))),
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Assert_failure)
+          ], Type (list, A))),
         LetVar ? len =
           Apply (319, Variable (319, length), [ Variable (319, l) ]) in
         IfThenElse
@@ -3291,8 +3327,11 @@ Value
         ((A -> (A -> Type (Z))) ->
           (Type (list, A) ->
             Monad
-              ([ Counter; NonTermination; OCaml.Assert_failure ],
-                Type (list, A))))), Variable (322, stable_sort))
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Assert_failure)
+              ], Type (list, A))))), Variable (322, stable_sort))
     ])
 
 323
@@ -3303,8 +3342,11 @@ Value
         ((A -> (A -> Type (Z))) ->
           (Type (list, A) ->
             Monad
-              ([ Counter; NonTermination; OCaml.Assert_failure ],
-                Type (list, A))))), Variable (323, stable_sort))
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Assert_failure)
+              ], Type (list, A))))), Variable (323, stable_sort))
     ])
 
 325 Module SortUniq:
@@ -3731,7 +3773,9 @@ Value
             (n, Type (Z));
             (l, Type (list, A))
           ],
-          Monad ([ NonTermination; OCaml.Assert_failure ], Type (list, A))),
+          Monad
+            ([ Type (NonTermination); Type (OCaml.Assert_failure) ],
+              Type (list, A))),
           Match
             (?, Variable (?, SortUniq/counter),
               [
@@ -3739,11 +3783,14 @@ Value
                   Lift
                     (?,
                       [
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                       [
-                        NonTermination;
-                        OCaml.Assert_failure
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Assert_failure)
                       ],
                       Apply
                         (?,
@@ -4435,11 +4482,14 @@ Value
                               Lift
                                 (?,
                                   [
-                                    OCaml.Assert_failure
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                   [
-                                    NonTermination;
-                                    OCaml.Assert_failure
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                   Apply
                                     (387,
@@ -4540,7 +4590,9 @@ Value
             (n, Type (Z));
             (l, Type (list, A))
           ],
-          Monad ([ NonTermination; OCaml.Assert_failure ], Type (list, A))),
+          Monad
+            ([ Type (NonTermination); Type (OCaml.Assert_failure) ],
+              Type (list, A))),
           Match
             (?, Variable (?, SortUniq/counter),
               [
@@ -4548,11 +4600,14 @@ Value
                   Lift
                     (?,
                       [
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                       [
-                        NonTermination;
-                        OCaml.Assert_failure
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Assert_failure)
                       ],
                       Apply
                         (?,
@@ -5244,11 +5299,14 @@ Value
                               Lift
                                 (?,
                                   [
-                                    OCaml.Assert_failure
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                   [
-                                    NonTermination;
-                                    OCaml.Assert_failure
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ],
                                   Apply
                                     (424,
@@ -5355,26 +5413,33 @@ Value
             (l, Type (list, A))
           ],
           Monad
-            ([ Counter; NonTermination; OCaml.Assert_failure ],
-              Type (list, A))),
+            ([
+              Type (Counter);
+              Type (NonTermination);
+              Type (OCaml.Assert_failure)
+            ], Type (list, A))),
           Bind
             (?,
               Lift
-                (?, [ Counter ],
+                (?, [ Type (Counter) ],
                   [
-                    Counter;
-                    NonTermination;
-                    OCaml.Assert_failure
+                    Type (Counter);
+                    Type (NonTermination);
+                    Type (OCaml.Assert_failure)
                   ],
                   Apply
                     (?, Variable (?, read_counter),
                       [ Tuple (?) ])), Some x,
               Lift
-                (?, [ NonTermination; OCaml.Assert_failure ],
+                (?,
                   [
-                    Counter;
-                    NonTermination;
-                    OCaml.Assert_failure
+                    Type (NonTermination);
+                    Type (OCaml.Assert_failure)
+                  ],
+                  [
+                    Type (Counter);
+                    Type (NonTermination);
+                    Type (OCaml.Assert_failure)
                   ],
                   Apply
                     (?, Variable (?, SortUniq/sort_rec),
@@ -5399,26 +5464,33 @@ Value
             (l, Type (list, A))
           ],
           Monad
-            ([ Counter; NonTermination; OCaml.Assert_failure ],
-              Type (list, A))),
+            ([
+              Type (Counter);
+              Type (NonTermination);
+              Type (OCaml.Assert_failure)
+            ], Type (list, A))),
           Bind
             (?,
               Lift
-                (?, [ Counter ],
+                (?, [ Type (Counter) ],
                   [
-                    Counter;
-                    NonTermination;
-                    OCaml.Assert_failure
+                    Type (Counter);
+                    Type (NonTermination);
+                    Type (OCaml.Assert_failure)
                   ],
                   Apply
                     (?, Variable (?, read_counter),
                       [ Tuple (?) ])), Some x,
               Lift
-                (?, [ NonTermination; OCaml.Assert_failure ],
+                (?,
                   [
-                    Counter;
-                    NonTermination;
-                    OCaml.Assert_failure
+                    Type (NonTermination);
+                    Type (OCaml.Assert_failure)
+                  ],
+                  [
+                    Type (Counter);
+                    Type (NonTermination);
+                    Type (OCaml.Assert_failure)
                   ],
                   Apply
                     (?,
@@ -5442,7 +5514,11 @@ Value
       ((sort_uniq, [ A ],
         [ (cmp, (A -> (A -> Type (Z)))); (l, Type (list, A)) ],
         Monad
-          ([ Counter; NonTermination; OCaml.Assert_failure ], Type (list, A))),
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Assert_failure)
+          ], Type (list, A))),
         LetVar ? len =
           Apply (431, Variable (431, length), [ Variable (431, l) ]) in
         IfThenElse

--- a/tests/ex28.effects
+++ b/tests/ex28.effects
@@ -49,7 +49,9 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .)),
                                     f),
                                 [
                                   Variable
@@ -144,7 +146,9 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .)),
                                     f),
                                 [
                                   Variable
@@ -178,7 +182,9 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .)),
                                       f);
                                   Variable
                                     ((14,
@@ -194,7 +200,7 @@ Value
           ((15, Effect ([ ], .)),
             Variable ((15, Effect ([ ], . -> . -> .)), map2_coq_rec),
             [
-              Variable ((15, Effect ([ ], .)), f);
+              Variable ((15, Effect ([ ], . -> .)), f);
               Variable ((15, Effect ([ ], .)), l)
             ]))
     ])

--- a/tests/ex29.effects
+++ b/tests/ex29.effects
@@ -18,7 +18,9 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .)),
                         negb),
                     [
                       Apply
@@ -63,7 +65,9 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .)),
                         negb),
                     [
                       Apply
@@ -98,23 +102,27 @@ Value
 Value
   (rec, @coq_rec,
     [
-      ((odd_length_with_print, [ A ], [ (l, Type (list, A)) ], Type (bool)),
+      ((odd_length_with_print, [ A ], [ (l, Type (list, A)) ],
+        Monad ([ Type (IO) ], Type (bool))),
         Match
-          ((15, Effect ([ IO ], .)), Variable ((15, Effect ([ ], .)), l),
+          ((15, Effect ([ Type (IO) ], .)),
+            Variable ((15, Effect ([ ], .)), l),
             [
               (Constructor ([]),
                 Sequence
                   ((16,
                     Effect
                       ([
-                        IO
+                        Type
+                          (IO)
                       ],
                         .)),
                     Apply
                       ((16,
                         Effect
                           ([
-                            IO
+                            Type
+                              (IO)
                           ],
                             .)),
                         Variable
@@ -124,7 +132,8 @@ Value
                               ],
                                 .
                                   -[
-                                    IO
+                                    Type
+                                      (IO)
                                   ]->
                                   .)),
                             OCaml.Pervasives.print_endline),
@@ -149,7 +158,8 @@ Value
                   ((17,
                     Effect
                       ([
-                        IO
+                        Type
+                          (IO)
                       ],
                         .)),
                     Variable
@@ -157,14 +167,17 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .)),
                         negb),
                     [
                       Apply
                         ((17,
                           Effect
                             ([
-                              IO
+                              Type
+                                (IO)
                             ],
                               .)),
                           Variable
@@ -174,7 +187,8 @@ Value
                                 ],
                                   .
                                     -[
-                                      IO
+                                      Type
+                                        (IO)
                                     ]->
                                     .)),
                               even_length_with_print),
@@ -189,9 +203,11 @@ Value
                           ])
                     ]))
             ]));
-      ((even_length_with_print, [ A ], [ (l, Type (list, A)) ], Type (bool)),
+      ((even_length_with_print, [ A ], [ (l, Type (list, A)) ],
+        Monad ([ Type (IO) ], Type (bool))),
         Match
-          ((21, Effect ([ IO ], .)), Variable ((21, Effect ([ ], .)), l),
+          ((21, Effect ([ Type (IO) ], .)),
+            Variable ((21, Effect ([ ], .)), l),
             [
               (Constructor ([]),
                 Constructor
@@ -202,7 +218,8 @@ Value
                   ((23,
                     Effect
                       ([
-                        IO
+                        Type
+                          (IO)
                       ],
                         .)),
                     Variable
@@ -210,14 +227,17 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .)),
                         negb),
                     [
                       Apply
                         ((23,
                           Effect
                             ([
-                              IO
+                              Type
+                                (IO)
                             ],
                               .)),
                           Variable
@@ -227,7 +247,8 @@ Value
                                 ],
                                   .
                                     -[
-                                      IO
+                                      Type
+                                        (IO)
                                     ]->
                                     .)),
                               odd_length_with_print),
@@ -249,9 +270,10 @@ Value
   (rec, @.,
     [
       ((odd_length_free_rec, [ A ],
-        [ (counter, Type (nat)); (l, Type (list, A)) ], Type (bool)),
+        [ (counter, Type (nat)); (l, Type (list, A)) ],
+        Monad ([ Type (NonTermination) ], Type (bool))),
         Match
-          ((?, Effect ([ NonTermination ], .)),
+          ((?, Effect ([ Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), counter),
             [
               (Constructor (O),
@@ -259,7 +281,8 @@ Value
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -269,7 +292,8 @@ Value
                           ],
                             .
                               -[
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         not_terminated),
@@ -286,7 +310,8 @@ Value
                   ((26,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -314,7 +339,8 @@ Value
                           ((28,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Variable
@@ -322,14 +348,17 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .)),
                                 negb),
                             [
                               Apply
                                 ((28,
                                   Effect
                                     ([
-                                      NonTermination
+                                      Type
+                                        (NonTermination)
                                     ],
                                       .)),
                                   Apply
@@ -339,7 +368,8 @@ Value
                                         ],
                                           .
                                             -[
-                                              NonTermination
+                                              Type
+                                                (NonTermination)
                                             ]->
                                             .)),
                                       Variable
@@ -351,7 +381,8 @@ Value
                                                 ->
                                                 .
                                                   -[
-                                                    NonTermination
+                                                    Type
+                                                      (NonTermination)
                                                   ]->
                                                   .)),
                                           even_length_free_rec),
@@ -377,9 +408,10 @@ Value
                     ]))
             ]));
       ((even_length_free_rec, [ A ],
-        [ (counter, Type (nat)); (l, Type (list, A)) ], Type (bool)),
+        [ (counter, Type (nat)); (l, Type (list, A)) ],
+        Monad ([ Type (NonTermination) ], Type (bool))),
         Match
-          ((?, Effect ([ NonTermination ], .)),
+          ((?, Effect ([ Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), counter),
             [
               (Constructor (O),
@@ -387,7 +419,8 @@ Value
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -397,7 +430,8 @@ Value
                           ],
                             .
                               -[
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         not_terminated),
@@ -414,7 +448,8 @@ Value
                   ((31,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -442,7 +477,8 @@ Value
                           ((33,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Variable
@@ -450,14 +486,17 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .)),
                                 negb),
                             [
                               Apply
                                 ((33,
                                   Effect
                                     ([
-                                      NonTermination
+                                      Type
+                                        (NonTermination)
                                     ],
                                       .)),
                                   Apply
@@ -467,7 +506,8 @@ Value
                                         ],
                                           .
                                             -[
-                                              NonTermination
+                                              Type
+                                                (NonTermination)
                                             ]->
                                             .)),
                                       Variable
@@ -479,7 +519,8 @@ Value
                                                 ->
                                                 .
                                                   -[
-                                                    NonTermination
+                                                    Type
+                                                      (NonTermination)
                                                   ]->
                                                   .)),
                                           odd_length_free_rec),
@@ -510,15 +551,16 @@ Value
 Value
   (non_rec, @.,
     [
-      ((odd_length_free, [ A ], [ (l, Type (list, A)) ], Type (bool)),
+      ((odd_length_free, [ A ], [ (l, Type (list, A)) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (bool))),
         Apply
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable
-              ((?, Effect ([ ], . -> . -[ NonTermination ]-> .)),
+              ((?, Effect ([ ], . -> . -[ Type (NonTermination) ]-> .)),
                 odd_length_free_rec),
             [
               Apply
-                ((?, Effect ([ Counter ], .)),
+                ((?, Effect ([ Type (Counter) ], .)),
                   Variable
                     ((?,
                       Effect
@@ -526,7 +568,8 @@ Value
                         ],
                           .
                             -[
-                              Counter
+                              Type
+                                (Counter)
                             ]->
                             .)),
                       read_counter),
@@ -546,15 +589,16 @@ Value
 Value
   (non_rec, @.,
     [
-      ((even_length_free, [ A ], [ (l, Type (list, A)) ], Type (bool)),
+      ((even_length_free, [ A ], [ (l, Type (list, A)) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (bool))),
         Apply
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable
-              ((?, Effect ([ ], . -> . -[ NonTermination ]-> .)),
+              ((?, Effect ([ ], . -> . -[ Type (NonTermination) ]-> .)),
                 even_length_free_rec),
             [
               Apply
-                ((?, Effect ([ Counter ], .)),
+                ((?, Effect ([ Type (Counter) ], .)),
                   Variable
                     ((?,
                       Effect
@@ -562,7 +606,8 @@ Value
                         ],
                           .
                             -[
-                              Counter
+                              Type
+                                (Counter)
                             ]->
                             .)),
                       read_counter),

--- a/tests/ex29.monadise
+++ b/tests/ex29.monadise
@@ -57,7 +57,7 @@ Value
   (rec, @coq_rec,
     [
       ((odd_length_with_print, [ A ], [ (l, Type (list, A)) ],
-        Monad ([ IO ], Type (bool))),
+        Monad ([ Type (IO) ], Type (bool))),
         Match
           (15, Variable (15, l),
             [
@@ -109,7 +109,7 @@ Value
                             ]))))
             ]));
       ((even_length_with_print, [ A ], [ (l, Type (list, A)) ],
-        Monad ([ IO ], Type (bool))),
+        Monad ([ Type (IO) ], Type (bool))),
         Match
           (21, Variable (21, l),
             [
@@ -150,7 +150,7 @@ Value
     [
       ((odd_length_free_rec, [ A ],
         [ (counter, Type (nat)); (l, Type (list, A)) ],
-        Monad ([ NonTermination ], Type (bool))),
+        Monad ([ Type (NonTermination) ], Type (bool))),
         Match
           (?, Variable (?, counter),
             [
@@ -216,7 +216,7 @@ Value
             ]));
       ((even_length_free_rec, [ A ],
         [ (counter, Type (nat)); (l, Type (list, A)) ],
-        Monad ([ NonTermination ], Type (bool))),
+        Monad ([ Type (NonTermination) ], Type (bool))),
         Match
           (?, Variable (?, counter),
             [
@@ -287,15 +287,17 @@ Value
   (non_rec, @.,
     [
       ((odd_length_free, [ A ], [ (l, Type (list, A)) ],
-        Monad ([ Counter; NonTermination ], Type (bool))),
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (bool))),
         Bind
           (?,
             Lift
-              (?, [ Counter ], [ Counter; NonTermination ],
+              (?, [ Type (Counter) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply (?, Variable (?, read_counter), [ Tuple (?) ])),
             Some x,
             Lift
-              (?, [ NonTermination ], [ Counter; NonTermination ],
+              (?, [ Type (NonTermination) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply
                   (?, Variable (?, odd_length_free_rec),
                     [ Variable (?, x); Variable (?, l) ]))))
@@ -306,15 +308,17 @@ Value
   (non_rec, @.,
     [
       ((even_length_free, [ A ], [ (l, Type (list, A)) ],
-        Monad ([ Counter; NonTermination ], Type (bool))),
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (bool))),
         Bind
           (?,
             Lift
-              (?, [ Counter ], [ Counter; NonTermination ],
+              (?, [ Type (Counter) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply (?, Variable (?, read_counter), [ Tuple (?) ])),
             Some x,
             Lift
-              (?, [ NonTermination ], [ Counter; NonTermination ],
+              (?, [ Type (NonTermination) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply
                   (?, Variable (?, even_length_free_rec),
                     [ Variable (?, x); Variable (?, l) ]))))

--- a/tests/ex30.effects
+++ b/tests/ex30.effects
@@ -3,9 +3,9 @@
   Value
     (non_rec, @.,
       [
-        ((f, [ A; B ], [ (x, A) ], B),
+        ((f, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Failure) ], B)),
           Match
-            ((?, Effect ([ OCaml.Failure ], .)),
+            ((?, Effect ([ Type (OCaml.Failure) ], .)),
               Variable ((?, Effect ([ ], .)), M/x),
               [
                 (Any,
@@ -13,7 +13,8 @@
                     ((4,
                       Effect
                         ([
-                          OCaml.Failure
+                          Type
+                            (OCaml.Failure)
                         ],
                           .)),
                       Variable
@@ -23,7 +24,8 @@
                             ],
                               .
                                 -[
-                                  OCaml.Failure
+                                  Type
+                                    (OCaml.Failure)
                                 ]->
                                 .)),
                           OCaml.Pervasives.failwith),
@@ -44,9 +46,9 @@
   Value
     (non_rec, @.,
       [
-        ((f, [ A; B ], [ (x, A) ], B),
+        ((f, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Assert_failure) ], B)),
           Match
-            ((?, Effect ([ OCaml.Assert_failure ], .)),
+            ((?, Effect ([ Type (OCaml.Assert_failure) ], .)),
               Variable ((?, Effect ([ ], .)), N/x),
               [
                 (Any,
@@ -54,7 +56,8 @@
                     ((8,
                       Effect
                         ([
-                          OCaml.Assert_failure
+                          Type
+                            (OCaml.Assert_failure)
                         ],
                           .)),
                       Variable
@@ -64,7 +67,8 @@
                             ],
                               .
                                 -[
-                                  OCaml.Assert_failure
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ]->
                                 .)),
                           OCaml.assert),
@@ -93,15 +97,18 @@
                   Apply
                     ((9,
                       Effect
-                        ([ OCaml.Assert_failure ],
-                          .)),
+                        ([
+                          Type
+                            (OCaml.Assert_failure)
+                        ], .)),
                       Variable
                         ((9,
                           Effect
                             ([ ],
                               .
                                 -[
-                                  OCaml.Assert_failure
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ]->
                                 .)),
                           N/f),
@@ -146,14 +153,18 @@
               Run
                 ((?, Effect ([ ], .)), OCaml.Failure, [ ],
                   Apply
-                    ((11, Effect ([ OCaml.Failure ], .)),
+                    ((11,
+                      Effect
+                        ([ Type (OCaml.Failure) ],
+                          .)),
                       Variable
                         ((11,
                           Effect
                             ([ ],
                               .
                                 -[
-                                  OCaml.Failure
+                                  Type
+                                    (OCaml.Failure)
                                 ]->
                                 .)),
                           M.f),
@@ -196,13 +207,16 @@ Value
             Run
               ((?, Effect ([ ], .)), OCaml.Assert_failure, [ ],
                 Apply
-                  ((14, Effect ([ OCaml.Assert_failure ], .)),
+                  ((14, Effect ([ Type (OCaml.Assert_failure) ], .)),
                     Variable
                       ((14,
                         Effect
                           ([ ],
-                            . -[ OCaml.Assert_failure ]->
-                              .)), N.f),
+                            .
+                              -[
+                                Type
+                                  (OCaml.Assert_failure)
+                              ]-> .)), N.f),
                     [ Constructor ((14, Effect ([ ], .)), tt) ])),
             [
               (Constructor (inl, x), Variable ((?, Effect ([ ], .)), x));
@@ -223,13 +237,16 @@ Value
             Run
               ((?, Effect ([ ], .)), OCaml.Assert_failure, [ ],
                 Apply
-                  ((16, Effect ([ OCaml.Assert_failure ], .)),
+                  ((16, Effect ([ Type (OCaml.Assert_failure) ], .)),
                     Variable
                       ((16,
                         Effect
                           ([ ],
-                            . -[ OCaml.Assert_failure ]->
-                              .)), N.f),
+                            .
+                              -[
+                                Type
+                                  (OCaml.Assert_failure)
+                              ]-> .)), N.f),
                     [ Constructor ((16, Effect ([ ], .)), tt) ])),
             [
               (Constructor (inl, x), Variable ((?, Effect ([ ], .)), x));
@@ -248,9 +265,9 @@ Value
   Value
     (non_rec, @.,
       [
-        ((x, [ A; B ], [ (x, A) ], B),
+        ((x, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Assert_failure) ], B)),
           Match
-            ((?, Effect ([ OCaml.Assert_failure ], .)),
+            ((?, Effect ([ Type (OCaml.Assert_failure) ], .)),
               Variable ((?, Effect ([ ], .)), A/x),
               [
                 (Any,
@@ -258,7 +275,8 @@ Value
                     ((21,
                       Effect
                         ([
-                          OCaml.Assert_failure
+                          Type
+                            (OCaml.Assert_failure)
                         ],
                           .)),
                       Variable
@@ -268,7 +286,8 @@ Value
                             ],
                               .
                                 -[
-                                  OCaml.Assert_failure
+                                  Type
+                                    (OCaml.Assert_failure)
                                 ]->
                                 .)),
                           OCaml.assert),
@@ -296,18 +315,19 @@ Value
   Value
     (non_rec, @.,
       [
-        ((b, [ A; B ], [ ], (A -> B)),
+        ((b, [ A; B ], [ ], (A -> Monad ([ Type (OCaml.Assert_failure) ], B))),
           Variable
-            ((27, Effect ([ ], . -[ OCaml.Assert_failure ]-> .)), A/x))
+            ((27, Effect ([ ], . -[ Type (OCaml.Assert_failure) ]-> .)),
+              A/x))
       ])
   
   28
   Value
     (non_rec, @.,
       [
-        ((x, [ A; B ], [ (x, A) ], B),
+        ((x, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Failure) ], B)),
           Match
-            ((?, Effect ([ OCaml.Failure ], .)),
+            ((?, Effect ([ Type (OCaml.Failure) ], .)),
               Variable ((?, Effect ([ ], .)), B/x),
               [
                 (Any,
@@ -315,7 +335,8 @@ Value
                     ((28,
                       Effect
                         ([
-                          OCaml.Failure
+                          Type
+                            (OCaml.Failure)
                         ],
                           .)),
                       Variable
@@ -325,7 +346,8 @@ Value
                             ],
                               .
                                 -[
-                                  OCaml.Failure
+                                  Type
+                                    (OCaml.Failure)
                                 ]->
                                 .)),
                           OCaml.Pervasives.failwith),
@@ -345,8 +367,9 @@ Value
   Value
     (non_rec, @.,
       [
-        ((c, [ A; B ], [ ], (A -> B)),
-          Variable ((29, Effect ([ ], . -[ OCaml.Failure ]-> .)), B/x))
+        ((c, [ A; B ], [ ], (A -> Monad ([ Type (OCaml.Failure) ], B))),
+          Variable
+            ((29, Effect ([ ], . -[ Type (OCaml.Failure) ]-> .)), B/x))
       ])
 
 32 Module C:
@@ -359,9 +382,9 @@ Value
   Value
     (non_rec, @.,
       [
-        ((x, [ A; B ], [ (x, A) ], B),
+        ((x, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Failure) ], B)),
           Match
-            ((?, Effect ([ OCaml.Failure ], .)),
+            ((?, Effect ([ Type (OCaml.Failure) ], .)),
               Variable ((?, Effect ([ ], .)), C/x),
               [
                 (Any,
@@ -369,7 +392,8 @@ Value
                     ((34,
                       Effect
                         ([
-                          OCaml.Failure
+                          Type
+                            (OCaml.Failure)
                         ],
                           .)),
                       Variable
@@ -379,7 +403,8 @@ Value
                             ],
                               .
                                 -[
-                                  OCaml.Failure
+                                  Type
+                                    (OCaml.Failure)
                                 ]->
                                 .)),
                           OCaml.Pervasives.failwith),
@@ -399,8 +424,9 @@ Value
   Value
     (non_rec, @.,
       [
-        ((b, [ A; B ], [ ], (A -> B)),
-          Variable ((35, Effect ([ ], . -[ OCaml.Failure ]-> .)), C/x))
+        ((b, [ A; B ], [ ], (A -> Monad ([ Type (OCaml.Failure) ], B))),
+          Variable
+            ((35, Effect ([ ], . -[ Type (OCaml.Failure) ]-> .)), C/x))
       ])
   
   36 Open A
@@ -409,9 +435,10 @@ Value
   Value
     (non_rec, @.,
       [
-        ((c, [ A; B ], [ ], (A -> B)),
+        ((c, [ A; B ], [ ], (A -> Monad ([ Type (OCaml.Assert_failure) ], B))),
           Variable
-            ((37, Effect ([ ], . -[ OCaml.Assert_failure ]-> .)), A.x))
+            ((37, Effect ([ ], . -[ Type (OCaml.Assert_failure) ]-> .)),
+              A.x))
       ])
 
 40 Module D:

--- a/tests/ex30.monadise
+++ b/tests/ex30.monadise
@@ -3,7 +3,7 @@
   Value
     (non_rec, @.,
       [
-        ((f, [ A; B ], [ (x, A) ], Monad ([ OCaml.Failure ], B)),
+        ((f, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Failure) ], B)),
           Match
             (?, Variable (?, M/x),
               [
@@ -26,7 +26,7 @@
   Value
     (non_rec, @.,
       [
-        ((f, [ A; B ], [ (x, A) ], Monad ([ OCaml.Assert_failure ], B)),
+        ((f, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Assert_failure) ], B)),
           Match
             (?, Variable (?, N/x),
               [
@@ -128,7 +128,7 @@ Value
   Value
     (non_rec, @.,
       [
-        ((x, [ A; B ], [ (x, A) ], Monad ([ OCaml.Assert_failure ], B)),
+        ((x, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Assert_failure) ], B)),
           Match
             (?, Variable (?, A/x),
               [
@@ -155,7 +155,7 @@ Value
   Value
     (non_rec, @.,
       [
-        ((b, [ A; B ], [ ], (A -> Monad ([ OCaml.Assert_failure ], B))),
+        ((b, [ A; B ], [ ], (A -> Monad ([ Type (OCaml.Assert_failure) ], B))),
           Variable (27, A/x))
       ])
   
@@ -163,7 +163,7 @@ Value
   Value
     (non_rec, @.,
       [
-        ((x, [ A; B ], [ (x, A) ], Monad ([ OCaml.Failure ], B)),
+        ((x, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Failure) ], B)),
           Match
             (?, Variable (?, B/x),
               [
@@ -185,7 +185,7 @@ Value
   Value
     (non_rec, @.,
       [
-        ((c, [ A; B ], [ ], (A -> Monad ([ OCaml.Failure ], B))),
+        ((c, [ A; B ], [ ], (A -> Monad ([ Type (OCaml.Failure) ], B))),
           Variable (29, B/x))
       ])
 
@@ -196,7 +196,7 @@ Value
   Value
     (non_rec, @.,
       [
-        ((x, [ A; B ], [ (x, A) ], Monad ([ OCaml.Failure ], B)),
+        ((x, [ A; B ], [ (x, A) ], Monad ([ Type (OCaml.Failure) ], B)),
           Match
             (?, Variable (?, C/x),
               [
@@ -218,7 +218,7 @@ Value
   Value
     (non_rec, @.,
       [
-        ((b, [ A; B ], [ ], (A -> Monad ([ OCaml.Failure ], B))),
+        ((b, [ A; B ], [ ], (A -> Monad ([ Type (OCaml.Failure) ], B))),
           Variable (35, C/x))
       ])
   
@@ -228,7 +228,7 @@ Value
   Value
     (non_rec, @.,
       [
-        ((c, [ A; B ], [ ], (A -> Monad ([ OCaml.Assert_failure ], B))),
+        ((c, [ A; B ], [ ], (A -> Monad ([ Type (OCaml.Assert_failure) ], B))),
           Variable (37, A.x))
       ])
 

--- a/tests/ex31.effects
+++ b/tests/ex31.effects
@@ -15,7 +15,8 @@ Value
     [
       ((n, [ ], [ ], Type (Z)),
         Apply
-          ((10, Effect ([ ], .)), Variable ((10, Effect ([ ], .)), Z.add),
+          ((10, Effect ([ ], .)),
+            Variable ((10, Effect ([ ], . -> . -> .)), Z.add),
             [
               Variable ((10, Effect ([ ], .)), M.n);
               Constant ((10, Effect ([ ], .)), Int(2))

--- a/tests/ex33.effects
+++ b/tests/ex33.effects
@@ -7,7 +7,7 @@
       [
         ((compare, [ ], [ (x, Type (Ord/t)) ], (Type (Ord/t) -> Type (Z))),
           Match
-            ((?, Effect ([ ], .)),
+            ((?, Effect ([ ], . -> .)),
               Variable ((?, Effect ([ ], .)), Ord/x),
               [
                 (Any,
@@ -98,7 +98,7 @@ Value
                 Apply
                   ((21, Effect ([ ], .)),
                     Variable
-                      ((21, Effect ([ ], .)),
+                      ((21, Effect ([ ], . -> . -> .)),
                         OCaml.Pervasives.ge),
                     [
                       Variable ((21, Effect ([ ], .)), hl);
@@ -106,14 +106,16 @@ Value
                     ]),
                 Apply
                   ((21, Effect ([ ], .)),
-                    Variable ((21, Effect ([ ], .)), Z.add),
+                    Variable
+                      ((21, Effect ([ ], . -> . -> .)), Z.add),
                     [
                       Variable ((21, Effect ([ ], .)), hl);
                       Constant ((21, Effect ([ ], .)), Int(1))
                     ]),
                 Apply
                   ((21, Effect ([ ], .)),
-                    Variable ((21, Effect ([ ], .)), Z.add),
+                    Variable
+                      ((21, Effect ([ ], . -> . -> .)), Z.add),
                     [
                       Variable ((21, Effect ([ ], .)), hr);
                       Constant ((21, Effect ([ ], .)), Int(1))
@@ -140,8 +142,8 @@ Value
     [
       ((bal, [ A ],
         [ (l, Type (t, A)); (x, Type (key)); (d, A); (r, Type (t, A)) ],
-        Type (t, A)),
-        LetVar (26, Effect ([ OCaml.Invalid_argument ], .)) hl =
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t, A))),
+        LetVar (26, Effect ([ Type (OCaml.Invalid_argument) ], .)) hl =
           Match
             ((26, Effect ([ ], .)), Variable ((26, Effect ([ ], .)), l),
               [
@@ -162,7 +164,7 @@ Value
                           .)),
                       h))
               ]) in
-        LetVar (27, Effect ([ OCaml.Invalid_argument ], .)) hr =
+        LetVar (27, Effect ([ Type (OCaml.Invalid_argument) ], .)) hr =
           Match
             ((27, Effect ([ ], .)), Variable ((27, Effect ([ ], .)), r),
               [
@@ -184,10 +186,12 @@ Value
                       h))
               ]) in
         IfThenElse
-          ((28, Effect ([ OCaml.Invalid_argument ], .)),
+          ((28, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Apply
               ((28, Effect ([ ], .)),
-                Variable ((28, Effect ([ ], .)), OCaml.Pervasives.gt),
+                Variable
+                  ((28, Effect ([ ], . -> . -> .)),
+                    OCaml.Pervasives.gt),
                 [
                   Variable ((28, Effect ([ ], .)), hl);
                   Apply
@@ -197,7 +201,11 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .
+                                  ->
+                                  .)),
                           Z.add),
                       [
                         Variable
@@ -217,7 +225,7 @@ Value
                       ])
                 ]),
             Match
-              ((28, Effect ([ OCaml.Invalid_argument ], .)),
+              ((28, Effect ([ Type (OCaml.Invalid_argument) ], .)),
                 Variable ((29, Effect ([ ], .)), l),
                 [
                   (Constructor (Empty),
@@ -225,7 +233,8 @@ Value
                       ((30,
                         Effect
                           ([
-                            OCaml.Invalid_argument
+                            Type
+                              (OCaml.Invalid_argument)
                           ],
                             .)),
                         Variable
@@ -235,7 +244,8 @@ Value
                               ],
                                 .
                                   -[
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ]->
                                   .)),
                             OCaml.Pervasives.invalid_arg),
@@ -253,7 +263,8 @@ Value
                       ((32,
                         Effect
                           ([
-                            OCaml.Invalid_argument
+                            Type
+                              (OCaml.Invalid_argument)
                           ],
                             .)),
                         Apply
@@ -267,7 +278,11 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .
+                                        ->
+                                        .)),
                                 OCaml.Pervasives.ge),
                             [
                               Apply
@@ -418,7 +433,8 @@ Value
                           ((34,
                             Effect
                               ([
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Variable
@@ -435,7 +451,8 @@ Value
                                   ((36,
                                     Effect
                                       ([
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ],
                                         .)),
                                     Variable
@@ -445,7 +462,8 @@ Value
                                           ],
                                             .
                                               -[
-                                                OCaml.Invalid_argument
+                                                Type
+                                                  (OCaml.Invalid_argument)
                                               ]->
                                               .)),
                                         OCaml.Pervasives.invalid_arg),
@@ -607,11 +625,11 @@ Value
                             ])))
                 ]),
             IfThenElse
-              ((40, Effect ([ OCaml.Invalid_argument ], .)),
+              ((40, Effect ([ Type (OCaml.Invalid_argument) ], .)),
                 Apply
                   ((40, Effect ([ ], .)),
                     Variable
-                      ((40, Effect ([ ], .)),
+                      ((40, Effect ([ ], . -> . -> .)),
                         OCaml.Pervasives.gt),
                     [
                       Variable ((40, Effect ([ ], .)), hr);
@@ -626,7 +644,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               Z.add),
                           [
                             Variable
@@ -646,7 +668,8 @@ Value
                           ])
                     ]),
                 Match
-                  ((40, Effect ([ OCaml.Invalid_argument ], .)),
+                  ((40,
+                    Effect ([ Type (OCaml.Invalid_argument) ], .)),
                     Variable ((41, Effect ([ ], .)), r),
                     [
                       (Constructor (Empty),
@@ -654,7 +677,8 @@ Value
                           ((42,
                             Effect
                               ([
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Variable
@@ -664,7 +688,8 @@ Value
                                   ],
                                     .
                                       -[
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ]->
                                       .)),
                                 OCaml.Pervasives.invalid_arg),
@@ -682,7 +707,8 @@ Value
                           ((44,
                             Effect
                               ([
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Apply
@@ -696,7 +722,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     OCaml.Pervasives.ge),
                                 [
                                   Apply
@@ -847,7 +877,8 @@ Value
                               ((46,
                                 Effect
                                   ([
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ],
                                     .)),
                                 Variable
@@ -864,7 +895,8 @@ Value
                                       ((48,
                                         Effect
                                           ([
-                                            OCaml.Invalid_argument
+                                            Type
+                                              (OCaml.Invalid_argument)
                                           ],
                                             .)),
                                         Variable
@@ -874,7 +906,8 @@ Value
                                               ],
                                                 .
                                                   -[
-                                                    OCaml.Invalid_argument
+                                                    Type
+                                                      (OCaml.Invalid_argument)
                                                   ]->
                                                   .)),
                                             OCaml.Pervasives.invalid_arg),
@@ -1046,7 +1079,9 @@ Value
                         Apply
                           ((53, Effect ([ ], .)),
                             Variable
-                              ((53, Effect ([ ], .)),
+                              ((53,
+                                Effect
+                                  ([ ], . -> . -> .)),
                                 OCaml.Pervasives.ge),
                             [
                               Variable
@@ -1067,7 +1102,9 @@ Value
                         Apply
                           ((53, Effect ([ ], .)),
                             Variable
-                              ((53, Effect ([ ], .)),
+                              ((53,
+                                Effect
+                                  ([ ], . -> . -> .)),
                                 Z.add),
                             [
                               Variable
@@ -1088,7 +1125,9 @@ Value
                         Apply
                           ((53, Effect ([ ], .)),
                             Variable
-                              ((53, Effect ([ ], .)),
+                              ((53,
+                                Effect
+                                  ([ ], . -> . -> .)),
                                 Z.add),
                             [
                               Variable
@@ -1137,9 +1176,9 @@ Value
   (rec, @coq_rec,
     [
       ((add, [ A ], [ (x, Type (key)); (data, A); (x_1, Type (t, A)) ],
-        Type (t, A)),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t, A))),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument ], .)),
+          ((?, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable ((?, Effect ([ ], .)), x_1),
             [
               (Constructor (Empty),
@@ -1186,7 +1225,8 @@ Value
                   (63,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .))
                   c =
@@ -1203,7 +1243,9 @@ Value
                             ],
                               .
                                 ->
-                                .)),
+                                .
+                                  ->
+                                  .)),
                           Ord.compare),
                       [
                         Variable
@@ -1226,7 +1268,8 @@ Value
                   ((64,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Apply
@@ -1240,7 +1283,11 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .
+                                    ->
+                                    .)),
                             equiv_decb),
                         [
                           Variable
@@ -1304,7 +1351,8 @@ Value
                       ((66,
                         Effect
                           ([
-                            OCaml.Invalid_argument
+                            Type
+                              (OCaml.Invalid_argument)
                           ],
                             .)),
                         Apply
@@ -1318,7 +1366,11 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .
+                                        ->
+                                        .)),
                                 OCaml.Pervasives.lt),
                             [
                               Variable
@@ -1340,7 +1392,8 @@ Value
                           ((67,
                             Effect
                               ([
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Variable
@@ -1356,7 +1409,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              OCaml.Invalid_argument
+                                              Type
+                                                (OCaml.Invalid_argument)
                                             ]->
                                             .)),
                                 bal),
@@ -1365,7 +1419,8 @@ Value
                                 ((67,
                                   Effect
                                     ([
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ],
                                       .)),
                                   Variable
@@ -1379,7 +1434,8 @@ Value
                                               ->
                                               .
                                                 -[
-                                                  OCaml.Invalid_argument
+                                                  Type
+                                                    (OCaml.Invalid_argument)
                                                 ]->
                                                 .)),
                                       add),
@@ -1432,7 +1488,8 @@ Value
                           ((69,
                             Effect
                               ([
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Variable
@@ -1448,7 +1505,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              OCaml.Invalid_argument
+                                              Type
+                                                (OCaml.Invalid_argument)
                                             ]->
                                             .)),
                                 bal),
@@ -1478,7 +1536,8 @@ Value
                                 ((69,
                                   Effect
                                     ([
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ],
                                       .)),
                                   Variable
@@ -1492,7 +1551,8 @@ Value
                                               ->
                                               .
                                                 -[
-                                                  OCaml.Invalid_argument
+                                                  Type
+                                                    (OCaml.Invalid_argument)
                                                 ]->
                                                 .)),
                                       add),
@@ -1527,9 +1587,10 @@ Value
 Value
   (rec, @coq_rec,
     [
-      ((find, [ A ], [ (x, Type (Ord.t)); (x_1, Type (t, A)) ], A),
+      ((find, [ A ], [ (x, Type (Ord.t)); (x_1, Type (t, A)) ],
+        Monad ([ Type (OCaml.Not_found) ], A)),
         Match
-          ((?, Effect ([ OCaml.Not_found ], .)),
+          ((?, Effect ([ Type (OCaml.Not_found) ], .)),
             Variable ((?, Effect ([ ], .)), x_1),
             [
               (Constructor (Empty),
@@ -1537,7 +1598,8 @@ Value
                   ((74,
                     Effect
                       ([
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Variable
@@ -1547,7 +1609,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Not_found
+                                Type
+                                  (OCaml.Not_found)
                               ]->
                               .)),
                         OCaml.raise_Not_found),
@@ -1564,7 +1627,8 @@ Value
                   (76,
                     Effect
                       ([
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .))
                   c =
@@ -1581,7 +1645,9 @@ Value
                             ],
                               .
                                 ->
-                                .)),
+                                .
+                                  ->
+                                  .)),
                           Ord.compare),
                       [
                         Variable
@@ -1604,7 +1670,8 @@ Value
                   ((77,
                     Effect
                       ([
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Apply
@@ -1618,7 +1685,11 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .
+                                    ->
+                                    .)),
                             equiv_decb),
                         [
                           Variable
@@ -1647,7 +1718,8 @@ Value
                       ((78,
                         Effect
                           ([
-                            OCaml.Not_found
+                            Type
+                              (OCaml.Not_found)
                           ],
                             .)),
                         Variable
@@ -1659,7 +1731,8 @@ Value
                                   ->
                                   .
                                     -[
-                                      OCaml.Not_found
+                                      Type
+                                        (OCaml.Not_found)
                                     ]->
                                     .)),
                             find),
@@ -1688,7 +1761,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       OCaml.Pervasives.lt),
                                   [
                                     Variable
@@ -1751,7 +1828,9 @@ Value
                             ],
                               .
                                 ->
-                                .)),
+                                .
+                                  ->
+                                  .)),
                           Ord.compare),
                       [
                         Variable
@@ -1777,7 +1856,11 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .
+                                ->
+                                .)),
                         orb),
                     [
                       Apply
@@ -1791,7 +1874,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               equiv_decb),
                           [
                             Variable
@@ -1851,7 +1938,11 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         OCaml.Pervasives.lt),
                                     [
                                       Variable
@@ -1892,9 +1983,10 @@ Value
 Value
   (rec, @coq_rec,
     [
-      ((min_binding, [ A ], [ (x, Type (t, A)) ], (Type (key) * A)),
+      ((min_binding, [ A ], [ (x, Type (t, A)) ],
+        Monad ([ Type (OCaml.Not_found) ], (Type (key) * A))),
         Match
-          ((?, Effect ([ OCaml.Not_found ], .)),
+          ((?, Effect ([ Type (OCaml.Not_found) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (Empty),
@@ -1902,7 +1994,8 @@ Value
                   ((90,
                     Effect
                       ([
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Variable
@@ -1912,7 +2005,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Not_found
+                                Type
+                                  (OCaml.Not_found)
                               ]->
                               .)),
                         OCaml.raise_Not_found),
@@ -1946,7 +2040,8 @@ Value
                   ((92,
                     Effect
                       ([
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Variable
@@ -1956,7 +2051,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Not_found
+                                Type
+                                  (OCaml.Not_found)
                               ]->
                               .)),
                         min_binding),
@@ -1976,9 +2072,10 @@ Value
 Value
   (rec, @coq_rec,
     [
-      ((max_binding, [ A ], [ (x, Type (t, A)) ], (Type (key) * A)),
+      ((max_binding, [ A ], [ (x, Type (t, A)) ],
+        Monad ([ Type (OCaml.Not_found) ], (Type (key) * A))),
         Match
-          ((?, Effect ([ OCaml.Not_found ], .)),
+          ((?, Effect ([ Type (OCaml.Not_found) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (Empty),
@@ -1986,7 +2083,8 @@ Value
                   ((96,
                     Effect
                       ([
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Variable
@@ -1996,7 +2094,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Not_found
+                                Type
+                                  (OCaml.Not_found)
                               ]->
                               .)),
                         OCaml.raise_Not_found),
@@ -2030,7 +2129,8 @@ Value
                   ((98,
                     Effect
                       ([
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Variable
@@ -2040,7 +2140,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Not_found
+                                Type
+                                  (OCaml.Not_found)
                               ]->
                               .)),
                         max_binding),
@@ -2060,9 +2161,10 @@ Value
 Value
   (rec, @coq_rec,
     [
-      ((remove_min_binding, [ A ], [ (x, Type (t, A)) ], Type (t, A)),
+      ((remove_min_binding, [ A ], [ (x, Type (t, A)) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t, A))),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument ], .)),
+          ((?, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (Empty),
@@ -2070,7 +2172,8 @@ Value
                   ((102,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -2080,7 +2183,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ]->
                               .)),
                         OCaml.Pervasives.invalid_arg),
@@ -2100,7 +2204,8 @@ Value
                   ((104,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -2116,7 +2221,8 @@ Value
                                   ->
                                   .
                                     -[
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ]->
                                     .)),
                         bal),
@@ -2125,7 +2231,8 @@ Value
                         ((104,
                           Effect
                             ([
-                              OCaml.Invalid_argument
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                               .)),
                           Variable
@@ -2135,7 +2242,8 @@ Value
                                 ],
                                   .
                                     -[
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ]->
                                     .)),
                               remove_min_binding),
@@ -2178,9 +2286,14 @@ Value
   (non_rec, @.,
     [
       ((remove_merge, [ A ], [ (t1, Type (t, A)); (t2, Type (t, A)) ],
-        Type (t, A)),
+        Monad
+          ([ Type (OCaml.Invalid_argument); Type (OCaml.Not_found) ],
+            Type (t, A))),
         Match
-          ((108, Effect ([ OCaml.Invalid_argument; OCaml.Not_found ], .)),
+          ((108,
+            Effect
+              ([ Type (OCaml.Invalid_argument); Type (OCaml.Not_found) ],
+                .)),
             Tuple
               ((108, Effect ([ ], .)),
                 Variable ((108, Effect ([ ], .)), t1),
@@ -2195,15 +2308,18 @@ Value
                   ((112,
                     Effect
                       ([
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Apply
                       ((112,
                         Effect
                           ([
-                            OCaml.Not_found
+                            Type
+                              (OCaml.Not_found)
                           ],
                             .)),
                         Variable
@@ -2213,7 +2329,8 @@ Value
                               ],
                                 .
                                   -[
-                                    OCaml.Not_found
+                                    Type
+                                      (OCaml.Not_found)
                                   ]->
                                   .)),
                             min_binding),
@@ -2234,7 +2351,8 @@ Value
                           ((113,
                             Effect
                               ([
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Variable
@@ -2250,7 +2368,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              OCaml.Invalid_argument
+                                              Type
+                                                (OCaml.Invalid_argument)
                                             ]->
                                             .)),
                                 bal),
@@ -2280,7 +2399,8 @@ Value
                                 ((113,
                                   Effect
                                     ([
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ],
                                       .)),
                                   Variable
@@ -2290,7 +2410,8 @@ Value
                                         ],
                                           .
                                             -[
-                                              OCaml.Invalid_argument
+                                              Type
+                                                (OCaml.Invalid_argument)
                                             ]->
                                             .)),
                                       remove_min_binding),
@@ -2312,10 +2433,15 @@ Value
 Value
   (rec, @coq_rec,
     [
-      ((remove, [ A ], [ (x, Type (Ord.t)); (x_1, Type (t, A)) ], Type (t, A)),
+      ((remove, [ A ], [ (x, Type (Ord.t)); (x_1, Type (t, A)) ],
+        Monad
+          ([ Type (OCaml.Invalid_argument); Type (OCaml.Not_found) ],
+            Type (t, A))),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument; OCaml.Not_found ], .)),
-            Variable ((?, Effect ([ ], .)), x_1),
+          ((?,
+            Effect
+              ([ Type (OCaml.Invalid_argument); Type (OCaml.Not_found) ],
+                .)), Variable ((?, Effect ([ ], .)), x_1),
             [
               (Constructor (Empty),
                 Constructor
@@ -2326,8 +2452,10 @@ Value
                   (119,
                     Effect
                       ([
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .))
                   c =
@@ -2344,7 +2472,9 @@ Value
                             ],
                               .
                                 ->
-                                .)),
+                                .
+                                  ->
+                                  .)),
                           Ord.compare),
                       [
                         Variable
@@ -2367,8 +2497,10 @@ Value
                   ((120,
                     Effect
                       ([
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Apply
@@ -2382,7 +2514,11 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .
+                                    ->
+                                    .)),
                             equiv_decb),
                         [
                           Variable
@@ -2404,8 +2540,10 @@ Value
                       ((121,
                         Effect
                           ([
-                            OCaml.Invalid_argument;
-                            OCaml.Not_found
+                            Type
+                              (OCaml.Invalid_argument);
+                            Type
+                              (OCaml.Not_found)
                           ],
                             .)),
                         Variable
@@ -2417,8 +2555,10 @@ Value
                                   ->
                                   .
                                     -[
-                                      OCaml.Invalid_argument;
-                                      OCaml.Not_found
+                                      Type
+                                        (OCaml.Invalid_argument);
+                                      Type
+                                        (OCaml.Not_found)
                                     ]->
                                     .)),
                             remove_merge),
@@ -2442,8 +2582,10 @@ Value
                       ((122,
                         Effect
                           ([
-                            OCaml.Invalid_argument;
-                            OCaml.Not_found
+                            Type
+                              (OCaml.Invalid_argument);
+                            Type
+                              (OCaml.Not_found)
                           ],
                             .)),
                         Apply
@@ -2457,7 +2599,11 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .
+                                        ->
+                                        .)),
                                 OCaml.Pervasives.lt),
                             [
                               Variable
@@ -2479,8 +2625,10 @@ Value
                           ((123,
                             Effect
                               ([
-                                OCaml.Invalid_argument;
-                                OCaml.Not_found
+                                Type
+                                  (OCaml.Invalid_argument);
+                                Type
+                                  (OCaml.Not_found)
                               ],
                                 .)),
                             Variable
@@ -2496,7 +2644,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              OCaml.Invalid_argument
+                                              Type
+                                                (OCaml.Invalid_argument)
                                             ]->
                                             .)),
                                 bal),
@@ -2505,8 +2654,10 @@ Value
                                 ((123,
                                   Effect
                                     ([
-                                      OCaml.Invalid_argument;
-                                      OCaml.Not_found
+                                      Type
+                                        (OCaml.Invalid_argument);
+                                      Type
+                                        (OCaml.Not_found)
                                     ],
                                       .)),
                                   Variable
@@ -2518,8 +2669,10 @@ Value
                                             ->
                                             .
                                               -[
-                                                OCaml.Invalid_argument;
-                                                OCaml.Not_found
+                                                Type
+                                                  (OCaml.Invalid_argument);
+                                                Type
+                                                  (OCaml.Not_found)
                                               ]->
                                               .)),
                                       remove),
@@ -2565,8 +2718,10 @@ Value
                           ((125,
                             Effect
                               ([
-                                OCaml.Invalid_argument;
-                                OCaml.Not_found
+                                Type
+                                  (OCaml.Invalid_argument);
+                                Type
+                                  (OCaml.Not_found)
                               ],
                                 .)),
                             Variable
@@ -2582,7 +2737,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              OCaml.Invalid_argument
+                                              Type
+                                                (OCaml.Invalid_argument)
                                             ]->
                                             .)),
                                 bal),
@@ -2612,8 +2768,10 @@ Value
                                 ((125,
                                   Effect
                                     ([
-                                      OCaml.Invalid_argument;
-                                      OCaml.Not_found
+                                      Type
+                                        (OCaml.Invalid_argument);
+                                      Type
+                                        (OCaml.Not_found)
                                     ],
                                       .)),
                                   Variable
@@ -2625,8 +2783,10 @@ Value
                                             ->
                                             .
                                               -[
-                                                OCaml.Invalid_argument;
-                                                OCaml.Not_found
+                                                Type
+                                                  (OCaml.Invalid_argument);
+                                                Type
+                                                  (OCaml.Not_found)
                                               ]->
                                               .)),
                                       remove),
@@ -2687,7 +2847,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               f);
                           Variable
                             ((131,
@@ -2714,7 +2878,11 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .
+                                        ->
+                                        .)),
                                 f),
                             [
                               Variable
@@ -2755,7 +2923,11 @@ Value
                                   Effect
                                     ([
                                     ],
-                                      .)),
+                                      .
+                                        ->
+                                        .
+                                          ->
+                                          .)),
                                   f);
                               Variable
                                 ((131,
@@ -2805,7 +2977,9 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .)),
                             f);
                         Variable
                           ((138,
@@ -2828,7 +3002,9 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .)),
                           f),
                       [
                         Variable
@@ -2864,7 +3040,9 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .)),
                             f);
                         Variable
                           ((140,
@@ -2954,7 +3132,11 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .
+                                    ->
+                                    .)),
                             f);
                         Variable
                           ((148,
@@ -2977,7 +3159,11 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .
+                                  ->
+                                  .)),
                           f),
                       [
                         Variable
@@ -3020,7 +3206,11 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .
+                                    ->
+                                    .)),
                             f);
                         Variable
                           ((150,
@@ -3106,7 +3296,13 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .
+                                  ->
+                                  .
+                                    ->
+                                    .)),
                           f);
                       Variable
                         ((158,
@@ -3126,7 +3322,13 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .
+                                        ->
+                                        .)),
                               f),
                           [
                             Variable
@@ -3168,7 +3370,13 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                       f);
                                   Variable
                                     ((158,
@@ -3212,7 +3420,11 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .
+                                ->
+                                .)),
                         andb),
                     [
                       Apply
@@ -3226,7 +3438,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               p),
                           [
                             Variable
@@ -3255,7 +3471,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               andb),
                           [
                             Apply
@@ -3281,7 +3501,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       p);
                                   Variable
                                     ((163,
@@ -3314,7 +3538,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       p);
                                   Variable
                                     ((163,
@@ -3351,7 +3579,11 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .
+                                ->
+                                .)),
                         orb),
                     [
                       Apply
@@ -3365,7 +3597,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               p),
                           [
                             Variable
@@ -3394,7 +3630,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               orb),
                           [
                             Apply
@@ -3420,7 +3660,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       p);
                                   Variable
                                     ((168,
@@ -3453,7 +3697,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       p);
                                   Variable
                                     ((168,
@@ -3473,9 +3721,9 @@ Value
   (rec, @coq_rec,
     [
       ((add_min_binding, [ A ], [ (k, Type (key)); (v, A); (x, Type (t, A)) ],
-        Type (t, A)),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t, A))),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument ], .)),
+          ((?, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (Empty),
@@ -3513,7 +3761,8 @@ Value
                   ((182,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -3529,7 +3778,8 @@ Value
                                   ->
                                   .
                                     -[
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ]->
                                     .)),
                         bal),
@@ -3538,7 +3788,8 @@ Value
                         ((182,
                           Effect
                             ([
-                              OCaml.Invalid_argument
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                               .)),
                           Variable
@@ -3552,7 +3803,8 @@ Value
                                       ->
                                       .
                                         -[
-                                          OCaml.Invalid_argument
+                                          Type
+                                            (OCaml.Invalid_argument)
                                         ]->
                                         .)),
                               add_min_binding),
@@ -3609,9 +3861,9 @@ Value
   (rec, @coq_rec,
     [
       ((add_max_binding, [ A ], [ (k, Type (key)); (v, A); (x, Type (t, A)) ],
-        Type (t, A)),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t, A))),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument ], .)),
+          ((?, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (Empty),
@@ -3649,7 +3901,8 @@ Value
                   ((188,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -3665,7 +3918,8 @@ Value
                                   ->
                                   .
                                     -[
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ]->
                                     .)),
                         bal),
@@ -3695,7 +3949,8 @@ Value
                         ((188,
                           Effect
                             ([
-                              OCaml.Invalid_argument
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                               .)),
                           Variable
@@ -3709,7 +3964,8 @@ Value
                                       ->
                                       .
                                         -[
-                                          OCaml.Invalid_argument
+                                          Type
+                                            (OCaml.Invalid_argument)
                                         ]->
                                         .)),
                               add_max_binding),
@@ -3751,17 +4007,23 @@ Value
           (v, Type (key));
           (d, A);
           (r, Type (t, A))
-        ], Type (t, A)),
+        ],
+        Monad
+          ([ Type (NonTermination); Type (OCaml.Invalid_argument) ],
+            Type (t, A))),
         Match
-          ((?, Effect ([ NonTermination; OCaml.Invalid_argument ], .)),
-            Variable ((?, Effect ([ ], .)), counter),
+          ((?,
+            Effect
+              ([ Type (NonTermination); Type (OCaml.Invalid_argument) ],
+                .)), Variable ((?, Effect ([ ], .)), counter),
             [
               (Constructor (O),
                 Apply
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -3771,7 +4033,8 @@ Value
                           ],
                             .
                               -[
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         not_terminated),
@@ -3788,8 +4051,10 @@ Value
                   ((195,
                     Effect
                       ([
-                        NonTermination;
-                        OCaml.Invalid_argument
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Tuple
@@ -3821,7 +4086,8 @@ Value
                           ((196,
                             Effect
                               ([
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Variable
@@ -3835,7 +4101,8 @@ Value
                                         ->
                                         .
                                           -[
-                                            OCaml.Invalid_argument
+                                            Type
+                                              (OCaml.Invalid_argument)
                                           ]->
                                           .)),
                                 add_min_binding),
@@ -3870,7 +4137,8 @@ Value
                           ((197,
                             Effect
                               ([
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Variable
@@ -3884,7 +4152,8 @@ Value
                                         ->
                                         .
                                           -[
-                                            OCaml.Invalid_argument
+                                            Type
+                                              (OCaml.Invalid_argument)
                                           ]->
                                           .)),
                                 add_max_binding),
@@ -3930,8 +4199,10 @@ Value
                           ((199,
                             Effect
                               ([
-                                NonTermination;
-                                OCaml.Invalid_argument
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Apply
@@ -3945,7 +4216,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     OCaml.Pervasives.gt),
                                 [
                                   Variable
@@ -3966,7 +4241,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           Z.add),
                                       [
                                         Variable
@@ -3989,8 +4268,10 @@ Value
                               ((199,
                                 Effect
                                   ([
-                                    NonTermination;
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ],
                                     .)),
                                 Variable
@@ -4006,7 +4287,8 @@ Value
                                               ->
                                               .
                                                 -[
-                                                  OCaml.Invalid_argument
+                                                  Type
+                                                    (OCaml.Invalid_argument)
                                                 ]->
                                                 .)),
                                     bal),
@@ -4036,8 +4318,10 @@ Value
                                     ((199,
                                       Effect
                                         ([
-                                          NonTermination;
-                                          OCaml.Invalid_argument
+                                          Type
+                                            (NonTermination);
+                                          Type
+                                            (OCaml.Invalid_argument)
                                         ],
                                           .)),
                                       Apply
@@ -4053,8 +4337,10 @@ Value
                                                     ->
                                                     .
                                                       -[
-                                                        NonTermination;
-                                                        OCaml.Invalid_argument
+                                                        Type
+                                                          (NonTermination);
+                                                        Type
+                                                          (OCaml.Invalid_argument)
                                                       ]->
                                                       .)),
                                           Variable
@@ -4072,8 +4358,10 @@ Value
                                                           ->
                                                           .
                                                             -[
-                                                              NonTermination;
-                                                              OCaml.Invalid_argument
+                                                              Type
+                                                                (NonTermination);
+                                                              Type
+                                                                (OCaml.Invalid_argument)
                                                             ]->
                                                             .)),
                                               join_rec),
@@ -4121,8 +4409,10 @@ Value
                               ((200,
                                 Effect
                                   ([
-                                    NonTermination;
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ],
                                     .)),
                                 Apply
@@ -4136,7 +4426,11 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         OCaml.Pervasives.gt),
                                     [
                                       Variable
@@ -4157,7 +4451,11 @@ Value
                                               Effect
                                                 ([
                                                 ],
-                                                  .)),
+                                                  .
+                                                    ->
+                                                    .
+                                                      ->
+                                                      .)),
                                               Z.add),
                                           [
                                             Variable
@@ -4180,8 +4478,10 @@ Value
                                   ((200,
                                     Effect
                                       ([
-                                        NonTermination;
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (NonTermination);
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ],
                                         .)),
                                     Variable
@@ -4197,7 +4497,8 @@ Value
                                                   ->
                                                   .
                                                     -[
-                                                      OCaml.Invalid_argument
+                                                      Type
+                                                        (OCaml.Invalid_argument)
                                                     ]->
                                                     .)),
                                         bal),
@@ -4206,8 +4507,10 @@ Value
                                         ((200,
                                           Effect
                                             ([
-                                              NonTermination;
-                                              OCaml.Invalid_argument
+                                              Type
+                                                (NonTermination);
+                                              Type
+                                                (OCaml.Invalid_argument)
                                             ],
                                               .)),
                                           Apply
@@ -4223,8 +4526,10 @@ Value
                                                         ->
                                                         .
                                                           -[
-                                                            NonTermination;
-                                                            OCaml.Invalid_argument
+                                                            Type
+                                                              (NonTermination);
+                                                            Type
+                                                              (OCaml.Invalid_argument)
                                                           ]->
                                                           .)),
                                               Variable
@@ -4242,8 +4547,10 @@ Value
                                                               ->
                                                               .
                                                                 -[
-                                                                  NonTermination;
-                                                                  OCaml.Invalid_argument
+                                                                  Type
+                                                                    (NonTermination);
+                                                                  Type
+                                                                    (OCaml.Invalid_argument)
                                                                 ]->
                                                                 .)),
                                                   join_rec),
@@ -4369,11 +4676,20 @@ Value
     [
       ((join, [ A ],
         [ (l, Type (t, A)); (v, Type (key)); (d, A); (r, Type (t, A)) ],
-        Type (t, A)),
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument)
+          ], Type (t, A))),
         Apply
           ((?,
             Effect
-              ([ Counter; NonTermination; OCaml.Invalid_argument ], .)),
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Invalid_argument)
+              ], .)),
             Variable
               ((?,
                 Effect
@@ -4384,12 +4700,13 @@ Value
                           . ->
                             .
                               -[
-                                NonTermination;
-                                OCaml.Invalid_argument
+                                Type (NonTermination);
+                                Type
+                                  (OCaml.Invalid_argument)
                               ]-> .)), join_rec),
             [
               Apply
-                ((?, Effect ([ Counter ], .)),
+                ((?, Effect ([ Type (Counter) ], .)),
                   Variable
                     ((?,
                       Effect
@@ -4397,7 +4714,8 @@ Value
                         ],
                           .
                             -[
-                              Counter
+                              Type
+                                (Counter)
                             ]->
                             .)),
                       read_counter),
@@ -4420,15 +4738,22 @@ Value
 Value
   (non_rec, @.,
     [
-      ((concat, [ A ], [ (t1, Type (t, A)); (t2, Type (t, A)) ], Type (t, A)),
+      ((concat, [ A ], [ (t1, Type (t, A)); (t2, Type (t, A)) ],
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Not_found)
+          ], Type (t, A))),
         Match
           ((208,
             Effect
               ([
-                Counter;
-                NonTermination;
-                OCaml.Invalid_argument;
-                OCaml.Not_found
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Invalid_argument);
+                Type (OCaml.Not_found)
               ], .)),
             Tuple
               ((208, Effect ([ ], .)),
@@ -4444,17 +4769,22 @@ Value
                   ((212,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Apply
                       ((212,
                         Effect
                           ([
-                            OCaml.Not_found
+                            Type
+                              (OCaml.Not_found)
                           ],
                             .)),
                         Variable
@@ -4464,7 +4794,8 @@ Value
                               ],
                                 .
                                   -[
-                                    OCaml.Not_found
+                                    Type
+                                      (OCaml.Not_found)
                                   ]->
                                   .)),
                             min_binding),
@@ -4485,9 +4816,12 @@ Value
                           ((213,
                             Effect
                               ([
-                                Counter;
-                                NonTermination;
-                                OCaml.Invalid_argument
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Variable
@@ -4503,9 +4837,12 @@ Value
                                           ->
                                           .
                                             -[
-                                              Counter;
-                                              NonTermination;
-                                              OCaml.Invalid_argument
+                                              Type
+                                                (Counter);
+                                              Type
+                                                (NonTermination);
+                                              Type
+                                                (OCaml.Invalid_argument)
                                             ]->
                                             .)),
                                 join),
@@ -4535,7 +4872,8 @@ Value
                                 ((213,
                                   Effect
                                     ([
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ],
                                       .)),
                                   Variable
@@ -4545,7 +4883,8 @@ Value
                                         ],
                                           .
                                             -[
-                                              OCaml.Invalid_argument
+                                              Type
+                                                (OCaml.Invalid_argument)
                                             ]->
                                             .)),
                                       remove_min_binding),
@@ -4573,15 +4912,22 @@ Value
           (v, Type (key));
           (d, Type (option, A));
           (t2, Type (t, A))
-        ], Type (t, A)),
+        ],
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Not_found)
+          ], Type (t, A))),
         Match
           ((216,
             Effect
               ([
-                Counter;
-                NonTermination;
-                OCaml.Invalid_argument;
-                OCaml.Not_found
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Invalid_argument);
+                Type (OCaml.Not_found)
               ], .)), Variable ((216, Effect ([ ], .)), d),
             [
               (Constructor (Some, d),
@@ -4589,9 +4935,12 @@ Value
                   ((217,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -4607,9 +4956,12 @@ Value
                                   ->
                                   .
                                     -[
-                                      Counter;
-                                      NonTermination;
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ]->
                                     .)),
                         join),
@@ -4648,10 +5000,14 @@ Value
                   ((218,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Variable
@@ -4663,10 +5019,14 @@ Value
                               ->
                               .
                                 -[
-                                  Counter;
-                                  NonTermination;
-                                  OCaml.Invalid_argument;
-                                  OCaml.Not_found
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Invalid_argument);
+                                  Type
+                                    (OCaml.Not_found)
                                 ]->
                                 .)),
                         concat),
@@ -4694,12 +5054,20 @@ Value
   (rec, @coq_rec,
     [
       ((split, [ A ], [ (x, Type (Ord.t)); (x_1, Type (t, A)) ],
-        (Type (t, A) * Type (option, A) * Type (t, A))),
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument)
+          ], (Type (t, A) * Type (option, A) * Type (t, A)))),
         Match
           ((?,
             Effect
-              ([ Counter; NonTermination; OCaml.Invalid_argument ], .)),
-            Variable ((?, Effect ([ ], .)), x_1),
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Invalid_argument)
+              ], .)), Variable ((?, Effect ([ ], .)), x_1),
             [
               (Constructor (Empty),
                 Tuple
@@ -4730,9 +5098,12 @@ Value
                   (224,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .))
                   c =
@@ -4749,7 +5120,9 @@ Value
                             ],
                               .
                                 ->
-                                .)),
+                                .
+                                  ->
+                                  .)),
                           Ord.compare),
                       [
                         Variable
@@ -4772,9 +5145,12 @@ Value
                   ((225,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Apply
@@ -4788,7 +5164,11 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .
+                                    ->
+                                    .)),
                             equiv_decb),
                         [
                           Variable
@@ -4844,9 +5224,12 @@ Value
                       ((226,
                         Effect
                           ([
-                            Counter;
-                            NonTermination;
-                            OCaml.Invalid_argument
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination);
+                            Type
+                              (OCaml.Invalid_argument)
                           ],
                             .)),
                         Apply
@@ -4860,7 +5243,11 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .
+                                        ->
+                                        .)),
                                 OCaml.Pervasives.lt),
                             [
                               Variable
@@ -4882,18 +5269,24 @@ Value
                           ((227,
                             Effect
                               ([
-                                Counter;
-                                NonTermination;
-                                OCaml.Invalid_argument
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Apply
                               ((227,
                                 Effect
                                   ([
-                                    Counter;
-                                    NonTermination;
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (Counter);
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ],
                                     .)),
                                 Variable
@@ -4905,9 +5298,12 @@ Value
                                           ->
                                           .
                                             -[
-                                              Counter;
-                                              NonTermination;
-                                              OCaml.Invalid_argument
+                                              Type
+                                                (Counter);
+                                              Type
+                                                (NonTermination);
+                                              Type
+                                                (OCaml.Invalid_argument)
                                             ]->
                                             .)),
                                     split),
@@ -4936,9 +5332,12 @@ Value
                                   ((227,
                                     Effect
                                       ([
-                                        Counter;
-                                        NonTermination;
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (Counter);
+                                        Type
+                                          (NonTermination);
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ],
                                         .)),
                                     Variable
@@ -4959,9 +5358,12 @@ Value
                                       ((227,
                                         Effect
                                           ([
-                                            Counter;
-                                            NonTermination;
-                                            OCaml.Invalid_argument
+                                            Type
+                                              (Counter);
+                                            Type
+                                              (NonTermination);
+                                            Type
+                                              (OCaml.Invalid_argument)
                                           ],
                                             .)),
                                         Variable
@@ -4977,9 +5379,12 @@ Value
                                                       ->
                                                       .
                                                         -[
-                                                          Counter;
-                                                          NonTermination;
-                                                          OCaml.Invalid_argument
+                                                          Type
+                                                            (Counter);
+                                                          Type
+                                                            (NonTermination);
+                                                          Type
+                                                            (OCaml.Invalid_argument)
                                                         ]->
                                                         .)),
                                             join),
@@ -5018,18 +5423,24 @@ Value
                           ((229,
                             Effect
                               ([
-                                Counter;
-                                NonTermination;
-                                OCaml.Invalid_argument
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Apply
                               ((229,
                                 Effect
                                   ([
-                                    Counter;
-                                    NonTermination;
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (Counter);
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ],
                                     .)),
                                 Variable
@@ -5041,9 +5452,12 @@ Value
                                           ->
                                           .
                                             -[
-                                              Counter;
-                                              NonTermination;
-                                              OCaml.Invalid_argument
+                                              Type
+                                                (Counter);
+                                              Type
+                                                (NonTermination);
+                                              Type
+                                                (OCaml.Invalid_argument)
                                             ]->
                                             .)),
                                     split),
@@ -5072,18 +5486,24 @@ Value
                                   ((229,
                                     Effect
                                       ([
-                                        Counter;
-                                        NonTermination;
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (Counter);
+                                        Type
+                                          (NonTermination);
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ],
                                         .)),
                                     Apply
                                       ((229,
                                         Effect
                                           ([
-                                            Counter;
-                                            NonTermination;
-                                            OCaml.Invalid_argument
+                                            Type
+                                              (Counter);
+                                            Type
+                                              (NonTermination);
+                                            Type
+                                              (OCaml.Invalid_argument)
                                           ],
                                             .)),
                                         Variable
@@ -5099,9 +5519,12 @@ Value
                                                       ->
                                                       .
                                                         -[
-                                                          Counter;
-                                                          NonTermination;
-                                                          OCaml.Invalid_argument
+                                                          Type
+                                                            (Counter);
+                                                          Type
+                                                            (NonTermination);
+                                                          Type
+                                                            (OCaml.Invalid_argument)
                                                         ]->
                                                         .)),
                                             join),
@@ -5167,16 +5590,24 @@ Value
                   Type (option, C)))));
           (s1, Type (t, A));
           (s2, Type (t, B))
-        ], Type (t, C)),
+        ],
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Match_failure);
+            Type (OCaml.Not_found)
+          ], Type (t, C))),
         Match
           ((?,
             Effect
               ([
-                Counter;
-                NonTermination;
-                OCaml.Invalid_argument;
-                OCaml.Match_failure;
-                OCaml.Not_found
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Invalid_argument);
+                Type (OCaml.Match_failure);
+                Type (OCaml.Not_found)
               ], .)), Variable ((?, Effect ([ ], .)), counter),
             [
               (Constructor (O),
@@ -5184,7 +5615,8 @@ Value
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -5194,7 +5626,8 @@ Value
                           ],
                             .
                               -[
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         not_terminated),
@@ -5211,11 +5644,16 @@ Value
                   (?,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument;
-                        OCaml.Match_failure;
-                        OCaml.Not_found
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Match_failure);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .))
                   i =
@@ -5284,7 +5722,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       OCaml.Pervasives.ge),
                                   [
                                     Variable
@@ -5355,11 +5797,16 @@ Value
                   ((233,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument;
-                        OCaml.Match_failure;
-                        OCaml.Not_found
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Match_failure);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Tuple
@@ -5425,20 +5872,28 @@ Value
                           ((236,
                             Effect
                               ([
-                                Counter;
-                                NonTermination;
-                                OCaml.Invalid_argument;
-                                OCaml.Match_failure;
-                                OCaml.Not_found
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Invalid_argument);
+                                Type
+                                  (OCaml.Match_failure);
+                                Type
+                                  (OCaml.Not_found)
                               ],
                                 .)),
                             Apply
                               ((236,
                                 Effect
                                   ([
-                                    Counter;
-                                    NonTermination;
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (Counter);
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ],
                                     .)),
                                 Variable
@@ -5450,9 +5905,12 @@ Value
                                           ->
                                           .
                                             -[
-                                              Counter;
-                                              NonTermination;
-                                              OCaml.Invalid_argument
+                                              Type
+                                                (Counter);
+                                              Type
+                                                (NonTermination);
+                                              Type
+                                                (OCaml.Invalid_argument)
                                             ]->
                                             .)),
                                     split),
@@ -5481,11 +5939,16 @@ Value
                                   ((237,
                                     Effect
                                       ([
-                                        Counter;
-                                        NonTermination;
-                                        OCaml.Invalid_argument;
-                                        OCaml.Match_failure;
-                                        OCaml.Not_found
+                                        Type
+                                          (Counter);
+                                        Type
+                                          (NonTermination);
+                                        Type
+                                          (OCaml.Invalid_argument);
+                                        Type
+                                          (OCaml.Match_failure);
+                                        Type
+                                          (OCaml.Not_found)
                                       ],
                                         .)),
                                     Variable
@@ -5501,10 +5964,14 @@ Value
                                                   ->
                                                   .
                                                     -[
-                                                      Counter;
-                                                      NonTermination;
-                                                      OCaml.Invalid_argument;
-                                                      OCaml.Not_found
+                                                      Type
+                                                        (Counter);
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Invalid_argument);
+                                                      Type
+                                                        (OCaml.Not_found)
                                                     ]->
                                                     .)),
                                         concat_or_join),
@@ -5513,11 +5980,16 @@ Value
                                         ((237,
                                           Effect
                                             ([
-                                              Counter;
-                                              NonTermination;
-                                              OCaml.Invalid_argument;
-                                              OCaml.Match_failure;
-                                              OCaml.Not_found
+                                              Type
+                                                (Counter);
+                                              Type
+                                                (NonTermination);
+                                              Type
+                                                (OCaml.Invalid_argument);
+                                              Type
+                                                (OCaml.Match_failure);
+                                              Type
+                                                (OCaml.Not_found)
                                             ],
                                               .)),
                                           Apply
@@ -5531,11 +6003,16 @@ Value
                                                       ->
                                                       .
                                                         -[
-                                                          Counter;
-                                                          NonTermination;
-                                                          OCaml.Invalid_argument;
-                                                          OCaml.Match_failure;
-                                                          OCaml.Not_found
+                                                          Type
+                                                            (Counter);
+                                                          Type
+                                                            (NonTermination);
+                                                          Type
+                                                            (OCaml.Invalid_argument);
+                                                          Type
+                                                            (OCaml.Match_failure);
+                                                          Type
+                                                            (OCaml.Not_found)
                                                         ]->
                                                         .)),
                                               Variable
@@ -5551,11 +6028,16 @@ Value
                                                             ->
                                                             .
                                                               -[
-                                                                Counter;
-                                                                NonTermination;
-                                                                OCaml.Invalid_argument;
-                                                                OCaml.Match_failure;
-                                                                OCaml.Not_found
+                                                                Type
+                                                                  (Counter);
+                                                                Type
+                                                                  (NonTermination);
+                                                                Type
+                                                                  (OCaml.Invalid_argument);
+                                                                Type
+                                                                  (OCaml.Match_failure);
+                                                                Type
+                                                                  (OCaml.Not_found)
                                                               ]->
                                                               .)),
                                                   merge_rec),
@@ -5574,7 +6056,13 @@ Value
                                                 Effect
                                                   ([
                                                   ],
-                                                    .)),
+                                                    .
+                                                      ->
+                                                      .
+                                                        ->
+                                                        .
+                                                          ->
+                                                          .)),
                                                 f);
                                             Variable
                                               ((237,
@@ -5609,7 +6097,13 @@ Value
                                               Effect
                                                 ([
                                                 ],
-                                                  .)),
+                                                  .
+                                                    ->
+                                                    .
+                                                      ->
+                                                      .
+                                                        ->
+                                                        .)),
                                               f),
                                           [
                                             Variable
@@ -5645,11 +6139,16 @@ Value
                                         ((237,
                                           Effect
                                             ([
-                                              Counter;
-                                              NonTermination;
-                                              OCaml.Invalid_argument;
-                                              OCaml.Match_failure;
-                                              OCaml.Not_found
+                                              Type
+                                                (Counter);
+                                              Type
+                                                (NonTermination);
+                                              Type
+                                                (OCaml.Invalid_argument);
+                                              Type
+                                                (OCaml.Match_failure);
+                                              Type
+                                                (OCaml.Not_found)
                                             ],
                                               .)),
                                           Apply
@@ -5663,11 +6162,16 @@ Value
                                                       ->
                                                       .
                                                         -[
-                                                          Counter;
-                                                          NonTermination;
-                                                          OCaml.Invalid_argument;
-                                                          OCaml.Match_failure;
-                                                          OCaml.Not_found
+                                                          Type
+                                                            (Counter);
+                                                          Type
+                                                            (NonTermination);
+                                                          Type
+                                                            (OCaml.Invalid_argument);
+                                                          Type
+                                                            (OCaml.Match_failure);
+                                                          Type
+                                                            (OCaml.Not_found)
                                                         ]->
                                                         .)),
                                               Variable
@@ -5683,11 +6187,16 @@ Value
                                                             ->
                                                             .
                                                               -[
-                                                                Counter;
-                                                                NonTermination;
-                                                                OCaml.Invalid_argument;
-                                                                OCaml.Match_failure;
-                                                                OCaml.Not_found
+                                                                Type
+                                                                  (Counter);
+                                                                Type
+                                                                  (NonTermination);
+                                                                Type
+                                                                  (OCaml.Invalid_argument);
+                                                                Type
+                                                                  (OCaml.Match_failure);
+                                                                Type
+                                                                  (OCaml.Not_found)
                                                               ]->
                                                               .)),
                                                   merge_rec),
@@ -5706,7 +6215,13 @@ Value
                                                 Effect
                                                   ([
                                                   ],
-                                                    .)),
+                                                    .
+                                                      ->
+                                                      .
+                                                        ->
+                                                        .
+                                                          ->
+                                                          .)),
                                                 f);
                                             Variable
                                               ((237,
@@ -5740,20 +6255,28 @@ Value
                           ((239,
                             Effect
                               ([
-                                Counter;
-                                NonTermination;
-                                OCaml.Invalid_argument;
-                                OCaml.Match_failure;
-                                OCaml.Not_found
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Invalid_argument);
+                                Type
+                                  (OCaml.Match_failure);
+                                Type
+                                  (OCaml.Not_found)
                               ],
                                 .)),
                             Apply
                               ((239,
                                 Effect
                                   ([
-                                    Counter;
-                                    NonTermination;
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (Counter);
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ],
                                     .)),
                                 Variable
@@ -5765,9 +6288,12 @@ Value
                                           ->
                                           .
                                             -[
-                                              Counter;
-                                              NonTermination;
-                                              OCaml.Invalid_argument
+                                              Type
+                                                (Counter);
+                                              Type
+                                                (NonTermination);
+                                              Type
+                                                (OCaml.Invalid_argument)
                                             ]->
                                             .)),
                                     split),
@@ -5796,11 +6322,16 @@ Value
                                   ((240,
                                     Effect
                                       ([
-                                        Counter;
-                                        NonTermination;
-                                        OCaml.Invalid_argument;
-                                        OCaml.Match_failure;
-                                        OCaml.Not_found
+                                        Type
+                                          (Counter);
+                                        Type
+                                          (NonTermination);
+                                        Type
+                                          (OCaml.Invalid_argument);
+                                        Type
+                                          (OCaml.Match_failure);
+                                        Type
+                                          (OCaml.Not_found)
                                       ],
                                         .)),
                                     Variable
@@ -5816,10 +6347,14 @@ Value
                                                   ->
                                                   .
                                                     -[
-                                                      Counter;
-                                                      NonTermination;
-                                                      OCaml.Invalid_argument;
-                                                      OCaml.Not_found
+                                                      Type
+                                                        (Counter);
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Invalid_argument);
+                                                      Type
+                                                        (OCaml.Not_found)
                                                     ]->
                                                     .)),
                                         concat_or_join),
@@ -5828,11 +6363,16 @@ Value
                                         ((240,
                                           Effect
                                             ([
-                                              Counter;
-                                              NonTermination;
-                                              OCaml.Invalid_argument;
-                                              OCaml.Match_failure;
-                                              OCaml.Not_found
+                                              Type
+                                                (Counter);
+                                              Type
+                                                (NonTermination);
+                                              Type
+                                                (OCaml.Invalid_argument);
+                                              Type
+                                                (OCaml.Match_failure);
+                                              Type
+                                                (OCaml.Not_found)
                                             ],
                                               .)),
                                           Apply
@@ -5846,11 +6386,16 @@ Value
                                                       ->
                                                       .
                                                         -[
-                                                          Counter;
-                                                          NonTermination;
-                                                          OCaml.Invalid_argument;
-                                                          OCaml.Match_failure;
-                                                          OCaml.Not_found
+                                                          Type
+                                                            (Counter);
+                                                          Type
+                                                            (NonTermination);
+                                                          Type
+                                                            (OCaml.Invalid_argument);
+                                                          Type
+                                                            (OCaml.Match_failure);
+                                                          Type
+                                                            (OCaml.Not_found)
                                                         ]->
                                                         .)),
                                               Variable
@@ -5866,11 +6411,16 @@ Value
                                                             ->
                                                             .
                                                               -[
-                                                                Counter;
-                                                                NonTermination;
-                                                                OCaml.Invalid_argument;
-                                                                OCaml.Match_failure;
-                                                                OCaml.Not_found
+                                                                Type
+                                                                  (Counter);
+                                                                Type
+                                                                  (NonTermination);
+                                                                Type
+                                                                  (OCaml.Invalid_argument);
+                                                                Type
+                                                                  (OCaml.Match_failure);
+                                                                Type
+                                                                  (OCaml.Not_found)
                                                               ]->
                                                               .)),
                                                   merge_rec),
@@ -5889,7 +6439,13 @@ Value
                                                 Effect
                                                   ([
                                                   ],
-                                                    .)),
+                                                    .
+                                                      ->
+                                                      .
+                                                        ->
+                                                        .
+                                                          ->
+                                                          .)),
                                                 f);
                                             Variable
                                               ((240,
@@ -5924,7 +6480,13 @@ Value
                                               Effect
                                                 ([
                                                 ],
-                                                  .)),
+                                                  .
+                                                    ->
+                                                    .
+                                                      ->
+                                                      .
+                                                        ->
+                                                        .)),
                                               f),
                                           [
                                             Variable
@@ -5960,11 +6522,16 @@ Value
                                         ((240,
                                           Effect
                                             ([
-                                              Counter;
-                                              NonTermination;
-                                              OCaml.Invalid_argument;
-                                              OCaml.Match_failure;
-                                              OCaml.Not_found
+                                              Type
+                                                (Counter);
+                                              Type
+                                                (NonTermination);
+                                              Type
+                                                (OCaml.Invalid_argument);
+                                              Type
+                                                (OCaml.Match_failure);
+                                              Type
+                                                (OCaml.Not_found)
                                             ],
                                               .)),
                                           Apply
@@ -5978,11 +6545,16 @@ Value
                                                       ->
                                                       .
                                                         -[
-                                                          Counter;
-                                                          NonTermination;
-                                                          OCaml.Invalid_argument;
-                                                          OCaml.Match_failure;
-                                                          OCaml.Not_found
+                                                          Type
+                                                            (Counter);
+                                                          Type
+                                                            (NonTermination);
+                                                          Type
+                                                            (OCaml.Invalid_argument);
+                                                          Type
+                                                            (OCaml.Match_failure);
+                                                          Type
+                                                            (OCaml.Not_found)
                                                         ]->
                                                         .)),
                                               Variable
@@ -5998,11 +6570,16 @@ Value
                                                             ->
                                                             .
                                                               -[
-                                                                Counter;
-                                                                NonTermination;
-                                                                OCaml.Invalid_argument;
-                                                                OCaml.Match_failure;
-                                                                OCaml.Not_found
+                                                                Type
+                                                                  (Counter);
+                                                                Type
+                                                                  (NonTermination);
+                                                                Type
+                                                                  (OCaml.Invalid_argument);
+                                                                Type
+                                                                  (OCaml.Match_failure);
+                                                                Type
+                                                                  (OCaml.Not_found)
                                                               ]->
                                                               .)),
                                                   merge_rec),
@@ -6021,7 +6598,13 @@ Value
                                                 Effect
                                                   ([
                                                   ],
-                                                    .)),
+                                                    .
+                                                      ->
+                                                      .
+                                                        ->
+                                                        .
+                                                          ->
+                                                          .)),
                                                 f);
                                             Variable
                                               ((240,
@@ -6045,7 +6628,8 @@ Value
                           ((?,
                             Effect
                               ([
-                                OCaml.Match_failure
+                                Type
+                                  (OCaml.Match_failure)
                               ],
                                 .)),
                             Variable
@@ -6055,7 +6639,8 @@ Value
                                   ],
                                     .
                                       -[
-                                        OCaml.Match_failure
+                                        Type
+                                          (OCaml.Match_failure)
                                       ]->
                                       .)),
                                 OCaml.raise_Match_failure),
@@ -6105,16 +6690,24 @@ Value
                   Type (option, C)))));
           (s1, Type (t, A));
           (s2, Type (t, B))
-        ], Type (t, C)),
+        ],
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Match_failure);
+            Type (OCaml.Not_found)
+          ], Type (t, C))),
         Apply
           ((?,
             Effect
               ([
-                Counter;
-                NonTermination;
-                OCaml.Invalid_argument;
-                OCaml.Match_failure;
-                OCaml.Not_found
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Invalid_argument);
+                Type (OCaml.Match_failure);
+                Type (OCaml.Not_found)
               ], .)),
             Variable
               ((?,
@@ -6125,15 +6718,16 @@ Value
                         . ->
                           .
                             -[
-                              Counter;
-                              NonTermination;
-                              OCaml.Invalid_argument;
-                              OCaml.Match_failure;
-                              OCaml.Not_found
+                              Type (Counter);
+                              Type (NonTermination);
+                              Type
+                                (OCaml.Invalid_argument);
+                              Type (OCaml.Match_failure);
+                              Type (OCaml.Not_found)
                             ]-> .)), merge_rec),
             [
               Apply
-                ((?, Effect ([ Counter ], .)),
+                ((?, Effect ([ Type (Counter) ], .)),
                   Variable
                     ((?,
                       Effect
@@ -6141,7 +6735,8 @@ Value
                         ],
                           .
                             -[
-                              Counter
+                              Type
+                                (Counter)
                             ]->
                             .)),
                       read_counter),
@@ -6153,7 +6748,7 @@ Value
                           ],
                             .)))
                   ]);
-              Variable ((?, Effect ([ ], .)), f);
+              Variable ((?, Effect ([ ], . -> . -> . -> .)), f);
               Variable ((?, Effect ([ ], .)), s1);
               Variable ((?, Effect ([ ], .)), s2)
             ]))
@@ -6165,15 +6760,21 @@ Value
     [
       ((filter, [ A ],
         [ (p, (Type (key) -> (A -> Type (bool)))); (x, Type (t, A)) ],
-        Type (t, A)),
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Not_found)
+          ], Type (t, A))),
         Match
           ((?,
             Effect
               ([
-                Counter;
-                NonTermination;
-                OCaml.Invalid_argument;
-                OCaml.Not_found
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Invalid_argument);
+                Type (OCaml.Not_found)
               ], .)), Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (Empty),
@@ -6185,10 +6786,14 @@ Value
                   (246,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .))
                   l' =
@@ -6196,10 +6801,14 @@ Value
                     ((246,
                       Effect
                         ([
-                          Counter;
-                          NonTermination;
-                          OCaml.Invalid_argument;
-                          OCaml.Not_found
+                          Type
+                            (Counter);
+                          Type
+                            (NonTermination);
+                          Type
+                            (OCaml.Invalid_argument);
+                          Type
+                            (OCaml.Not_found)
                         ],
                           .)),
                       Variable
@@ -6211,10 +6820,14 @@ Value
                                 ->
                                 .
                                   -[
-                                    Counter;
-                                    NonTermination;
-                                    OCaml.Invalid_argument;
-                                    OCaml.Not_found
+                                    Type
+                                      (Counter);
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Invalid_argument);
+                                    Type
+                                      (OCaml.Not_found)
                                   ]->
                                   .)),
                           filter),
@@ -6224,7 +6837,11 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .
+                                    ->
+                                    .)),
                             p);
                         Variable
                           ((246,
@@ -6239,10 +6856,14 @@ Value
                   (247,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .))
                   pvd =
@@ -6257,7 +6878,11 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .
+                                  ->
+                                  .)),
                           p),
                       [
                         Variable
@@ -6280,10 +6905,14 @@ Value
                   (248,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .))
                   r' =
@@ -6291,10 +6920,14 @@ Value
                     ((248,
                       Effect
                         ([
-                          Counter;
-                          NonTermination;
-                          OCaml.Invalid_argument;
-                          OCaml.Not_found
+                          Type
+                            (Counter);
+                          Type
+                            (NonTermination);
+                          Type
+                            (OCaml.Invalid_argument);
+                          Type
+                            (OCaml.Not_found)
                         ],
                           .)),
                       Variable
@@ -6306,10 +6939,14 @@ Value
                                 ->
                                 .
                                   -[
-                                    Counter;
-                                    NonTermination;
-                                    OCaml.Invalid_argument;
-                                    OCaml.Not_found
+                                    Type
+                                      (Counter);
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Invalid_argument);
+                                    Type
+                                      (OCaml.Not_found)
                                   ]->
                                   .)),
                           filter),
@@ -6319,7 +6956,11 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .
+                                    ->
+                                    .)),
                             p);
                         Variable
                           ((248,
@@ -6334,10 +6975,14 @@ Value
                   ((249,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Variable
@@ -6351,9 +6996,12 @@ Value
                       ((249,
                         Effect
                           ([
-                            Counter;
-                            NonTermination;
-                            OCaml.Invalid_argument
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination);
+                            Type
+                              (OCaml.Invalid_argument)
                           ],
                             .)),
                         Variable
@@ -6369,9 +7017,12 @@ Value
                                       ->
                                       .
                                         -[
-                                          Counter;
-                                          NonTermination;
-                                          OCaml.Invalid_argument
+                                          Type
+                                            (Counter);
+                                          Type
+                                            (NonTermination);
+                                          Type
+                                            (OCaml.Invalid_argument)
                                         ]->
                                         .)),
                             join),
@@ -6409,10 +7060,14 @@ Value
                       ((249,
                         Effect
                           ([
-                            Counter;
-                            NonTermination;
-                            OCaml.Invalid_argument;
-                            OCaml.Not_found
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination);
+                            Type
+                              (OCaml.Invalid_argument);
+                            Type
+                              (OCaml.Not_found)
                           ],
                             .)),
                         Variable
@@ -6424,10 +7079,14 @@ Value
                                   ->
                                   .
                                     -[
-                                      Counter;
-                                      NonTermination;
-                                      OCaml.Invalid_argument;
-                                      OCaml.Not_found
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Invalid_argument);
+                                      Type
+                                        (OCaml.Not_found)
                                     ]->
                                     .)),
                             concat),
@@ -6456,15 +7115,21 @@ Value
     [
       ((partition, [ A ],
         [ (p, (Type (key) -> (A -> Type (bool)))); (x, Type (t, A)) ],
-        (Type (t, A) * Type (t, A))),
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Not_found)
+          ], (Type (t, A) * Type (t, A)))),
         Match
           ((?,
             Effect
               ([
-                Counter;
-                NonTermination;
-                OCaml.Invalid_argument;
-                OCaml.Not_found
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Invalid_argument);
+                Type (OCaml.Not_found)
               ], .)), Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (Empty),
@@ -6489,20 +7154,28 @@ Value
                   ((256,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Apply
                       ((256,
                         Effect
                           ([
-                            Counter;
-                            NonTermination;
-                            OCaml.Invalid_argument;
-                            OCaml.Not_found
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination);
+                            Type
+                              (OCaml.Invalid_argument);
+                            Type
+                              (OCaml.Not_found)
                           ],
                             .)),
                         Variable
@@ -6514,10 +7187,14 @@ Value
                                   ->
                                   .
                                     -[
-                                      Counter;
-                                      NonTermination;
-                                      OCaml.Invalid_argument;
-                                      OCaml.Not_found
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Invalid_argument);
+                                      Type
+                                        (OCaml.Not_found)
                                     ]->
                                     .)),
                             partition),
@@ -6527,7 +7204,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               p);
                           Variable
                             ((256,
@@ -6545,10 +7226,14 @@ Value
                           (257,
                             Effect
                               ([
-                                Counter;
-                                NonTermination;
-                                OCaml.Invalid_argument;
-                                OCaml.Not_found
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Invalid_argument);
+                                Type
+                                  (OCaml.Not_found)
                               ],
                                 .))
                           pvd
@@ -6564,7 +7249,11 @@ Value
                                   Effect
                                     ([
                                     ],
-                                      .)),
+                                      .
+                                        ->
+                                        .
+                                          ->
+                                          .)),
                                   p),
                               [
                                 Variable
@@ -6587,20 +7276,28 @@ Value
                           ((258,
                             Effect
                               ([
-                                Counter;
-                                NonTermination;
-                                OCaml.Invalid_argument;
-                                OCaml.Not_found
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Invalid_argument);
+                                Type
+                                  (OCaml.Not_found)
                               ],
                                 .)),
                             Apply
                               ((258,
                                 Effect
                                   ([
-                                    Counter;
-                                    NonTermination;
-                                    OCaml.Invalid_argument;
-                                    OCaml.Not_found
+                                    Type
+                                      (Counter);
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Invalid_argument);
+                                    Type
+                                      (OCaml.Not_found)
                                   ],
                                     .)),
                                 Variable
@@ -6612,10 +7309,14 @@ Value
                                           ->
                                           .
                                             -[
-                                              Counter;
-                                              NonTermination;
-                                              OCaml.Invalid_argument;
-                                              OCaml.Not_found
+                                              Type
+                                                (Counter);
+                                              Type
+                                                (NonTermination);
+                                              Type
+                                                (OCaml.Invalid_argument);
+                                              Type
+                                                (OCaml.Not_found)
                                             ]->
                                             .)),
                                     partition),
@@ -6625,7 +7326,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       p);
                                   Variable
                                     ((258,
@@ -6643,10 +7348,14 @@ Value
                                   ((259,
                                     Effect
                                       ([
-                                        Counter;
-                                        NonTermination;
-                                        OCaml.Invalid_argument;
-                                        OCaml.Not_found
+                                        Type
+                                          (Counter);
+                                        Type
+                                          (NonTermination);
+                                        Type
+                                          (OCaml.Invalid_argument);
+                                        Type
+                                          (OCaml.Not_found)
                                       ],
                                         .)),
                                     Variable
@@ -6660,19 +7369,26 @@ Value
                                       ((260,
                                         Effect
                                           ([
-                                            Counter;
-                                            NonTermination;
-                                            OCaml.Invalid_argument;
-                                            OCaml.Not_found
+                                            Type
+                                              (Counter);
+                                            Type
+                                              (NonTermination);
+                                            Type
+                                              (OCaml.Invalid_argument);
+                                            Type
+                                              (OCaml.Not_found)
                                           ],
                                             .)),
                                         Apply
                                           ((260,
                                             Effect
                                               ([
-                                                Counter;
-                                                NonTermination;
-                                                OCaml.Invalid_argument
+                                                Type
+                                                  (Counter);
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Invalid_argument)
                                               ],
                                                 .)),
                                             Variable
@@ -6688,9 +7404,12 @@ Value
                                                           ->
                                                           .
                                                             -[
-                                                              Counter;
-                                                              NonTermination;
-                                                              OCaml.Invalid_argument
+                                                              Type
+                                                                (Counter);
+                                                              Type
+                                                                (NonTermination);
+                                                              Type
+                                                                (OCaml.Invalid_argument)
                                                             ]->
                                                             .)),
                                                 join),
@@ -6728,10 +7447,14 @@ Value
                                           ((260,
                                             Effect
                                               ([
-                                                Counter;
-                                                NonTermination;
-                                                OCaml.Invalid_argument;
-                                                OCaml.Not_found
+                                                Type
+                                                  (Counter);
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Invalid_argument);
+                                                Type
+                                                  (OCaml.Not_found)
                                               ],
                                                 .)),
                                             Variable
@@ -6743,10 +7466,14 @@ Value
                                                       ->
                                                       .
                                                         -[
-                                                          Counter;
-                                                          NonTermination;
-                                                          OCaml.Invalid_argument;
-                                                          OCaml.Not_found
+                                                          Type
+                                                            (Counter);
+                                                          Type
+                                                            (NonTermination);
+                                                          Type
+                                                            (OCaml.Invalid_argument);
+                                                          Type
+                                                            (OCaml.Not_found)
                                                         ]->
                                                         .)),
                                                 concat),
@@ -6770,20 +7497,28 @@ Value
                                       ((261,
                                         Effect
                                           ([
-                                            Counter;
-                                            NonTermination;
-                                            OCaml.Invalid_argument;
-                                            OCaml.Not_found
+                                            Type
+                                              (Counter);
+                                            Type
+                                              (NonTermination);
+                                            Type
+                                              (OCaml.Invalid_argument);
+                                            Type
+                                              (OCaml.Not_found)
                                           ],
                                             .)),
                                         Apply
                                           ((261,
                                             Effect
                                               ([
-                                                Counter;
-                                                NonTermination;
-                                                OCaml.Invalid_argument;
-                                                OCaml.Not_found
+                                                Type
+                                                  (Counter);
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Invalid_argument);
+                                                Type
+                                                  (OCaml.Not_found)
                                               ],
                                                 .)),
                                             Variable
@@ -6795,10 +7530,14 @@ Value
                                                       ->
                                                       .
                                                         -[
-                                                          Counter;
-                                                          NonTermination;
-                                                          OCaml.Invalid_argument;
-                                                          OCaml.Not_found
+                                                          Type
+                                                            (Counter);
+                                                          Type
+                                                            (NonTermination);
+                                                          Type
+                                                            (OCaml.Invalid_argument);
+                                                          Type
+                                                            (OCaml.Not_found)
                                                         ]->
                                                         .)),
                                                 concat),
@@ -6822,9 +7561,12 @@ Value
                                           ((261,
                                             Effect
                                               ([
-                                                Counter;
-                                                NonTermination;
-                                                OCaml.Invalid_argument
+                                                Type
+                                                  (Counter);
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Invalid_argument)
                                               ],
                                                 .)),
                                             Variable
@@ -6840,9 +7582,12 @@ Value
                                                           ->
                                                           .
                                                             -[
-                                                              Counter;
-                                                              NonTermination;
-                                                              OCaml.Invalid_argument
+                                                              Type
+                                                                (Counter);
+                                                              Type
+                                                                (NonTermination);
+                                                              Type
+                                                                (OCaml.Invalid_argument)
                                                             ]->
                                                             .)),
                                                 join),
@@ -6964,8 +7709,8 @@ Value
     [
       ((compare, [ A; B ],
         [ (cmp, (A -> (B -> Type (Z)))); (m1, Type (t, A)); (m2, Type (t, B)) ],
-        Type (Z)),
-        LetFun (273, Effect ([ Counter; NonTermination ], .))
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (Z))),
+        LetFun (273, Effect ([ Type (Counter); Type (NonTermination) ], .))
           (rec, @.,
             [
               ((compare_aux_rec, [ ],
@@ -6979,12 +7724,18 @@ Value
                     Type
                       (enumeration,
                         B))
-                ], Type (Z)),
+                ],
+                Monad
+                  ([
+                    Type
+                      (NonTermination)
+                  ], Type (Z))),
                 Match
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -7001,7 +7752,8 @@ Value
                           ((?,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Variable
@@ -7011,7 +7763,8 @@ Value
                                   ],
                                     .
                                       -[
-                                        NonTermination
+                                        Type
+                                          (NonTermination)
                                       ]->
                                       .)),
                                 not_terminated),
@@ -7030,7 +7783,8 @@ Value
                           ((274,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Tuple
@@ -7105,7 +7859,8 @@ Value
                                   (279,
                                     Effect
                                       ([
-                                        NonTermination
+                                        Type
+                                          (NonTermination)
                                       ],
                                         .))
                                   c
@@ -7123,7 +7878,9 @@ Value
                                             ],
                                               .
                                                 ->
-                                                .)),
+                                                .
+                                                  ->
+                                                  .)),
                                           Ord.compare),
                                       [
                                         Variable
@@ -7146,7 +7903,8 @@ Value
                                   ((280,
                                     Effect
                                       ([
-                                        NonTermination
+                                        Type
+                                          (NonTermination)
                                       ],
                                         .)),
                                     Apply
@@ -7160,7 +7918,11 @@ Value
                                             Effect
                                               ([
                                               ],
-                                                .)),
+                                                .
+                                                  ->
+                                                  .
+                                                    ->
+                                                    .)),
                                             nequiv_decb),
                                         [
                                           Variable
@@ -7189,7 +7951,8 @@ Value
                                       (281,
                                         Effect
                                           ([
-                                            NonTermination
+                                            Type
+                                              (NonTermination)
                                           ],
                                             .))
                                       c
@@ -7205,7 +7968,11 @@ Value
                                               Effect
                                                 ([
                                                 ],
-                                                  .)),
+                                                  .
+                                                    ->
+                                                    .
+                                                      ->
+                                                      .)),
                                               cmp),
                                           [
                                             Variable
@@ -7228,7 +7995,8 @@ Value
                                       ((282,
                                         Effect
                                           ([
-                                            NonTermination
+                                            Type
+                                              (NonTermination)
                                           ],
                                             .)),
                                         Apply
@@ -7242,7 +8010,11 @@ Value
                                                 Effect
                                                   ([
                                                   ],
-                                                    .)),
+                                                    .
+                                                      ->
+                                                      .
+                                                        ->
+                                                        .)),
                                                 nequiv_decb),
                                             [
                                               Variable
@@ -7271,7 +8043,8 @@ Value
                                           ((283,
                                             Effect
                                               ([
-                                                NonTermination
+                                                Type
+                                                  (NonTermination)
                                               ],
                                                 .)),
                                             Apply
@@ -7283,7 +8056,8 @@ Value
                                                       ->
                                                       .
                                                         -[
-                                                          NonTermination
+                                                          Type
+                                                            (NonTermination)
                                                         ]->
                                                         .)),
                                                 Variable
@@ -7297,7 +8071,8 @@ Value
                                                             ->
                                                             .
                                                               -[
-                                                                NonTermination
+                                                                Type
+                                                                  (NonTermination)
                                                               ]->
                                                               .)),
                                                     compare_aux_rec),
@@ -7381,7 +8156,7 @@ Value
                             ]))
                     ]))
             ]) in
-        LetFun (273, Effect ([ Counter; NonTermination ], .))
+        LetFun (273, Effect ([ Type (Counter); Type (NonTermination) ], .))
           (non_rec, @.,
             [
               ((compare_aux, [ ],
@@ -7394,13 +8169,22 @@ Value
                     Type
                       (enumeration,
                         B))
-                ], Type (Z)),
+                ],
+                Monad
+                  ([
+                    Type
+                      (Counter);
+                    Type
+                      (NonTermination)
+                  ], Type (Z))),
                 Apply
                   ((?,
                     Effect
                       ([
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -7414,7 +8198,8 @@ Value
                                 ->
                                 .
                                   -[
-                                    NonTermination
+                                    Type
+                                      (NonTermination)
                                   ]->
                                   .)),
                         compare_aux_rec),
@@ -7423,7 +8208,8 @@ Value
                         ((?,
                           Effect
                             ([
-                              Counter
+                              Type
+                                (Counter)
                             ],
                               .)),
                           Variable
@@ -7433,7 +8219,8 @@ Value
                                 ],
                                   .
                                     -[
-                                      Counter
+                                      Type
+                                        (Counter)
                                     ]->
                                     .)),
                               read_counter),
@@ -7462,11 +8249,17 @@ Value
                     ]))
             ]) in
         Apply
-          ((284, Effect ([ Counter; NonTermination ], .)),
+          ((284, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable
               ((284,
-                Effect ([ ], . -> . -[ Counter; NonTermination ]-> .)),
-                compare_aux),
+                Effect
+                  ([ ],
+                    . ->
+                      .
+                        -[
+                          Type (Counter);
+                          Type (NonTermination)
+                        ]-> .)), compare_aux),
             [
               Apply
                 ((284, Effect ([ ], .)),
@@ -7538,8 +8331,8 @@ Value
           (cmp, (A -> (B -> Type (bool))));
           (m1, Type (t, A));
           (m2, Type (t, B))
-        ], Type (bool)),
-        LetFun (287, Effect ([ Counter; NonTermination ], .))
+        ], Monad ([ Type (Counter); Type (NonTermination) ], Type (bool))),
+        LetFun (287, Effect ([ Type (Counter); Type (NonTermination) ], .))
           (rec, @.,
             [
               ((equal_aux_rec, [ ],
@@ -7553,12 +8346,18 @@ Value
                     Type
                       (enumeration,
                         B))
-                ], Type (bool)),
+                ],
+                Monad
+                  ([
+                    Type
+                      (NonTermination)
+                  ], Type (bool))),
                 Match
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -7575,7 +8374,8 @@ Value
                           ((?,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Variable
@@ -7585,7 +8385,8 @@ Value
                                   ],
                                     .
                                       -[
-                                        NonTermination
+                                        Type
+                                          (NonTermination)
                                       ]->
                                       .)),
                                 not_terminated),
@@ -7604,7 +8405,8 @@ Value
                           ((288,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Tuple
@@ -7679,7 +8481,8 @@ Value
                                   ((293,
                                     Effect
                                       ([
-                                        NonTermination
+                                        Type
+                                          (NonTermination)
                                       ],
                                         .)),
                                     Variable
@@ -7687,7 +8490,11 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         andb),
                                     [
                                       Apply
@@ -7701,7 +8508,11 @@ Value
                                               Effect
                                                 ([
                                                 ],
-                                                  .)),
+                                                  .
+                                                    ->
+                                                    .
+                                                      ->
+                                                      .)),
                                               equiv_decb),
                                           [
                                             Apply
@@ -7717,7 +8528,9 @@ Value
                                                       ],
                                                         .
                                                           ->
-                                                          .)),
+                                                          .
+                                                            ->
+                                                            .)),
                                                     Ord.compare),
                                                 [
                                                   Variable
@@ -7747,7 +8560,8 @@ Value
                                         ((293,
                                           Effect
                                             ([
-                                              NonTermination
+                                              Type
+                                                (NonTermination)
                                             ],
                                               .)),
                                           Variable
@@ -7755,7 +8569,11 @@ Value
                                               Effect
                                                 ([
                                                 ],
-                                                  .)),
+                                                  .
+                                                    ->
+                                                    .
+                                                      ->
+                                                      .)),
                                               andb),
                                           [
                                             Apply
@@ -7769,7 +8587,11 @@ Value
                                                     Effect
                                                       ([
                                                       ],
-                                                        .)),
+                                                        .
+                                                          ->
+                                                          .
+                                                            ->
+                                                            .)),
                                                     cmp),
                                                 [
                                                   Variable
@@ -7791,7 +8613,8 @@ Value
                                               ((294,
                                                 Effect
                                                   ([
-                                                    NonTermination
+                                                    Type
+                                                      (NonTermination)
                                                   ],
                                                     .)),
                                                 Apply
@@ -7803,7 +8626,8 @@ Value
                                                           ->
                                                           .
                                                             -[
-                                                              NonTermination
+                                                              Type
+                                                                (NonTermination)
                                                             ]->
                                                             .)),
                                                     Variable
@@ -7817,7 +8641,8 @@ Value
                                                                 ->
                                                                 .
                                                                   -[
-                                                                    NonTermination
+                                                                    Type
+                                                                      (NonTermination)
                                                                   ]->
                                                                   .)),
                                                         equal_aux_rec),
@@ -7903,7 +8728,7 @@ Value
                             ]))
                     ]))
             ]) in
-        LetFun (287, Effect ([ Counter; NonTermination ], .))
+        LetFun (287, Effect ([ Type (Counter); Type (NonTermination) ], .))
           (non_rec, @.,
             [
               ((equal_aux, [ ],
@@ -7916,13 +8741,22 @@ Value
                     Type
                       (enumeration,
                         B))
-                ], Type (bool)),
+                ],
+                Monad
+                  ([
+                    Type
+                      (Counter);
+                    Type
+                      (NonTermination)
+                  ], Type (bool))),
                 Apply
                   ((?,
                     Effect
                       ([
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -7936,7 +8770,8 @@ Value
                                 ->
                                 .
                                   -[
-                                    NonTermination
+                                    Type
+                                      (NonTermination)
                                   ]->
                                   .)),
                         equal_aux_rec),
@@ -7945,7 +8780,8 @@ Value
                         ((?,
                           Effect
                             ([
-                              Counter
+                              Type
+                                (Counter)
                             ],
                               .)),
                           Variable
@@ -7955,7 +8791,8 @@ Value
                                 ],
                                   .
                                     -[
-                                      Counter
+                                      Type
+                                        (Counter)
                                     ]->
                                     .)),
                               read_counter),
@@ -7984,11 +8821,17 @@ Value
                     ]))
             ]) in
         Apply
-          ((295, Effect ([ Counter; NonTermination ], .)),
+          ((295, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable
               ((295,
-                Effect ([ ], . -> . -[ Counter; NonTermination ]-> .)),
-                equal_aux),
+                Effect
+                  ([ ],
+                    . ->
+                      .
+                        -[
+                          Type (Counter);
+                          Type (NonTermination)
+                        ]-> .)), equal_aux),
             [
               Apply
                 ((295, Effect ([ ], .)),
@@ -8071,7 +8914,11 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .
+                                ->
+                                .)),
                         Z.add),
                     [
                       Apply
@@ -8085,7 +8932,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               Z.add),
                           [
                             Apply
@@ -8264,7 +9115,9 @@ Value
 Value
   (non_rec, @.,
     [
-      ((choose, [ A ], [ ], (Type (t, A) -> (Type (key) * A))),
+      ((choose, [ A ], [ ],
+        (Type (t, A) -> Monad ([ Type (OCaml.Not_found) ], (Type (key) * A)))),
         Variable
-          ((310, Effect ([ ], . -[ OCaml.Not_found ]-> .)), min_binding))
+          ((310, Effect ([ ], . -[ Type (OCaml.Not_found) ]-> .)),
+            min_binding))
     ])

--- a/tests/ex33.monadise
+++ b/tests/ex33.monadise
@@ -95,7 +95,7 @@ Value
     [
       ((bal, [ A ],
         [ (l, Type (t, A)); (x, Type (key)); (d, A); (r, Type (t, A)) ],
-        Monad ([ OCaml.Invalid_argument ], Type (t, A))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t, A))),
         LetVar ? hl =
           Match
             (26, Variable (26, l),
@@ -531,7 +531,7 @@ Value
   (rec, @coq_rec,
     [
       ((add, [ A ], [ (x, Type (key)); (data, A); (x_1, Type (t, A)) ],
-        Monad ([ OCaml.Invalid_argument ], Type (t, A))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t, A))),
         Match
           (?, Variable (?, x_1),
             [
@@ -708,7 +708,7 @@ Value
   (rec, @coq_rec,
     [
       ((find, [ A ], [ (x, Type (Ord.t)); (x_1, Type (t, A)) ],
-        Monad ([ OCaml.Not_found ], A)),
+        Monad ([ Type (OCaml.Not_found) ], A)),
         Match
           (?, Variable (?, x_1),
             [
@@ -876,7 +876,7 @@ Value
   (rec, @coq_rec,
     [
       ((min_binding, [ A ], [ (x, Type (t, A)) ],
-        Monad ([ OCaml.Not_found ], (Type (key) * A))),
+        Monad ([ Type (OCaml.Not_found) ], (Type (key) * A))),
         Match
           (?, Variable (?, x),
             [
@@ -920,7 +920,7 @@ Value
   (rec, @coq_rec,
     [
       ((max_binding, [ A ], [ (x, Type (t, A)) ],
-        Monad ([ OCaml.Not_found ], (Type (key) * A))),
+        Monad ([ Type (OCaml.Not_found) ], (Type (key) * A))),
         Match
           (?, Variable (?, x),
             [
@@ -964,7 +964,7 @@ Value
   (rec, @coq_rec,
     [
       ((remove_min_binding, [ A ], [ (x, Type (t, A)) ],
-        Monad ([ OCaml.Invalid_argument ], Type (t, A))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t, A))),
         Match
           (?, Variable (?, x),
             [
@@ -1023,7 +1023,9 @@ Value
   (non_rec, @.,
     [
       ((remove_merge, [ A ], [ (t1, Type (t, A)); (t2, Type (t, A)) ],
-        Monad ([ OCaml.Invalid_argument; OCaml.Not_found ], Type (t, A))),
+        Monad
+          ([ Type (OCaml.Invalid_argument); Type (OCaml.Not_found) ],
+            Type (t, A))),
         Match
           (108, Tuple (108, Variable (108, t1), Variable (108, t2)),
             [
@@ -1037,11 +1039,14 @@ Value
                     Lift
                       (?,
                         [
-                          OCaml.Not_found
+                          Type
+                            (OCaml.Not_found)
                         ],
                         [
-                          OCaml.Invalid_argument;
-                          OCaml.Not_found
+                          Type
+                            (OCaml.Invalid_argument);
+                          Type
+                            (OCaml.Not_found)
                         ],
                         Apply
                           (112,
@@ -1067,11 +1072,14 @@ Value
                             Lift
                               (?,
                                 [
-                                  OCaml.Invalid_argument
+                                  Type
+                                    (OCaml.Invalid_argument)
                                 ],
                                 [
-                                  OCaml.Invalid_argument;
-                                  OCaml.Not_found
+                                  Type
+                                    (OCaml.Invalid_argument);
+                                  Type
+                                    (OCaml.Not_found)
                                 ],
                                 Bind
                                   (?,
@@ -1115,7 +1123,9 @@ Value
   (rec, @coq_rec,
     [
       ((remove, [ A ], [ (x, Type (Ord.t)); (x_1, Type (t, A)) ],
-        Monad ([ OCaml.Invalid_argument; OCaml.Not_found ], Type (t, A))),
+        Monad
+          ([ Type (OCaml.Invalid_argument); Type (OCaml.Not_found) ],
+            Type (t, A))),
         Match
           (?, Variable (?, x_1),
             [
@@ -1200,11 +1210,14 @@ Value
                             Lift
                               (?,
                                 [
-                                  OCaml.Invalid_argument
+                                  Type
+                                    (OCaml.Invalid_argument)
                                 ],
                                 [
-                                  OCaml.Invalid_argument;
-                                  OCaml.Not_found
+                                  Type
+                                    (OCaml.Invalid_argument);
+                                  Type
+                                    (OCaml.Not_found)
                                 ],
                                 Apply
                                   (123,
@@ -1245,11 +1258,14 @@ Value
                             Lift
                               (?,
                                 [
-                                  OCaml.Invalid_argument
+                                  Type
+                                    (OCaml.Invalid_argument)
                                 ],
                                 [
-                                  OCaml.Invalid_argument;
-                                  OCaml.Not_found
+                                  Type
+                                    (OCaml.Invalid_argument);
+                                  Type
+                                    (OCaml.Not_found)
                                 ],
                                 Apply
                                   (125,
@@ -1646,7 +1662,7 @@ Value
   (rec, @coq_rec,
     [
       ((add_min_binding, [ A ], [ (k, Type (key)); (v, A); (x, Type (t, A)) ],
-        Monad ([ OCaml.Invalid_argument ], Type (t, A))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t, A))),
         Match
           (?, Variable (?, x),
             [
@@ -1714,7 +1730,7 @@ Value
   (rec, @coq_rec,
     [
       ((add_max_binding, [ A ], [ (k, Type (key)); (v, A); (x, Type (t, A)) ],
-        Monad ([ OCaml.Invalid_argument ], Type (t, A))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t, A))),
         Match
           (?, Variable (?, x),
             [
@@ -1788,7 +1804,10 @@ Value
           (v, Type (key));
           (d, A);
           (r, Type (t, A))
-        ], Monad ([ NonTermination; OCaml.Invalid_argument ], Type (t, A))),
+        ],
+        Monad
+          ([ Type (NonTermination); Type (OCaml.Invalid_argument) ],
+            Type (t, A))),
         Match
           (?, Variable (?, counter),
             [
@@ -1796,11 +1815,14 @@ Value
                 Lift
                   (?,
                     [
-                      NonTermination
+                      Type
+                        (NonTermination)
                     ],
                     [
-                      NonTermination;
-                      OCaml.Invalid_argument
+                      Type
+                        (NonTermination);
+                      Type
+                        (OCaml.Invalid_argument)
                     ],
                     Apply
                       (?,
@@ -1830,11 +1852,14 @@ Value
                         Lift
                           (?,
                             [
-                              OCaml.Invalid_argument
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                             [
-                              NonTermination;
-                              OCaml.Invalid_argument
+                              Type
+                                (NonTermination);
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                             Apply
                               (196,
@@ -1859,11 +1884,14 @@ Value
                         Lift
                           (?,
                             [
-                              OCaml.Invalid_argument
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                             [
-                              NonTermination;
-                              OCaml.Invalid_argument
+                              Type
+                                (NonTermination);
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                             Apply
                               (197,
@@ -1954,11 +1982,14 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ],
                                     [
-                                      NonTermination;
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ],
                                     Apply
                                       (199,
@@ -2037,11 +2068,14 @@ Value
                                     Lift
                                       (?,
                                         [
-                                          OCaml.Invalid_argument
+                                          Type
+                                            (OCaml.Invalid_argument)
                                         ],
                                         [
-                                          NonTermination;
-                                          OCaml.Invalid_argument
+                                          Type
+                                            (NonTermination);
+                                          Type
+                                            (OCaml.Invalid_argument)
                                         ],
                                         Apply
                                           (200,
@@ -2094,17 +2128,33 @@ Value
       ((join, [ A ],
         [ (l, Type (t, A)); (v, Type (key)); (d, A); (r, Type (t, A)) ],
         Monad
-          ([ Counter; NonTermination; OCaml.Invalid_argument ], Type (t, A))),
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument)
+          ], Type (t, A))),
         Bind
           (?,
             Lift
-              (?, [ Counter ],
-                [ Counter; NonTermination; OCaml.Invalid_argument ],
+              (?, [ Type (Counter) ],
+                [
+                  Type (Counter);
+                  Type (NonTermination);
+                  Type (OCaml.Invalid_argument)
+                ],
                 Apply (?, Variable (?, read_counter), [ Tuple (?) ])),
             Some x,
             Lift
-              (?, [ NonTermination; OCaml.Invalid_argument ],
-                [ Counter; NonTermination; OCaml.Invalid_argument ],
+              (?,
+                [
+                  Type (NonTermination);
+                  Type (OCaml.Invalid_argument)
+                ],
+                [
+                  Type (Counter);
+                  Type (NonTermination);
+                  Type (OCaml.Invalid_argument)
+                ],
                 Apply
                   (?, Variable (?, join_rec),
                     [
@@ -2123,10 +2173,10 @@ Value
       ((concat, [ A ], [ (t1, Type (t, A)); (t2, Type (t, A)) ],
         Monad
           ([
-            Counter;
-            NonTermination;
-            OCaml.Invalid_argument;
-            OCaml.Not_found
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Not_found)
           ], Type (t, A))),
         Match
           (208, Tuple (208, Variable (208, t1), Variable (208, t2)),
@@ -2141,13 +2191,18 @@ Value
                     Lift
                       (?,
                         [
-                          OCaml.Not_found
+                          Type
+                            (OCaml.Not_found)
                         ],
                         [
-                          Counter;
-                          NonTermination;
-                          OCaml.Invalid_argument;
-                          OCaml.Not_found
+                          Type
+                            (Counter);
+                          Type
+                            (NonTermination);
+                          Type
+                            (OCaml.Invalid_argument);
+                          Type
+                            (OCaml.Not_found)
                         ],
                         Apply
                           (212,
@@ -2173,27 +2228,38 @@ Value
                             Lift
                               (?,
                                 [
-                                  Counter;
-                                  NonTermination;
-                                  OCaml.Invalid_argument
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Invalid_argument)
                                 ],
                                 [
-                                  Counter;
-                                  NonTermination;
-                                  OCaml.Invalid_argument;
-                                  OCaml.Not_found
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Invalid_argument);
+                                  Type
+                                    (OCaml.Not_found)
                                 ],
                                 Bind
                                   (?,
                                     Lift
                                       (?,
                                         [
-                                          OCaml.Invalid_argument
+                                          Type
+                                            (OCaml.Invalid_argument)
                                         ],
                                         [
-                                          Counter;
-                                          NonTermination;
-                                          OCaml.Invalid_argument
+                                          Type
+                                            (Counter);
+                                          Type
+                                            (NonTermination);
+                                          Type
+                                            (OCaml.Invalid_argument)
                                         ],
                                         Apply
                                           (213,
@@ -2243,10 +2309,10 @@ Value
         ],
         Monad
           ([
-            Counter;
-            NonTermination;
-            OCaml.Invalid_argument;
-            OCaml.Not_found
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Not_found)
           ], Type (t, A))),
         Match
           (216, Variable (216, d),
@@ -2255,15 +2321,22 @@ Value
                 Lift
                   (?,
                     [
-                      Counter;
-                      NonTermination;
-                      OCaml.Invalid_argument
+                      Type
+                        (Counter);
+                      Type
+                        (NonTermination);
+                      Type
+                        (OCaml.Invalid_argument)
                     ],
                     [
-                      Counter;
-                      NonTermination;
-                      OCaml.Invalid_argument;
-                      OCaml.Not_found
+                      Type
+                        (Counter);
+                      Type
+                        (NonTermination);
+                      Type
+                        (OCaml.Invalid_argument);
+                      Type
+                        (OCaml.Not_found)
                     ],
                     Apply
                       (217,
@@ -2307,8 +2380,11 @@ Value
     [
       ((split, [ A ], [ (x, Type (Ord.t)); (x_1, Type (t, A)) ],
         Monad
-          ([ Counter; NonTermination; OCaml.Invalid_argument ],
-            (Type (t, A) * Type (option, A) * Type (t, A)))),
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument)
+          ], (Type (t, A) * Type (option, A) * Type (t, A)))),
         Match
           (?, Variable (?, x_1),
             [
@@ -2536,11 +2612,11 @@ Value
         ],
         Monad
           ([
-            Counter;
-            NonTermination;
-            OCaml.Invalid_argument;
-            OCaml.Match_failure;
-            OCaml.Not_found
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Match_failure);
+            Type (OCaml.Not_found)
           ], Type (t, C))),
         Match
           (?, Variable (?, counter),
@@ -2549,14 +2625,20 @@ Value
                 Lift
                   (?,
                     [
-                      NonTermination
+                      Type
+                        (NonTermination)
                     ],
                     [
-                      Counter;
-                      NonTermination;
-                      OCaml.Invalid_argument;
-                      OCaml.Match_failure;
-                      OCaml.Not_found
+                      Type
+                        (Counter);
+                      Type
+                        (NonTermination);
+                      Type
+                        (OCaml.Invalid_argument);
+                      Type
+                        (OCaml.Match_failure);
+                      Type
+                        (OCaml.Not_found)
                     ],
                     Apply
                       (?,
@@ -2683,16 +2765,24 @@ Value
                             Lift
                               (?,
                                 [
-                                  Counter;
-                                  NonTermination;
-                                  OCaml.Invalid_argument
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Invalid_argument)
                                 ],
                                 [
-                                  Counter;
-                                  NonTermination;
-                                  OCaml.Invalid_argument;
-                                  OCaml.Match_failure;
-                                  OCaml.Not_found
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Invalid_argument);
+                                  Type
+                                    (OCaml.Match_failure);
+                                  Type
+                                    (OCaml.Not_found)
                                 ],
                                 Apply
                                   (236,
@@ -2776,17 +2866,26 @@ Value
                                             Lift
                                               (?,
                                                 [
-                                                  Counter;
-                                                  NonTermination;
-                                                  OCaml.Invalid_argument;
-                                                  OCaml.Not_found
+                                                  Type
+                                                    (Counter);
+                                                  Type
+                                                    (NonTermination);
+                                                  Type
+                                                    (OCaml.Invalid_argument);
+                                                  Type
+                                                    (OCaml.Not_found)
                                                 ],
                                                 [
-                                                  Counter;
-                                                  NonTermination;
-                                                  OCaml.Invalid_argument;
-                                                  OCaml.Match_failure;
-                                                  OCaml.Not_found
+                                                  Type
+                                                    (Counter);
+                                                  Type
+                                                    (NonTermination);
+                                                  Type
+                                                    (OCaml.Invalid_argument);
+                                                  Type
+                                                    (OCaml.Match_failure);
+                                                  Type
+                                                    (OCaml.Not_found)
                                                 ],
                                                 Apply
                                                   (237,
@@ -2840,16 +2939,24 @@ Value
                             Lift
                               (?,
                                 [
-                                  Counter;
-                                  NonTermination;
-                                  OCaml.Invalid_argument
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Invalid_argument)
                                 ],
                                 [
-                                  Counter;
-                                  NonTermination;
-                                  OCaml.Invalid_argument;
-                                  OCaml.Match_failure;
-                                  OCaml.Not_found
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Invalid_argument);
+                                  Type
+                                    (OCaml.Match_failure);
+                                  Type
+                                    (OCaml.Not_found)
                                 ],
                                 Apply
                                   (239,
@@ -2933,17 +3040,26 @@ Value
                                             Lift
                                               (?,
                                                 [
-                                                  Counter;
-                                                  NonTermination;
-                                                  OCaml.Invalid_argument;
-                                                  OCaml.Not_found
+                                                  Type
+                                                    (Counter);
+                                                  Type
+                                                    (NonTermination);
+                                                  Type
+                                                    (OCaml.Invalid_argument);
+                                                  Type
+                                                    (OCaml.Not_found)
                                                 ],
                                                 [
-                                                  Counter;
-                                                  NonTermination;
-                                                  OCaml.Invalid_argument;
-                                                  OCaml.Match_failure;
-                                                  OCaml.Not_found
+                                                  Type
+                                                    (Counter);
+                                                  Type
+                                                    (NonTermination);
+                                                  Type
+                                                    (OCaml.Invalid_argument);
+                                                  Type
+                                                    (OCaml.Match_failure);
+                                                  Type
+                                                    (OCaml.Not_found)
                                                 ],
                                                 Apply
                                                   (240,
@@ -2985,14 +3101,20 @@ Value
                         Lift
                           (?,
                             [
-                              OCaml.Match_failure
+                              Type
+                                (OCaml.Match_failure)
                             ],
                             [
-                              Counter;
-                              NonTermination;
-                              OCaml.Invalid_argument;
-                              OCaml.Match_failure;
-                              OCaml.Not_found
+                              Type
+                                (Counter);
+                              Type
+                                (NonTermination);
+                              Type
+                                (OCaml.Invalid_argument);
+                              Type
+                                (OCaml.Match_failure);
+                              Type
+                                (OCaml.Not_found)
                             ],
                             Apply
                               (?,
@@ -3032,22 +3154,22 @@ Value
         ],
         Monad
           ([
-            Counter;
-            NonTermination;
-            OCaml.Invalid_argument;
-            OCaml.Match_failure;
-            OCaml.Not_found
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Match_failure);
+            Type (OCaml.Not_found)
           ], Type (t, C))),
         Bind
           (?,
             Lift
-              (?, [ Counter ],
+              (?, [ Type (Counter) ],
                 [
-                  Counter;
-                  NonTermination;
-                  OCaml.Invalid_argument;
-                  OCaml.Match_failure;
-                  OCaml.Not_found
+                  Type (Counter);
+                  Type (NonTermination);
+                  Type (OCaml.Invalid_argument);
+                  Type (OCaml.Match_failure);
+                  Type (OCaml.Not_found)
                 ],
                 Apply (?, Variable (?, read_counter), [ Tuple (?) ])),
             Some x,
@@ -3069,10 +3191,10 @@ Value
         [ (p, (Type (key) -> (A -> Type (bool)))); (x, Type (t, A)) ],
         Monad
           ([
-            Counter;
-            NonTermination;
-            OCaml.Invalid_argument;
-            OCaml.Not_found
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Not_found)
           ], Type (t, A))),
         Match
           (?, Variable (?, x),
@@ -3140,15 +3262,22 @@ Value
                             Lift
                               (?,
                                 [
-                                  Counter;
-                                  NonTermination;
-                                  OCaml.Invalid_argument
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Invalid_argument)
                                 ],
                                 [
-                                  Counter;
-                                  NonTermination;
-                                  OCaml.Invalid_argument;
-                                  OCaml.Not_found
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Invalid_argument);
+                                  Type
+                                    (OCaml.Not_found)
                                 ],
                                 Apply
                                   (249,
@@ -3193,10 +3322,10 @@ Value
         [ (p, (Type (key) -> (A -> Type (bool)))); (x, Type (t, A)) ],
         Monad
           ([
-            Counter;
-            NonTermination;
-            OCaml.Invalid_argument;
-            OCaml.Not_found
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Not_found)
           ], (Type (t, A) * Type (t, A)))),
         Match
           (?, Variable (?, x),
@@ -3293,15 +3422,22 @@ Value
                                                 Lift
                                                   (?,
                                                     [
-                                                      Counter;
-                                                      NonTermination;
-                                                      OCaml.Invalid_argument
+                                                      Type
+                                                        (Counter);
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Invalid_argument)
                                                     ],
                                                     [
-                                                      Counter;
-                                                      NonTermination;
-                                                      OCaml.Invalid_argument;
-                                                      OCaml.Not_found
+                                                      Type
+                                                        (Counter);
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Invalid_argument);
+                                                      Type
+                                                        (OCaml.Not_found)
                                                     ],
                                                     Apply
                                                       (260,
@@ -3373,15 +3509,22 @@ Value
                                                     Lift
                                                       (?,
                                                         [
-                                                          Counter;
-                                                          NonTermination;
-                                                          OCaml.Invalid_argument
+                                                          Type
+                                                            (Counter);
+                                                          Type
+                                                            (NonTermination);
+                                                          Type
+                                                            (OCaml.Invalid_argument)
                                                         ],
                                                         [
-                                                          Counter;
-                                                          NonTermination;
-                                                          OCaml.Invalid_argument;
-                                                          OCaml.Not_found
+                                                          Type
+                                                            (Counter);
+                                                          Type
+                                                            (NonTermination);
+                                                          Type
+                                                            (OCaml.Invalid_argument);
+                                                          Type
+                                                            (OCaml.Not_found)
                                                         ],
                                                         Apply
                                                           (261,
@@ -3469,7 +3612,7 @@ Value
     [
       ((compare, [ A; B ],
         [ (cmp, (A -> (B -> Type (Z)))); (m1, Type (t, A)); (m2, Type (t, B)) ],
-        Monad ([ Counter; NonTermination ], Type (Z))),
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (Z))),
         LetFun 273
           (rec, @.,
             [
@@ -3484,7 +3627,12 @@ Value
                     Type
                       (enumeration,
                         B))
-                ], Monad ([ NonTermination ], Type (Z))),
+                ],
+                Monad
+                  ([
+                    Type
+                      (NonTermination)
+                  ], Type (Z))),
                 Match
                   (?,
                     Variable
@@ -3692,19 +3840,24 @@ Value
                 ],
                 Monad
                   ([
-                    Counter;
-                    NonTermination
+                    Type
+                      (Counter);
+                    Type
+                      (NonTermination)
                   ], Type (Z))),
                 Bind
                   (?,
                     Lift
                       (?,
                         [
-                          Counter
+                          Type
+                            (Counter)
                         ],
                         [
-                          Counter;
-                          NonTermination
+                          Type
+                            (Counter);
+                          Type
+                            (NonTermination)
                         ],
                         Apply
                           (?,
@@ -3720,11 +3873,14 @@ Value
                     Lift
                       (?,
                         [
-                          NonTermination
+                          Type
+                            (NonTermination)
                         ],
                         [
-                          Counter;
-                          NonTermination
+                          Type
+                            (Counter);
+                          Type
+                            (NonTermination)
                         ],
                         Apply
                           (?,
@@ -3778,7 +3934,7 @@ Value
           (cmp, (A -> (B -> Type (bool))));
           (m1, Type (t, A));
           (m2, Type (t, B))
-        ], Monad ([ Counter; NonTermination ], Type (bool))),
+        ], Monad ([ Type (Counter); Type (NonTermination) ], Type (bool))),
         LetFun 287
           (rec, @.,
             [
@@ -3794,7 +3950,11 @@ Value
                       (enumeration,
                         B))
                 ],
-                Monad ([ NonTermination ], Type (bool))),
+                Monad
+                  ([
+                    Type
+                      (NonTermination)
+                  ], Type (bool))),
                 Match
                   (?,
                     Variable
@@ -3994,19 +4154,24 @@ Value
                 ],
                 Monad
                   ([
-                    Counter;
-                    NonTermination
+                    Type
+                      (Counter);
+                    Type
+                      (NonTermination)
                   ], Type (bool))),
                 Bind
                   (?,
                     Lift
                       (?,
                         [
-                          Counter
+                          Type
+                            (Counter)
                         ],
                         [
-                          Counter;
-                          NonTermination
+                          Type
+                            (Counter);
+                          Type
+                            (NonTermination)
                         ],
                         Apply
                           (?,
@@ -4022,11 +4187,14 @@ Value
                     Lift
                       (?,
                         [
-                          NonTermination
+                          Type
+                            (NonTermination)
                         ],
                         [
-                          Counter;
-                          NonTermination
+                          Type
+                            (Counter);
+                          Type
+                            (NonTermination)
                         ],
                         Apply
                           (?,
@@ -4185,6 +4353,6 @@ Value
   (non_rec, @.,
     [
       ((choose, [ A ], [ ],
-        (Type (t, A) -> Monad ([ OCaml.Not_found ], (Type (key) * A)))),
+        (Type (t, A) -> Monad ([ Type (OCaml.Not_found) ], (Type (key) * A)))),
         Variable (310, min_binding))
     ])

--- a/tests/ex34.effects
+++ b/tests/ex34.effects
@@ -9,7 +9,7 @@ Require [ OCaml.List ]
       [
         ((compare, [ ], [ (x, Type (Ord/t)) ], (Type (Ord/t) -> Type (Z))),
           Match
-            ((?, Effect ([ ], .)),
+            ((?, Effect ([ ], . -> .)),
               Variable ((?, Effect ([ ], .)), Ord/x),
               [
                 (Any,
@@ -125,7 +125,7 @@ Value
                 Apply
                   ((26, Effect ([ ], .)),
                     Variable
-                      ((26, Effect ([ ], .)),
+                      ((26, Effect ([ ], . -> . -> .)),
                         OCaml.Pervasives.ge),
                     [
                       Variable ((26, Effect ([ ], .)), hl);
@@ -133,14 +133,16 @@ Value
                     ]),
                 Apply
                   ((26, Effect ([ ], .)),
-                    Variable ((26, Effect ([ ], .)), Z.add),
+                    Variable
+                      ((26, Effect ([ ], . -> . -> .)), Z.add),
                     [
                       Variable ((26, Effect ([ ], .)), hl);
                       Constant ((26, Effect ([ ], .)), Int(1))
                     ]),
                 Apply
                   ((26, Effect ([ ], .)),
-                    Variable ((26, Effect ([ ], .)), Z.add),
+                    Variable
+                      ((26, Effect ([ ], . -> . -> .)), Z.add),
                     [
                       Variable ((26, Effect ([ ], .)), hr);
                       Constant ((26, Effect ([ ], .)), Int(1))
@@ -151,8 +153,9 @@ Value
 Value
   (non_rec, @.,
     [
-      ((bal, [ ], [ (l, Type (t)); (v, Type (elt)); (r, Type (t)) ], Type (t)),
-        LetVar (34, Effect ([ OCaml.Invalid_argument ], .)) hl =
+      ((bal, [ ], [ (l, Type (t)); (v, Type (elt)); (r, Type (t)) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t))),
+        LetVar (34, Effect ([ Type (OCaml.Invalid_argument) ], .)) hl =
           Match
             ((34, Effect ([ ], .)), Variable ((34, Effect ([ ], .)), l),
               [
@@ -173,7 +176,7 @@ Value
                           .)),
                       h))
               ]) in
-        LetVar (35, Effect ([ OCaml.Invalid_argument ], .)) hr =
+        LetVar (35, Effect ([ Type (OCaml.Invalid_argument) ], .)) hr =
           Match
             ((35, Effect ([ ], .)), Variable ((35, Effect ([ ], .)), r),
               [
@@ -195,10 +198,12 @@ Value
                       h))
               ]) in
         IfThenElse
-          ((36, Effect ([ OCaml.Invalid_argument ], .)),
+          ((36, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Apply
               ((36, Effect ([ ], .)),
-                Variable ((36, Effect ([ ], .)), OCaml.Pervasives.gt),
+                Variable
+                  ((36, Effect ([ ], . -> . -> .)),
+                    OCaml.Pervasives.gt),
                 [
                   Variable ((36, Effect ([ ], .)), hl);
                   Apply
@@ -208,7 +213,11 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .
+                                  ->
+                                  .)),
                           Z.add),
                       [
                         Variable
@@ -228,7 +237,7 @@ Value
                       ])
                 ]),
             Match
-              ((36, Effect ([ OCaml.Invalid_argument ], .)),
+              ((36, Effect ([ Type (OCaml.Invalid_argument) ], .)),
                 Variable ((37, Effect ([ ], .)), l),
                 [
                   (Constructor (Empty),
@@ -236,7 +245,8 @@ Value
                       ((38,
                         Effect
                           ([
-                            OCaml.Invalid_argument
+                            Type
+                              (OCaml.Invalid_argument)
                           ],
                             .)),
                         Variable
@@ -246,7 +256,8 @@ Value
                               ],
                                 .
                                   -[
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ]->
                                   .)),
                             OCaml.Pervasives.invalid_arg),
@@ -264,7 +275,8 @@ Value
                       ((40,
                         Effect
                           ([
-                            OCaml.Invalid_argument
+                            Type
+                              (OCaml.Invalid_argument)
                           ],
                             .)),
                         Apply
@@ -278,7 +290,11 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .
+                                        ->
+                                        .)),
                                 OCaml.Pervasives.ge),
                             [
                               Apply
@@ -411,7 +427,8 @@ Value
                           ((42,
                             Effect
                               ([
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Variable
@@ -428,7 +445,8 @@ Value
                                   ((44,
                                     Effect
                                       ([
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ],
                                         .)),
                                     Variable
@@ -438,7 +456,8 @@ Value
                                           ],
                                             .
                                               -[
-                                                OCaml.Invalid_argument
+                                                Type
+                                                  (OCaml.Invalid_argument)
                                               ]->
                                               .)),
                                         OCaml.Pervasives.invalid_arg),
@@ -572,11 +591,11 @@ Value
                             ])))
                 ]),
             IfThenElse
-              ((48, Effect ([ OCaml.Invalid_argument ], .)),
+              ((48, Effect ([ Type (OCaml.Invalid_argument) ], .)),
                 Apply
                   ((48, Effect ([ ], .)),
                     Variable
-                      ((48, Effect ([ ], .)),
+                      ((48, Effect ([ ], . -> . -> .)),
                         OCaml.Pervasives.gt),
                     [
                       Variable ((48, Effect ([ ], .)), hr);
@@ -591,7 +610,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               Z.add),
                           [
                             Variable
@@ -611,7 +634,8 @@ Value
                           ])
                     ]),
                 Match
-                  ((48, Effect ([ OCaml.Invalid_argument ], .)),
+                  ((48,
+                    Effect ([ Type (OCaml.Invalid_argument) ], .)),
                     Variable ((49, Effect ([ ], .)), r),
                     [
                       (Constructor (Empty),
@@ -619,7 +643,8 @@ Value
                           ((50,
                             Effect
                               ([
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Variable
@@ -629,7 +654,8 @@ Value
                                   ],
                                     .
                                       -[
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ]->
                                       .)),
                                 OCaml.Pervasives.invalid_arg),
@@ -647,7 +673,8 @@ Value
                           ((52,
                             Effect
                               ([
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Apply
@@ -661,7 +688,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     OCaml.Pervasives.ge),
                                 [
                                   Apply
@@ -794,7 +825,8 @@ Value
                               ((54,
                                 Effect
                                   ([
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ],
                                     .)),
                                 Variable
@@ -811,7 +843,8 @@ Value
                                       ((56,
                                         Effect
                                           ([
-                                            OCaml.Invalid_argument
+                                            Type
+                                              (OCaml.Invalid_argument)
                                           ],
                                             .)),
                                         Variable
@@ -821,7 +854,8 @@ Value
                                               ],
                                                 .
                                                   -[
-                                                    OCaml.Invalid_argument
+                                                    Type
+                                                      (OCaml.Invalid_argument)
                                                   ]->
                                                   .)),
                                             OCaml.Pervasives.invalid_arg),
@@ -964,7 +998,9 @@ Value
                         Apply
                           ((61, Effect ([ ], .)),
                             Variable
-                              ((61, Effect ([ ], .)),
+                              ((61,
+                                Effect
+                                  ([ ], . -> . -> .)),
                                 OCaml.Pervasives.ge),
                             [
                               Variable
@@ -985,7 +1021,9 @@ Value
                         Apply
                           ((61, Effect ([ ], .)),
                             Variable
-                              ((61, Effect ([ ], .)),
+                              ((61,
+                                Effect
+                                  ([ ], . -> . -> .)),
                                 Z.add),
                             [
                               Variable
@@ -1006,7 +1044,9 @@ Value
                         Apply
                           ((61, Effect ([ ], .)),
                             Variable
-                              ((61, Effect ([ ], .)),
+                              ((61,
+                                Effect
+                                  ([ ], . -> . -> .)),
                                 Z.add),
                             [
                               Variable
@@ -1030,9 +1070,10 @@ Value
 Value
   (rec, @coq_rec,
     [
-      ((add, [ ], [ (x, Type (elt)); (x_1, Type (t)) ], Type (t)),
+      ((add, [ ], [ (x, Type (elt)); (x_1, Type (t)) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t))),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument ], .)),
+          ((?, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable ((?, Effect ([ ], .)), x_1),
             [
               (Constructor (Empty),
@@ -1072,7 +1113,8 @@ Value
                   (68,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .))
                   c =
@@ -1089,7 +1131,9 @@ Value
                             ],
                               .
                                 ->
-                                .)),
+                                .
+                                  ->
+                                  .)),
                           Ord.compare),
                       [
                         Variable
@@ -1112,7 +1156,8 @@ Value
                   ((69,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Apply
@@ -1126,7 +1171,11 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .
+                                    ->
+                                    .)),
                             equiv_decb),
                         [
                           Variable
@@ -1155,7 +1204,8 @@ Value
                       ((70,
                         Effect
                           ([
-                            OCaml.Invalid_argument
+                            Type
+                              (OCaml.Invalid_argument)
                           ],
                             .)),
                         Apply
@@ -1169,7 +1219,11 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .
+                                        ->
+                                        .)),
                                 OCaml.Pervasives.lt),
                             [
                               Variable
@@ -1191,7 +1245,8 @@ Value
                           ((70,
                             Effect
                               ([
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Variable
@@ -1205,7 +1260,8 @@ Value
                                         ->
                                         .
                                           -[
-                                            OCaml.Invalid_argument
+                                            Type
+                                              (OCaml.Invalid_argument)
                                           ]->
                                           .)),
                                 bal),
@@ -1214,7 +1270,8 @@ Value
                                 ((70,
                                   Effect
                                     ([
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ],
                                       .)),
                                   Variable
@@ -1226,7 +1283,8 @@ Value
                                             ->
                                             .
                                               -[
-                                                OCaml.Invalid_argument
+                                                Type
+                                                  (OCaml.Invalid_argument)
                                               ]->
                                               .)),
                                       add),
@@ -1265,7 +1323,8 @@ Value
                           ((70,
                             Effect
                               ([
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Variable
@@ -1279,7 +1338,8 @@ Value
                                         ->
                                         .
                                           -[
-                                            OCaml.Invalid_argument
+                                            Type
+                                              (OCaml.Invalid_argument)
                                           ]->
                                           .)),
                                 bal),
@@ -1302,7 +1362,8 @@ Value
                                 ((70,
                                   Effect
                                     ([
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ],
                                       .)),
                                   Variable
@@ -1314,7 +1375,8 @@ Value
                                             ->
                                             .
                                               -[
-                                                OCaml.Invalid_argument
+                                                Type
+                                                  (OCaml.Invalid_argument)
                                               ]->
                                               .)),
                                       add),
@@ -1355,9 +1417,10 @@ Value
 Value
   (rec, @coq_rec,
     [
-      ((add_min_element, [ ], [ (v, Type (elt)); (x, Type (t)) ], Type (t)),
+      ((add_min_element, [ ], [ (v, Type (elt)); (x, Type (t)) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t))),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument ], .)),
+          ((?, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (Empty),
@@ -1386,7 +1449,8 @@ Value
                   ((85,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -1400,7 +1464,8 @@ Value
                                 ->
                                 .
                                   -[
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ]->
                                   .)),
                         bal),
@@ -1409,7 +1474,8 @@ Value
                         ((85,
                           Effect
                             ([
-                              OCaml.Invalid_argument
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                               .)),
                           Variable
@@ -1421,7 +1487,8 @@ Value
                                     ->
                                     .
                                       -[
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ]->
                                       .)),
                               add_min_element),
@@ -1463,9 +1530,10 @@ Value
 Value
   (rec, @coq_rec,
     [
-      ((add_max_element, [ ], [ (v, Type (elt)); (x, Type (t)) ], Type (t)),
+      ((add_max_element, [ ], [ (v, Type (elt)); (x, Type (t)) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t))),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument ], .)),
+          ((?, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (Empty),
@@ -1494,7 +1562,8 @@ Value
                   ((91,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -1508,7 +1577,8 @@ Value
                                 ->
                                 .
                                   -[
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ]->
                                   .)),
                         bal),
@@ -1531,7 +1601,8 @@ Value
                         ((91,
                           Effect
                             ([
-                              OCaml.Invalid_argument
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                               .)),
                           Variable
@@ -1543,7 +1614,8 @@ Value
                                     ->
                                     .
                                       -[
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ]->
                                       .)),
                               add_max_element),
@@ -1577,17 +1649,23 @@ Value
           (l, Type (t));
           (v, Type (elt));
           (r, Type (t))
-        ], Type (t)),
+        ],
+        Monad
+          ([ Type (NonTermination); Type (OCaml.Invalid_argument) ],
+            Type (t))),
         Match
-          ((?, Effect ([ NonTermination; OCaml.Invalid_argument ], .)),
-            Variable ((?, Effect ([ ], .)), counter),
+          ((?,
+            Effect
+              ([ Type (NonTermination); Type (OCaml.Invalid_argument) ],
+                .)), Variable ((?, Effect ([ ], .)), counter),
             [
               (Constructor (O),
                 Apply
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -1597,7 +1675,8 @@ Value
                           ],
                             .
                               -[
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         not_terminated),
@@ -1614,8 +1693,10 @@ Value
                   ((98,
                     Effect
                       ([
-                        NonTermination;
-                        OCaml.Invalid_argument
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Tuple
@@ -1647,7 +1728,8 @@ Value
                           ((99,
                             Effect
                               ([
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Variable
@@ -1659,7 +1741,8 @@ Value
                                       ->
                                       .
                                         -[
-                                          OCaml.Invalid_argument
+                                          Type
+                                            (OCaml.Invalid_argument)
                                         ]->
                                         .)),
                                 add_min_element),
@@ -1687,7 +1770,8 @@ Value
                           ((100,
                             Effect
                               ([
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Variable
@@ -1699,7 +1783,8 @@ Value
                                       ->
                                       .
                                         -[
-                                          OCaml.Invalid_argument
+                                          Type
+                                            (OCaml.Invalid_argument)
                                         ]->
                                         .)),
                                 add_max_element),
@@ -1736,8 +1821,10 @@ Value
                           ((102,
                             Effect
                               ([
-                                NonTermination;
-                                OCaml.Invalid_argument
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Apply
@@ -1751,7 +1838,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     OCaml.Pervasives.gt),
                                 [
                                   Variable
@@ -1772,7 +1863,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           Z.add),
                                       [
                                         Variable
@@ -1795,8 +1890,10 @@ Value
                               ((102,
                                 Effect
                                   ([
-                                    NonTermination;
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ],
                                     .)),
                                 Variable
@@ -1810,7 +1907,8 @@ Value
                                             ->
                                             .
                                               -[
-                                                OCaml.Invalid_argument
+                                                Type
+                                                  (OCaml.Invalid_argument)
                                               ]->
                                               .)),
                                     bal),
@@ -1833,8 +1931,10 @@ Value
                                     ((102,
                                       Effect
                                         ([
-                                          NonTermination;
-                                          OCaml.Invalid_argument
+                                          Type
+                                            (NonTermination);
+                                          Type
+                                            (OCaml.Invalid_argument)
                                         ],
                                           .)),
                                       Apply
@@ -1848,8 +1948,10 @@ Value
                                                   ->
                                                   .
                                                     -[
-                                                      NonTermination;
-                                                      OCaml.Invalid_argument
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Invalid_argument)
                                                     ]->
                                                     .)),
                                           Variable
@@ -1865,8 +1967,10 @@ Value
                                                         ->
                                                         .
                                                           -[
-                                                            NonTermination;
-                                                            OCaml.Invalid_argument
+                                                            Type
+                                                              (NonTermination);
+                                                            Type
+                                                              (OCaml.Invalid_argument)
                                                           ]->
                                                           .)),
                                               join_rec),
@@ -1907,8 +2011,10 @@ Value
                               ((103,
                                 Effect
                                   ([
-                                    NonTermination;
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ],
                                     .)),
                                 Apply
@@ -1922,7 +2028,11 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         OCaml.Pervasives.gt),
                                     [
                                       Variable
@@ -1943,7 +2053,11 @@ Value
                                               Effect
                                                 ([
                                                 ],
-                                                  .)),
+                                                  .
+                                                    ->
+                                                    .
+                                                      ->
+                                                      .)),
                                               Z.add),
                                           [
                                             Variable
@@ -1966,8 +2080,10 @@ Value
                                   ((103,
                                     Effect
                                       ([
-                                        NonTermination;
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (NonTermination);
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ],
                                         .)),
                                     Variable
@@ -1981,7 +2097,8 @@ Value
                                                 ->
                                                 .
                                                   -[
-                                                    OCaml.Invalid_argument
+                                                    Type
+                                                      (OCaml.Invalid_argument)
                                                   ]->
                                                   .)),
                                         bal),
@@ -1990,8 +2107,10 @@ Value
                                         ((103,
                                           Effect
                                             ([
-                                              NonTermination;
-                                              OCaml.Invalid_argument
+                                              Type
+                                                (NonTermination);
+                                              Type
+                                                (OCaml.Invalid_argument)
                                             ],
                                               .)),
                                           Apply
@@ -2005,8 +2124,10 @@ Value
                                                       ->
                                                       .
                                                         -[
-                                                          NonTermination;
-                                                          OCaml.Invalid_argument
+                                                          Type
+                                                            (NonTermination);
+                                                          Type
+                                                            (OCaml.Invalid_argument)
                                                         ]->
                                                         .)),
                                               Variable
@@ -2022,8 +2143,10 @@ Value
                                                             ->
                                                             .
                                                               -[
-                                                                NonTermination;
-                                                                OCaml.Invalid_argument
+                                                                Type
+                                                                  (NonTermination);
+                                                                Type
+                                                                  (OCaml.Invalid_argument)
                                                               ]->
                                                               .)),
                                                   join_rec),
@@ -2124,11 +2247,21 @@ Value
 Value
   (non_rec, @.,
     [
-      ((join, [ ], [ (l, Type (t)); (v, Type (elt)); (r, Type (t)) ], Type (t)),
+      ((join, [ ], [ (l, Type (t)); (v, Type (elt)); (r, Type (t)) ],
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument)
+          ], Type (t))),
         Apply
           ((?,
             Effect
-              ([ Counter; NonTermination; OCaml.Invalid_argument ], .)),
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Invalid_argument)
+              ], .)),
             Variable
               ((?,
                 Effect
@@ -2138,12 +2271,13 @@ Value
                         . ->
                           .
                             -[
-                              NonTermination;
-                              OCaml.Invalid_argument
+                              Type (NonTermination);
+                              Type
+                                (OCaml.Invalid_argument)
                             ]-> .)), join_rec),
             [
               Apply
-                ((?, Effect ([ Counter ], .)),
+                ((?, Effect ([ Type (Counter) ], .)),
                   Variable
                     ((?,
                       Effect
@@ -2151,7 +2285,8 @@ Value
                         ],
                           .
                             -[
-                              Counter
+                              Type
+                                (Counter)
                             ]->
                             .)),
                       read_counter),
@@ -2173,9 +2308,10 @@ Value
 Value
   (rec, @coq_rec,
     [
-      ((min_elt, [ ], [ (x, Type (t)) ], Type (elt)),
+      ((min_elt, [ ], [ (x, Type (t)) ],
+        Monad ([ Type (OCaml.Not_found) ], Type (elt))),
         Match
-          ((?, Effect ([ OCaml.Not_found ], .)),
+          ((?, Effect ([ Type (OCaml.Not_found) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (Empty),
@@ -2183,7 +2319,8 @@ Value
                   ((109,
                     Effect
                       ([
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Variable
@@ -2193,7 +2330,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Not_found
+                                Type
+                                  (OCaml.Not_found)
                               ]->
                               .)),
                         OCaml.raise_Not_found),
@@ -2212,7 +2350,8 @@ Value
                   ((111,
                     Effect
                       ([
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Variable
@@ -2222,7 +2361,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Not_found
+                                Type
+                                  (OCaml.Not_found)
                               ]->
                               .)),
                         min_elt),
@@ -2242,9 +2382,10 @@ Value
 Value
   (rec, @coq_rec,
     [
-      ((max_elt, [ ], [ (x, Type (t)) ], Type (elt)),
+      ((max_elt, [ ], [ (x, Type (t)) ],
+        Monad ([ Type (OCaml.Not_found) ], Type (elt))),
         Match
-          ((?, Effect ([ OCaml.Not_found ], .)),
+          ((?, Effect ([ Type (OCaml.Not_found) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (Empty),
@@ -2252,7 +2393,8 @@ Value
                   ((115,
                     Effect
                       ([
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Variable
@@ -2262,7 +2404,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Not_found
+                                Type
+                                  (OCaml.Not_found)
                               ]->
                               .)),
                         OCaml.raise_Not_found),
@@ -2281,7 +2424,8 @@ Value
                   ((117,
                     Effect
                       ([
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Variable
@@ -2291,7 +2435,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Not_found
+                                Type
+                                  (OCaml.Not_found)
                               ]->
                               .)),
                         max_elt),
@@ -2311,9 +2456,10 @@ Value
 Value
   (rec, @coq_rec,
     [
-      ((remove_min_elt, [ ], [ (x, Type (t)) ], Type (t)),
+      ((remove_min_elt, [ ], [ (x, Type (t)) ],
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t))),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument ], .)),
+          ((?, Effect ([ Type (OCaml.Invalid_argument) ], .)),
             Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (Empty),
@@ -2321,7 +2467,8 @@ Value
                   ((123,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -2331,7 +2478,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Invalid_argument
+                                Type
+                                  (OCaml.Invalid_argument)
                               ]->
                               .)),
                         OCaml.Pervasives.invalid_arg),
@@ -2351,7 +2499,8 @@ Value
                   ((125,
                     Effect
                       ([
-                        OCaml.Invalid_argument
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Variable
@@ -2365,7 +2514,8 @@ Value
                                 ->
                                 .
                                   -[
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ]->
                                   .)),
                         bal),
@@ -2374,7 +2524,8 @@ Value
                         ((125,
                           Effect
                             ([
-                              OCaml.Invalid_argument
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                               .)),
                           Variable
@@ -2384,7 +2535,8 @@ Value
                                 ],
                                   .
                                     -[
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ]->
                                     .)),
                               remove_min_elt),
@@ -2419,9 +2571,15 @@ Value
 Value
   (non_rec, @.,
     [
-      ((merge, [ ], [ (t1, Type (t)); (t2, Type (t)) ], Type (t)),
+      ((merge, [ ], [ (t1, Type (t)); (t2, Type (t)) ],
+        Monad
+          ([ Type (OCaml.Invalid_argument); Type (OCaml.Not_found) ],
+            Type (t))),
         Match
-          ((133, Effect ([ OCaml.Invalid_argument; OCaml.Not_found ], .)),
+          ((133,
+            Effect
+              ([ Type (OCaml.Invalid_argument); Type (OCaml.Not_found) ],
+                .)),
             Tuple
               ((133, Effect ([ ], .)),
                 Variable ((133, Effect ([ ], .)), t1),
@@ -2436,8 +2594,10 @@ Value
                   ((136,
                     Effect
                       ([
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Variable
@@ -2451,7 +2611,8 @@ Value
                                 ->
                                 .
                                   -[
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ]->
                                   .)),
                         bal),
@@ -2467,7 +2628,8 @@ Value
                         ((136,
                           Effect
                             ([
-                              OCaml.Not_found
+                              Type
+                                (OCaml.Not_found)
                             ],
                               .)),
                           Variable
@@ -2477,7 +2639,8 @@ Value
                                 ],
                                   .
                                     -[
-                                      OCaml.Not_found
+                                      Type
+                                        (OCaml.Not_found)
                                     ]->
                                     .)),
                               min_elt),
@@ -2494,7 +2657,8 @@ Value
                         ((136,
                           Effect
                             ([
-                              OCaml.Invalid_argument
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                               .)),
                           Variable
@@ -2504,7 +2668,8 @@ Value
                                 ],
                                   .
                                     -[
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ]->
                                     .)),
                               remove_min_elt),
@@ -2525,15 +2690,22 @@ Value
 Value
   (non_rec, @.,
     [
-      ((concat, [ ], [ (t1, Type (t)); (t2, Type (t)) ], Type (t)),
+      ((concat, [ ], [ (t1, Type (t)); (t2, Type (t)) ],
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Not_found)
+          ], Type (t))),
         Match
           ((143,
             Effect
               ([
-                Counter;
-                NonTermination;
-                OCaml.Invalid_argument;
-                OCaml.Not_found
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Invalid_argument);
+                Type (OCaml.Not_found)
               ], .)),
             Tuple
               ((143, Effect ([ ], .)),
@@ -2549,10 +2721,14 @@ Value
                   ((146,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Variable
@@ -2566,9 +2742,12 @@ Value
                                 ->
                                 .
                                   -[
-                                    Counter;
-                                    NonTermination;
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (Counter);
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ]->
                                   .)),
                         join),
@@ -2584,7 +2763,8 @@ Value
                         ((146,
                           Effect
                             ([
-                              OCaml.Not_found
+                              Type
+                                (OCaml.Not_found)
                             ],
                               .)),
                           Variable
@@ -2594,7 +2774,8 @@ Value
                                 ],
                                   .
                                     -[
-                                      OCaml.Not_found
+                                      Type
+                                        (OCaml.Not_found)
                                     ]->
                                     .)),
                               min_elt),
@@ -2611,7 +2792,8 @@ Value
                         ((146,
                           Effect
                             ([
-                              OCaml.Invalid_argument
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                               .)),
                           Variable
@@ -2621,7 +2803,8 @@ Value
                                 ],
                                   .
                                     -[
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ]->
                                     .)),
                               remove_min_elt),
@@ -2643,12 +2826,20 @@ Value
   (rec, @coq_rec,
     [
       ((split, [ ], [ (x, Type (Ord.t)); (x_1, Type (t)) ],
-        (Type (t) * Type (bool) * Type (t))),
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument)
+          ], (Type (t) * Type (bool) * Type (t)))),
         Match
           ((?,
             Effect
-              ([ Counter; NonTermination; OCaml.Invalid_argument ], .)),
-            Variable ((?, Effect ([ ], .)), x_1),
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Invalid_argument)
+              ], .)), Variable ((?, Effect ([ ], .)), x_1),
             [
               (Constructor (Empty),
                 Tuple
@@ -2679,9 +2870,12 @@ Value
                   (158,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .))
                   c =
@@ -2698,7 +2892,9 @@ Value
                             ],
                               .
                                 ->
-                                .)),
+                                .
+                                  ->
+                                  .)),
                           Ord.compare),
                       [
                         Variable
@@ -2721,9 +2917,12 @@ Value
                   ((159,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Apply
@@ -2737,7 +2936,11 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .
+                                    ->
+                                    .)),
                             equiv_decb),
                         [
                           Variable
@@ -2786,9 +2989,12 @@ Value
                       ((160,
                         Effect
                           ([
-                            Counter;
-                            NonTermination;
-                            OCaml.Invalid_argument
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination);
+                            Type
+                              (OCaml.Invalid_argument)
                           ],
                             .)),
                         Apply
@@ -2802,7 +3008,11 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .
+                                        ->
+                                        .)),
                                 OCaml.Pervasives.lt),
                             [
                               Variable
@@ -2824,18 +3034,24 @@ Value
                           ((161,
                             Effect
                               ([
-                                Counter;
-                                NonTermination;
-                                OCaml.Invalid_argument
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Apply
                               ((161,
                                 Effect
                                   ([
-                                    Counter;
-                                    NonTermination;
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (Counter);
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ],
                                     .)),
                                 Variable
@@ -2847,9 +3063,12 @@ Value
                                           ->
                                           .
                                             -[
-                                              Counter;
-                                              NonTermination;
-                                              OCaml.Invalid_argument
+                                              Type
+                                                (Counter);
+                                              Type
+                                                (NonTermination);
+                                              Type
+                                                (OCaml.Invalid_argument)
                                             ]->
                                             .)),
                                     split),
@@ -2878,9 +3097,12 @@ Value
                                   ((161,
                                     Effect
                                       ([
-                                        Counter;
-                                        NonTermination;
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (Counter);
+                                        Type
+                                          (NonTermination);
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ],
                                         .)),
                                     Variable
@@ -2901,9 +3123,12 @@ Value
                                       ((161,
                                         Effect
                                           ([
-                                            Counter;
-                                            NonTermination;
-                                            OCaml.Invalid_argument
+                                            Type
+                                              (Counter);
+                                            Type
+                                              (NonTermination);
+                                            Type
+                                              (OCaml.Invalid_argument)
                                           ],
                                             .)),
                                         Variable
@@ -2917,9 +3142,12 @@ Value
                                                     ->
                                                     .
                                                       -[
-                                                        Counter;
-                                                        NonTermination;
-                                                        OCaml.Invalid_argument
+                                                        Type
+                                                          (Counter);
+                                                        Type
+                                                          (NonTermination);
+                                                        Type
+                                                          (OCaml.Invalid_argument)
                                                       ]->
                                                       .)),
                                             join),
@@ -2951,18 +3179,24 @@ Value
                           ((163,
                             Effect
                               ([
-                                Counter;
-                                NonTermination;
-                                OCaml.Invalid_argument
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Apply
                               ((163,
                                 Effect
                                   ([
-                                    Counter;
-                                    NonTermination;
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (Counter);
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ],
                                     .)),
                                 Variable
@@ -2974,9 +3208,12 @@ Value
                                           ->
                                           .
                                             -[
-                                              Counter;
-                                              NonTermination;
-                                              OCaml.Invalid_argument
+                                              Type
+                                                (Counter);
+                                              Type
+                                                (NonTermination);
+                                              Type
+                                                (OCaml.Invalid_argument)
                                             ]->
                                             .)),
                                     split),
@@ -3005,18 +3242,24 @@ Value
                                   ((163,
                                     Effect
                                       ([
-                                        Counter;
-                                        NonTermination;
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (Counter);
+                                        Type
+                                          (NonTermination);
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ],
                                         .)),
                                     Apply
                                       ((163,
                                         Effect
                                           ([
-                                            Counter;
-                                            NonTermination;
-                                            OCaml.Invalid_argument
+                                            Type
+                                              (Counter);
+                                            Type
+                                              (NonTermination);
+                                            Type
+                                              (OCaml.Invalid_argument)
                                           ],
                                             .)),
                                         Variable
@@ -3030,9 +3273,12 @@ Value
                                                     ->
                                                     .
                                                       -[
-                                                        Counter;
-                                                        NonTermination;
-                                                        OCaml.Invalid_argument
+                                                        Type
+                                                          (Counter);
+                                                        Type
+                                                          (NonTermination);
+                                                        Type
+                                                          (OCaml.Invalid_argument)
                                                       ]->
                                                       .)),
                                             join),
@@ -3127,7 +3373,9 @@ Value
                             ],
                               .
                                 ->
-                                .)),
+                                .
+                                  ->
+                                  .)),
                           Ord.compare),
                       [
                         Variable
@@ -3153,7 +3401,11 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .
+                                ->
+                                .)),
                         orb),
                     [
                       Apply
@@ -3167,7 +3419,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               equiv_decb),
                           [
                             Variable
@@ -3227,7 +3483,11 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         OCaml.Pervasives.lt),
                                     [
                                       Variable
@@ -3268,10 +3528,15 @@ Value
 Value
   (rec, @coq_rec,
     [
-      ((remove, [ ], [ (x, Type (Ord.t)); (x_1, Type (t)) ], Type (t)),
+      ((remove, [ ], [ (x, Type (Ord.t)); (x_1, Type (t)) ],
+        Monad
+          ([ Type (OCaml.Invalid_argument); Type (OCaml.Not_found) ],
+            Type (t))),
         Match
-          ((?, Effect ([ OCaml.Invalid_argument; OCaml.Not_found ], .)),
-            Variable ((?, Effect ([ ], .)), x_1),
+          ((?,
+            Effect
+              ([ Type (OCaml.Invalid_argument); Type (OCaml.Not_found) ],
+                .)), Variable ((?, Effect ([ ], .)), x_1),
             [
               (Constructor (Empty),
                 Constructor
@@ -3282,8 +3547,10 @@ Value
                   (182,
                     Effect
                       ([
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .))
                   c =
@@ -3300,7 +3567,9 @@ Value
                             ],
                               .
                                 ->
-                                .)),
+                                .
+                                  ->
+                                  .)),
                           Ord.compare),
                       [
                         Variable
@@ -3323,8 +3592,10 @@ Value
                   ((183,
                     Effect
                       ([
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Apply
@@ -3338,7 +3609,11 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .
+                                    ->
+                                    .)),
                             equiv_decb),
                         [
                           Variable
@@ -3360,8 +3635,10 @@ Value
                       ((183,
                         Effect
                           ([
-                            OCaml.Invalid_argument;
-                            OCaml.Not_found
+                            Type
+                              (OCaml.Invalid_argument);
+                            Type
+                              (OCaml.Not_found)
                           ],
                             .)),
                         Variable
@@ -3373,8 +3650,10 @@ Value
                                   ->
                                   .
                                     -[
-                                      OCaml.Invalid_argument;
-                                      OCaml.Not_found
+                                      Type
+                                        (OCaml.Invalid_argument);
+                                      Type
+                                        (OCaml.Not_found)
                                     ]->
                                     .)),
                             merge),
@@ -3398,8 +3677,10 @@ Value
                       ((184,
                         Effect
                           ([
-                            OCaml.Invalid_argument;
-                            OCaml.Not_found
+                            Type
+                              (OCaml.Invalid_argument);
+                            Type
+                              (OCaml.Not_found)
                           ],
                             .)),
                         Apply
@@ -3413,7 +3694,11 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .
+                                        ->
+                                        .)),
                                 OCaml.Pervasives.lt),
                             [
                               Variable
@@ -3435,8 +3720,10 @@ Value
                           ((184,
                             Effect
                               ([
-                                OCaml.Invalid_argument;
-                                OCaml.Not_found
+                                Type
+                                  (OCaml.Invalid_argument);
+                                Type
+                                  (OCaml.Not_found)
                               ],
                                 .)),
                             Variable
@@ -3450,7 +3737,8 @@ Value
                                         ->
                                         .
                                           -[
-                                            OCaml.Invalid_argument
+                                            Type
+                                              (OCaml.Invalid_argument)
                                           ]->
                                           .)),
                                 bal),
@@ -3459,8 +3747,10 @@ Value
                                 ((184,
                                   Effect
                                     ([
-                                      OCaml.Invalid_argument;
-                                      OCaml.Not_found
+                                      Type
+                                        (OCaml.Invalid_argument);
+                                      Type
+                                        (OCaml.Not_found)
                                     ],
                                       .)),
                                   Variable
@@ -3472,8 +3762,10 @@ Value
                                             ->
                                             .
                                               -[
-                                                OCaml.Invalid_argument;
-                                                OCaml.Not_found
+                                                Type
+                                                  (OCaml.Invalid_argument);
+                                                Type
+                                                  (OCaml.Not_found)
                                               ]->
                                               .)),
                                       remove),
@@ -3512,8 +3804,10 @@ Value
                           ((184,
                             Effect
                               ([
-                                OCaml.Invalid_argument;
-                                OCaml.Not_found
+                                Type
+                                  (OCaml.Invalid_argument);
+                                Type
+                                  (OCaml.Not_found)
                               ],
                                 .)),
                             Variable
@@ -3527,7 +3821,8 @@ Value
                                         ->
                                         .
                                           -[
-                                            OCaml.Invalid_argument
+                                            Type
+                                              (OCaml.Invalid_argument)
                                           ]->
                                           .)),
                                 bal),
@@ -3550,8 +3845,10 @@ Value
                                 ((184,
                                   Effect
                                     ([
-                                      OCaml.Invalid_argument;
-                                      OCaml.Not_found
+                                      Type
+                                        (OCaml.Invalid_argument);
+                                      Type
+                                        (OCaml.Not_found)
                                     ],
                                       .)),
                                   Variable
@@ -3563,8 +3860,10 @@ Value
                                             ->
                                             .
                                               -[
-                                                OCaml.Invalid_argument;
-                                                OCaml.Not_found
+                                                Type
+                                                  (OCaml.Invalid_argument);
+                                                Type
+                                                  (OCaml.Not_found)
                                               ]->
                                               .)),
                                       remove),
@@ -3593,19 +3892,29 @@ Value
   (rec, @.,
     [
       ((union_rec, [ ],
-        [ (counter, Type (nat)); (s1, Type (t)); (s2, Type (t)) ], Type (t)),
+        [ (counter, Type (nat)); (s1, Type (t)); (s2, Type (t)) ],
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument)
+          ], Type (t))),
         Match
           ((?,
             Effect
-              ([ Counter; NonTermination; OCaml.Invalid_argument ], .)),
-            Variable ((?, Effect ([ ], .)), counter),
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Invalid_argument)
+              ], .)), Variable ((?, Effect ([ ], .)), counter),
             [
               (Constructor (O),
                 Apply
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -3615,7 +3924,8 @@ Value
                           ],
                             .
                               -[
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         not_terminated),
@@ -3632,9 +3942,12 @@ Value
                   ((188,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument)
                       ],
                         .)),
                     Tuple
@@ -3697,9 +4010,12 @@ Value
                           ((192,
                             Effect
                               ([
-                                Counter;
-                                NonTermination;
-                                OCaml.Invalid_argument
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Invalid_argument)
                               ],
                                 .)),
                             Apply
@@ -3713,7 +4029,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     OCaml.Pervasives.ge),
                                 [
                                   Variable
@@ -3735,9 +4055,12 @@ Value
                               ((193,
                                 Effect
                                   ([
-                                    Counter;
-                                    NonTermination;
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (Counter);
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ],
                                     .)),
                                 Apply
@@ -3751,7 +4074,11 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         equiv_decb),
                                     [
                                       Variable
@@ -3773,7 +4100,8 @@ Value
                                   ((193,
                                     Effect
                                       ([
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ],
                                         .)),
                                     Variable
@@ -3785,7 +4113,8 @@ Value
                                               ->
                                               .
                                                 -[
-                                                  OCaml.Invalid_argument
+                                                  Type
+                                                    (OCaml.Invalid_argument)
                                                 ]->
                                                 .)),
                                         add),
@@ -3809,18 +4138,24 @@ Value
                                   ((193,
                                     Effect
                                       ([
-                                        Counter;
-                                        NonTermination;
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (Counter);
+                                        Type
+                                          (NonTermination);
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ],
                                         .)),
                                     Apply
                                       ((194,
                                         Effect
                                           ([
-                                            Counter;
-                                            NonTermination;
-                                            OCaml.Invalid_argument
+                                            Type
+                                              (Counter);
+                                            Type
+                                              (NonTermination);
+                                            Type
+                                              (OCaml.Invalid_argument)
                                           ],
                                             .)),
                                         Variable
@@ -3832,9 +4167,12 @@ Value
                                                   ->
                                                   .
                                                     -[
-                                                      Counter;
-                                                      NonTermination;
-                                                      OCaml.Invalid_argument
+                                                      Type
+                                                        (Counter);
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Invalid_argument)
                                                     ]->
                                                     .)),
                                             split),
@@ -3863,9 +4201,12 @@ Value
                                           ((195,
                                             Effect
                                               ([
-                                                Counter;
-                                                NonTermination;
-                                                OCaml.Invalid_argument
+                                                Type
+                                                  (Counter);
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Invalid_argument)
                                               ],
                                                 .)),
                                             Variable
@@ -3879,9 +4220,12 @@ Value
                                                         ->
                                                         .
                                                           -[
-                                                            Counter;
-                                                            NonTermination;
-                                                            OCaml.Invalid_argument
+                                                            Type
+                                                              (Counter);
+                                                            Type
+                                                              (NonTermination);
+                                                            Type
+                                                              (OCaml.Invalid_argument)
                                                           ]->
                                                           .)),
                                                 join),
@@ -3890,9 +4234,12 @@ Value
                                                 ((195,
                                                   Effect
                                                     ([
-                                                      Counter;
-                                                      NonTermination;
-                                                      OCaml.Invalid_argument
+                                                      Type
+                                                        (Counter);
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Invalid_argument)
                                                     ],
                                                       .)),
                                                   Apply
@@ -3904,9 +4251,12 @@ Value
                                                             ->
                                                             .
                                                               -[
-                                                                Counter;
-                                                                NonTermination;
-                                                                OCaml.Invalid_argument
+                                                                Type
+                                                                  (Counter);
+                                                                Type
+                                                                  (NonTermination);
+                                                                Type
+                                                                  (OCaml.Invalid_argument)
                                                               ]->
                                                               .)),
                                                       Variable
@@ -3920,9 +4270,12 @@ Value
                                                                   ->
                                                                   .
                                                                     -[
-                                                                      Counter;
-                                                                      NonTermination;
-                                                                      OCaml.Invalid_argument
+                                                                      Type
+                                                                        (Counter);
+                                                                      Type
+                                                                        (NonTermination);
+                                                                      Type
+                                                                        (OCaml.Invalid_argument)
                                                                     ]->
                                                                     .)),
                                                           union_rec),
@@ -3962,9 +4315,12 @@ Value
                                                 ((195,
                                                   Effect
                                                     ([
-                                                      Counter;
-                                                      NonTermination;
-                                                      OCaml.Invalid_argument
+                                                      Type
+                                                        (Counter);
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Invalid_argument)
                                                     ],
                                                       .)),
                                                   Apply
@@ -3976,9 +4332,12 @@ Value
                                                             ->
                                                             .
                                                               -[
-                                                                Counter;
-                                                                NonTermination;
-                                                                OCaml.Invalid_argument
+                                                                Type
+                                                                  (Counter);
+                                                                Type
+                                                                  (NonTermination);
+                                                                Type
+                                                                  (OCaml.Invalid_argument)
                                                               ]->
                                                               .)),
                                                       Variable
@@ -3992,9 +4351,12 @@ Value
                                                                   ->
                                                                   .
                                                                     -[
-                                                                      Counter;
-                                                                      NonTermination;
-                                                                      OCaml.Invalid_argument
+                                                                      Type
+                                                                        (Counter);
+                                                                      Type
+                                                                        (NonTermination);
+                                                                      Type
+                                                                        (OCaml.Invalid_argument)
                                                                     ]->
                                                                     .)),
                                                           union_rec),
@@ -4029,9 +4391,12 @@ Value
                               ((198,
                                 Effect
                                   ([
-                                    Counter;
-                                    NonTermination;
-                                    OCaml.Invalid_argument
+                                    Type
+                                      (Counter);
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Invalid_argument)
                                   ],
                                     .)),
                                 Apply
@@ -4045,7 +4410,11 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         equiv_decb),
                                     [
                                       Variable
@@ -4067,7 +4436,8 @@ Value
                                   ((198,
                                     Effect
                                       ([
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ],
                                         .)),
                                     Variable
@@ -4079,7 +4449,8 @@ Value
                                               ->
                                               .
                                                 -[
-                                                  OCaml.Invalid_argument
+                                                  Type
+                                                    (OCaml.Invalid_argument)
                                                 ]->
                                                 .)),
                                         add),
@@ -4103,18 +4474,24 @@ Value
                                   ((198,
                                     Effect
                                       ([
-                                        Counter;
-                                        NonTermination;
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (Counter);
+                                        Type
+                                          (NonTermination);
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ],
                                         .)),
                                     Apply
                                       ((199,
                                         Effect
                                           ([
-                                            Counter;
-                                            NonTermination;
-                                            OCaml.Invalid_argument
+                                            Type
+                                              (Counter);
+                                            Type
+                                              (NonTermination);
+                                            Type
+                                              (OCaml.Invalid_argument)
                                           ],
                                             .)),
                                         Variable
@@ -4126,9 +4503,12 @@ Value
                                                   ->
                                                   .
                                                     -[
-                                                      Counter;
-                                                      NonTermination;
-                                                      OCaml.Invalid_argument
+                                                      Type
+                                                        (Counter);
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Invalid_argument)
                                                     ]->
                                                     .)),
                                             split),
@@ -4157,9 +4537,12 @@ Value
                                           ((200,
                                             Effect
                                               ([
-                                                Counter;
-                                                NonTermination;
-                                                OCaml.Invalid_argument
+                                                Type
+                                                  (Counter);
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Invalid_argument)
                                               ],
                                                 .)),
                                             Variable
@@ -4173,9 +4556,12 @@ Value
                                                         ->
                                                         .
                                                           -[
-                                                            Counter;
-                                                            NonTermination;
-                                                            OCaml.Invalid_argument
+                                                            Type
+                                                              (Counter);
+                                                            Type
+                                                              (NonTermination);
+                                                            Type
+                                                              (OCaml.Invalid_argument)
                                                           ]->
                                                           .)),
                                                 join),
@@ -4184,9 +4570,12 @@ Value
                                                 ((200,
                                                   Effect
                                                     ([
-                                                      Counter;
-                                                      NonTermination;
-                                                      OCaml.Invalid_argument
+                                                      Type
+                                                        (Counter);
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Invalid_argument)
                                                     ],
                                                       .)),
                                                   Apply
@@ -4198,9 +4587,12 @@ Value
                                                             ->
                                                             .
                                                               -[
-                                                                Counter;
-                                                                NonTermination;
-                                                                OCaml.Invalid_argument
+                                                                Type
+                                                                  (Counter);
+                                                                Type
+                                                                  (NonTermination);
+                                                                Type
+                                                                  (OCaml.Invalid_argument)
                                                               ]->
                                                               .)),
                                                       Variable
@@ -4214,9 +4606,12 @@ Value
                                                                   ->
                                                                   .
                                                                     -[
-                                                                      Counter;
-                                                                      NonTermination;
-                                                                      OCaml.Invalid_argument
+                                                                      Type
+                                                                        (Counter);
+                                                                      Type
+                                                                        (NonTermination);
+                                                                      Type
+                                                                        (OCaml.Invalid_argument)
                                                                     ]->
                                                                     .)),
                                                           union_rec),
@@ -4256,9 +4651,12 @@ Value
                                                 ((200,
                                                   Effect
                                                     ([
-                                                      Counter;
-                                                      NonTermination;
-                                                      OCaml.Invalid_argument
+                                                      Type
+                                                        (Counter);
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Invalid_argument)
                                                     ],
                                                       .)),
                                                   Apply
@@ -4270,9 +4668,12 @@ Value
                                                             ->
                                                             .
                                                               -[
-                                                                Counter;
-                                                                NonTermination;
-                                                                OCaml.Invalid_argument
+                                                                Type
+                                                                  (Counter);
+                                                                Type
+                                                                  (NonTermination);
+                                                                Type
+                                                                  (OCaml.Invalid_argument)
                                                               ]->
                                                               .)),
                                                       Variable
@@ -4286,9 +4687,12 @@ Value
                                                                   ->
                                                                   .
                                                                     -[
-                                                                      Counter;
-                                                                      NonTermination;
-                                                                      OCaml.Invalid_argument
+                                                                      Type
+                                                                        (Counter);
+                                                                      Type
+                                                                        (NonTermination);
+                                                                      Type
+                                                                        (OCaml.Invalid_argument)
                                                                     ]->
                                                                     .)),
                                                           union_rec),
@@ -4327,11 +4731,21 @@ Value
 Value
   (non_rec, @.,
     [
-      ((union, [ ], [ (s1, Type (t)); (s2, Type (t)) ], Type (t)),
+      ((union, [ ], [ (s1, Type (t)); (s2, Type (t)) ],
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument)
+          ], Type (t))),
         Apply
           ((?,
             Effect
-              ([ Counter; NonTermination; OCaml.Invalid_argument ], .)),
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Invalid_argument)
+              ], .)),
             Variable
               ((?,
                 Effect
@@ -4340,13 +4754,13 @@ Value
                       . ->
                         .
                           -[
-                            Counter;
-                            NonTermination;
-                            OCaml.Invalid_argument
+                            Type (Counter);
+                            Type (NonTermination);
+                            Type (OCaml.Invalid_argument)
                           ]-> .)), union_rec),
             [
               Apply
-                ((?, Effect ([ Counter ], .)),
+                ((?, Effect ([ Type (Counter) ], .)),
                   Variable
                     ((?,
                       Effect
@@ -4354,7 +4768,8 @@ Value
                         ],
                           .
                             -[
-                              Counter
+                              Type
+                                (Counter)
                             ]->
                             .)),
                       read_counter),
@@ -4375,15 +4790,22 @@ Value
 Value
   (rec, @coq_rec,
     [
-      ((inter, [ ], [ (s1, Type (t)); (s2, Type (t)) ], Type (t)),
+      ((inter, [ ], [ (s1, Type (t)); (s2, Type (t)) ],
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Not_found)
+          ], Type (t))),
         Match
           ((204,
             Effect
               ([
-                Counter;
-                NonTermination;
-                OCaml.Invalid_argument;
-                OCaml.Not_found
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Invalid_argument);
+                Type (OCaml.Not_found)
               ], .)),
             Tuple
               ((204, Effect ([ ], .)),
@@ -4403,19 +4825,26 @@ Value
                   ((208,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Apply
                       ((208,
                         Effect
                           ([
-                            Counter;
-                            NonTermination;
-                            OCaml.Invalid_argument
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination);
+                            Type
+                              (OCaml.Invalid_argument)
                           ],
                             .)),
                         Variable
@@ -4427,9 +4856,12 @@ Value
                                   ->
                                   .
                                     -[
-                                      Counter;
-                                      NonTermination;
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ]->
                                     .)),
                             split),
@@ -4459,10 +4891,14 @@ Value
                           ((210,
                             Effect
                               ([
-                                Counter;
-                                NonTermination;
-                                OCaml.Invalid_argument;
-                                OCaml.Not_found
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Invalid_argument);
+                                Type
+                                  (OCaml.Not_found)
                               ],
                                 .)),
                             Variable
@@ -4474,10 +4910,14 @@ Value
                                       ->
                                       .
                                         -[
-                                          Counter;
-                                          NonTermination;
-                                          OCaml.Invalid_argument;
-                                          OCaml.Not_found
+                                          Type
+                                            (Counter);
+                                          Type
+                                            (NonTermination);
+                                          Type
+                                            (OCaml.Invalid_argument);
+                                          Type
+                                            (OCaml.Not_found)
                                         ]->
                                         .)),
                                 concat),
@@ -4486,10 +4926,14 @@ Value
                                 ((210,
                                   Effect
                                     ([
-                                      Counter;
-                                      NonTermination;
-                                      OCaml.Invalid_argument;
-                                      OCaml.Not_found
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Invalid_argument);
+                                      Type
+                                        (OCaml.Not_found)
                                     ],
                                       .)),
                                   Variable
@@ -4501,10 +4945,14 @@ Value
                                             ->
                                             .
                                               -[
-                                                Counter;
-                                                NonTermination;
-                                                OCaml.Invalid_argument;
-                                                OCaml.Not_found
+                                                Type
+                                                  (Counter);
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Invalid_argument);
+                                                Type
+                                                  (OCaml.Not_found)
                                               ]->
                                               .)),
                                       inter),
@@ -4528,10 +4976,14 @@ Value
                                 ((210,
                                   Effect
                                     ([
-                                      Counter;
-                                      NonTermination;
-                                      OCaml.Invalid_argument;
-                                      OCaml.Not_found
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Invalid_argument);
+                                      Type
+                                        (OCaml.Not_found)
                                     ],
                                       .)),
                                   Variable
@@ -4543,10 +4995,14 @@ Value
                                             ->
                                             .
                                               -[
-                                                Counter;
-                                                NonTermination;
-                                                OCaml.Invalid_argument;
-                                                OCaml.Not_found
+                                                Type
+                                                  (Counter);
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Invalid_argument);
+                                                Type
+                                                  (OCaml.Not_found)
                                               ]->
                                               .)),
                                       inter),
@@ -4576,10 +5032,14 @@ Value
                           ((212,
                             Effect
                               ([
-                                Counter;
-                                NonTermination;
-                                OCaml.Invalid_argument;
-                                OCaml.Not_found
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Invalid_argument);
+                                Type
+                                  (OCaml.Not_found)
                               ],
                                 .)),
                             Variable
@@ -4593,9 +5053,12 @@ Value
                                         ->
                                         .
                                           -[
-                                            Counter;
-                                            NonTermination;
-                                            OCaml.Invalid_argument
+                                            Type
+                                              (Counter);
+                                            Type
+                                              (NonTermination);
+                                            Type
+                                              (OCaml.Invalid_argument)
                                           ]->
                                           .)),
                                 join),
@@ -4604,10 +5067,14 @@ Value
                                 ((212,
                                   Effect
                                     ([
-                                      Counter;
-                                      NonTermination;
-                                      OCaml.Invalid_argument;
-                                      OCaml.Not_found
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Invalid_argument);
+                                      Type
+                                        (OCaml.Not_found)
                                     ],
                                       .)),
                                   Variable
@@ -4619,10 +5086,14 @@ Value
                                             ->
                                             .
                                               -[
-                                                Counter;
-                                                NonTermination;
-                                                OCaml.Invalid_argument;
-                                                OCaml.Not_found
+                                                Type
+                                                  (Counter);
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Invalid_argument);
+                                                Type
+                                                  (OCaml.Not_found)
                                               ]->
                                               .)),
                                       inter),
@@ -4653,10 +5124,14 @@ Value
                                 ((212,
                                   Effect
                                     ([
-                                      Counter;
-                                      NonTermination;
-                                      OCaml.Invalid_argument;
-                                      OCaml.Not_found
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Invalid_argument);
+                                      Type
+                                        (OCaml.Not_found)
                                     ],
                                       .)),
                                   Variable
@@ -4668,10 +5143,14 @@ Value
                                             ->
                                             .
                                               -[
-                                                Counter;
-                                                NonTermination;
-                                                OCaml.Invalid_argument;
-                                                OCaml.Not_found
+                                                Type
+                                                  (Counter);
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Invalid_argument);
+                                                Type
+                                                  (OCaml.Not_found)
                                               ]->
                                               .)),
                                       inter),
@@ -4700,15 +5179,22 @@ Value
 Value
   (rec, @coq_rec,
     [
-      ((diff, [ ], [ (s1, Type (t)); (s2, Type (t)) ], Type (t)),
+      ((diff, [ ], [ (s1, Type (t)); (s2, Type (t)) ],
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Not_found)
+          ], Type (t))),
         Match
           ((216,
             Effect
               ([
-                Counter;
-                NonTermination;
-                OCaml.Invalid_argument;
-                OCaml.Not_found
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Invalid_argument);
+                Type (OCaml.Not_found)
               ], .)),
             Tuple
               ((216, Effect ([ ], .)),
@@ -4726,19 +5212,26 @@ Value
                   ((220,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Apply
                       ((220,
                         Effect
                           ([
-                            Counter;
-                            NonTermination;
-                            OCaml.Invalid_argument
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination);
+                            Type
+                              (OCaml.Invalid_argument)
                           ],
                             .)),
                         Variable
@@ -4750,9 +5243,12 @@ Value
                                   ->
                                   .
                                     -[
-                                      Counter;
-                                      NonTermination;
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ]->
                                     .)),
                             split),
@@ -4782,10 +5278,14 @@ Value
                           ((222,
                             Effect
                               ([
-                                Counter;
-                                NonTermination;
-                                OCaml.Invalid_argument;
-                                OCaml.Not_found
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Invalid_argument);
+                                Type
+                                  (OCaml.Not_found)
                               ],
                                 .)),
                             Variable
@@ -4799,9 +5299,12 @@ Value
                                         ->
                                         .
                                           -[
-                                            Counter;
-                                            NonTermination;
-                                            OCaml.Invalid_argument
+                                            Type
+                                              (Counter);
+                                            Type
+                                              (NonTermination);
+                                            Type
+                                              (OCaml.Invalid_argument)
                                           ]->
                                           .)),
                                 join),
@@ -4810,10 +5313,14 @@ Value
                                 ((222,
                                   Effect
                                     ([
-                                      Counter;
-                                      NonTermination;
-                                      OCaml.Invalid_argument;
-                                      OCaml.Not_found
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Invalid_argument);
+                                      Type
+                                        (OCaml.Not_found)
                                     ],
                                       .)),
                                   Variable
@@ -4825,10 +5332,14 @@ Value
                                             ->
                                             .
                                               -[
-                                                Counter;
-                                                NonTermination;
-                                                OCaml.Invalid_argument;
-                                                OCaml.Not_found
+                                                Type
+                                                  (Counter);
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Invalid_argument);
+                                                Type
+                                                  (OCaml.Not_found)
                                               ]->
                                               .)),
                                       diff),
@@ -4859,10 +5370,14 @@ Value
                                 ((222,
                                   Effect
                                     ([
-                                      Counter;
-                                      NonTermination;
-                                      OCaml.Invalid_argument;
-                                      OCaml.Not_found
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Invalid_argument);
+                                      Type
+                                        (OCaml.Not_found)
                                     ],
                                       .)),
                                   Variable
@@ -4874,10 +5389,14 @@ Value
                                             ->
                                             .
                                               -[
-                                                Counter;
-                                                NonTermination;
-                                                OCaml.Invalid_argument;
-                                                OCaml.Not_found
+                                                Type
+                                                  (Counter);
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Invalid_argument);
+                                                Type
+                                                  (OCaml.Not_found)
                                               ]->
                                               .)),
                                       diff),
@@ -4907,10 +5426,14 @@ Value
                           ((224,
                             Effect
                               ([
-                                Counter;
-                                NonTermination;
-                                OCaml.Invalid_argument;
-                                OCaml.Not_found
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Invalid_argument);
+                                Type
+                                  (OCaml.Not_found)
                               ],
                                 .)),
                             Variable
@@ -4922,10 +5445,14 @@ Value
                                       ->
                                       .
                                         -[
-                                          Counter;
-                                          NonTermination;
-                                          OCaml.Invalid_argument;
-                                          OCaml.Not_found
+                                          Type
+                                            (Counter);
+                                          Type
+                                            (NonTermination);
+                                          Type
+                                            (OCaml.Invalid_argument);
+                                          Type
+                                            (OCaml.Not_found)
                                         ]->
                                         .)),
                                 concat),
@@ -4934,10 +5461,14 @@ Value
                                 ((224,
                                   Effect
                                     ([
-                                      Counter;
-                                      NonTermination;
-                                      OCaml.Invalid_argument;
-                                      OCaml.Not_found
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Invalid_argument);
+                                      Type
+                                        (OCaml.Not_found)
                                     ],
                                       .)),
                                   Variable
@@ -4949,10 +5480,14 @@ Value
                                             ->
                                             .
                                               -[
-                                                Counter;
-                                                NonTermination;
-                                                OCaml.Invalid_argument;
-                                                OCaml.Not_found
+                                                Type
+                                                  (Counter);
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Invalid_argument);
+                                                Type
+                                                  (OCaml.Not_found)
                                               ]->
                                               .)),
                                       diff),
@@ -4976,10 +5511,14 @@ Value
                                 ((224,
                                   Effect
                                     ([
-                                      Counter;
-                                      NonTermination;
-                                      OCaml.Invalid_argument;
-                                      OCaml.Not_found
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Invalid_argument);
+                                      Type
+                                        (OCaml.Not_found)
                                     ],
                                       .)),
                                   Variable
@@ -4991,10 +5530,14 @@ Value
                                             ->
                                             .
                                               -[
-                                                Counter;
-                                                NonTermination;
-                                                OCaml.Invalid_argument;
-                                                OCaml.Not_found
+                                                Type
+                                                  (Counter);
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Invalid_argument);
+                                                Type
+                                                  (OCaml.Not_found)
                                               ]->
                                               .)),
                                       diff),
@@ -5097,9 +5640,9 @@ Value
           (counter, Type (nat));
           (e1, Type (enumeration));
           (e2, Type (enumeration))
-        ], Type (Z)),
+        ], Monad ([ Type (NonTermination) ], Type (Z))),
         Match
-          ((?, Effect ([ NonTermination ], .)),
+          ((?, Effect ([ Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), counter),
             [
               (Constructor (O),
@@ -5107,7 +5650,8 @@ Value
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -5117,7 +5661,8 @@ Value
                           ],
                             .
                               -[
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         not_terminated),
@@ -5134,7 +5679,8 @@ Value
                   ((236,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Tuple
@@ -5207,7 +5753,8 @@ Value
                           (241,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .))
                           c
@@ -5225,7 +5772,9 @@ Value
                                     ],
                                       .
                                         ->
-                                        .)),
+                                        .
+                                          ->
+                                          .)),
                                   Ord.compare),
                               [
                                 Variable
@@ -5248,7 +5797,8 @@ Value
                           ((242,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Apply
@@ -5262,7 +5812,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     nequiv_decb),
                                 [
                                   Variable
@@ -5291,7 +5845,8 @@ Value
                               ((244,
                                 Effect
                                   ([
-                                    NonTermination
+                                    Type
+                                      (NonTermination)
                                   ],
                                     .)),
                                 Apply
@@ -5303,7 +5858,8 @@ Value
                                           ->
                                           .
                                             -[
-                                              NonTermination
+                                              Type
+                                                (NonTermination)
                                             ]->
                                             .)),
                                     Variable
@@ -5317,7 +5873,8 @@ Value
                                                 ->
                                                 .
                                                   -[
-                                                    NonTermination
+                                                    Type
+                                                      (NonTermination)
                                                   ]->
                                                   .)),
                                         compare_aux_rec),
@@ -5407,15 +5964,18 @@ Value
   (non_rec, @.,
     [
       ((compare_aux, [ ],
-        [ (e1, Type (enumeration)); (e2, Type (enumeration)) ], Type (Z)),
+        [ (e1, Type (enumeration)); (e2, Type (enumeration)) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (Z))),
         Apply
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable
-              ((?, Effect ([ ], . -> . -> . -[ NonTermination ]-> .)),
+              ((?,
+                Effect
+                  ([ ], . -> . -> . -[ Type (NonTermination) ]-> .)),
                 compare_aux_rec),
             [
               Apply
-                ((?, Effect ([ Counter ], .)),
+                ((?, Effect ([ Type (Counter) ], .)),
                   Variable
                     ((?,
                       Effect
@@ -5423,7 +5983,8 @@ Value
                         ],
                           .
                             -[
-                              Counter
+                              Type
+                                (Counter)
                             ]->
                             .)),
                       read_counter),
@@ -5444,13 +6005,20 @@ Value
 Value
   (non_rec, @.,
     [
-      ((compare, [ ], [ (s1, Type (t)); (s2, Type (t)) ], Type (Z)),
+      ((compare, [ ], [ (s1, Type (t)); (s2, Type (t)) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (Z))),
         Apply
-          ((247, Effect ([ Counter; NonTermination ], .)),
+          ((247, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable
               ((247,
-                Effect ([ ], . -> . -[ Counter; NonTermination ]-> .)),
-                compare_aux),
+                Effect
+                  ([ ],
+                    . ->
+                      .
+                        -[
+                          Type (Counter);
+                          Type (NonTermination)
+                        ]-> .)), compare_aux),
             [
               Apply
                 ((247, Effect ([ ], .)),
@@ -5517,17 +6085,20 @@ Value
 Value
   (non_rec, @.,
     [
-      ((equal, [ ], [ (s1, Type (t)); (s2, Type (t)) ], Type (bool)),
+      ((equal, [ ], [ (s1, Type (t)); (s2, Type (t)) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (bool))),
         Apply
-          ((250, Effect ([ Counter; NonTermination ], .)),
-            Variable ((250, Effect ([ ], .)), equiv_decb),
+          ((250, Effect ([ Type (Counter); Type (NonTermination) ], .)),
+            Variable ((250, Effect ([ ], . -> . -> .)), equiv_decb),
             [
               Apply
                 ((250,
                   Effect
                     ([
-                      Counter;
-                      NonTermination
+                      Type
+                        (Counter);
+                      Type
+                        (NonTermination)
                     ], .)),
                   Variable
                     ((250,
@@ -5538,8 +6109,10 @@ Value
                             ->
                             .
                               -[
-                                Counter;
-                                NonTermination
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                       compare),
@@ -5568,9 +6141,10 @@ Value
   (rec, @.,
     [
       ((subset_rec, [ ],
-        [ (counter, Type (nat)); (s1, Type (t)); (s2, Type (t)) ], Type (bool)),
+        [ (counter, Type (nat)); (s1, Type (t)); (s2, Type (t)) ],
+        Monad ([ Type (NonTermination) ], Type (bool))),
         Match
-          ((?, Effect ([ NonTermination ], .)),
+          ((?, Effect ([ Type (NonTermination) ], .)),
             Variable ((?, Effect ([ ], .)), counter),
             [
               (Constructor (O),
@@ -5578,7 +6152,8 @@ Value
                   ((?,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Variable
@@ -5588,7 +6163,8 @@ Value
                           ],
                             .
                               -[
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ]->
                               .)),
                         not_terminated),
@@ -5605,7 +6181,8 @@ Value
                   ((253,
                     Effect
                       ([
-                        NonTermination
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     Tuple
@@ -5670,7 +6247,8 @@ Value
                           (259,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .))
                           c
@@ -5688,7 +6266,9 @@ Value
                                     ],
                                       .
                                         ->
-                                        .)),
+                                        .
+                                          ->
+                                          .)),
                                   Ord.compare),
                               [
                                 Variable
@@ -5711,7 +6291,8 @@ Value
                           ((260,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Apply
@@ -5725,7 +6306,11 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     equiv_decb),
                                 [
                                   Variable
@@ -5747,7 +6332,8 @@ Value
                               ((261,
                                 Effect
                                   ([
-                                    NonTermination
+                                    Type
+                                      (NonTermination)
                                   ],
                                     .)),
                                 Variable
@@ -5755,14 +6341,19 @@ Value
                                     Effect
                                       ([
                                       ],
-                                        .)),
+                                        .
+                                          ->
+                                          .
+                                            ->
+                                            .)),
                                     andb),
                                 [
                                   Apply
                                     ((261,
                                       Effect
                                         ([
-                                          NonTermination
+                                          Type
+                                            (NonTermination)
                                         ],
                                           .)),
                                       Apply
@@ -5774,7 +6365,8 @@ Value
                                                 ->
                                                 .
                                                   -[
-                                                    NonTermination
+                                                    Type
+                                                      (NonTermination)
                                                   ]->
                                                   .)),
                                           Variable
@@ -5788,7 +6380,8 @@ Value
                                                       ->
                                                       .
                                                         -[
-                                                          NonTermination
+                                                          Type
+                                                            (NonTermination)
                                                         ]->
                                                         .)),
                                               subset_rec),
@@ -5821,7 +6414,8 @@ Value
                                     ((261,
                                       Effect
                                         ([
-                                          NonTermination
+                                          Type
+                                            (NonTermination)
                                         ],
                                           .)),
                                       Apply
@@ -5833,7 +6427,8 @@ Value
                                                 ->
                                                 .
                                                   -[
-                                                    NonTermination
+                                                    Type
+                                                      (NonTermination)
                                                   ]->
                                                   .)),
                                           Variable
@@ -5847,7 +6442,8 @@ Value
                                                       ->
                                                       .
                                                         -[
-                                                          NonTermination
+                                                          Type
+                                                            (NonTermination)
                                                         ]->
                                                         .)),
                                               subset_rec),
@@ -5881,7 +6477,8 @@ Value
                               ((262,
                                 Effect
                                   ([
-                                    NonTermination
+                                    Type
+                                      (NonTermination)
                                   ],
                                     .)),
                                 Apply
@@ -5895,7 +6492,11 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         OCaml.Pervasives.lt),
                                     [
                                       Variable
@@ -5917,7 +6518,8 @@ Value
                                   ((263,
                                     Effect
                                       ([
-                                        NonTermination
+                                        Type
+                                          (NonTermination)
                                       ],
                                         .)),
                                     Variable
@@ -5925,14 +6527,19 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         andb),
                                     [
                                       Apply
                                         ((263,
                                           Effect
                                             ([
-                                              NonTermination
+                                              Type
+                                                (NonTermination)
                                             ],
                                               .)),
                                           Apply
@@ -5944,7 +6551,8 @@ Value
                                                     ->
                                                     .
                                                       -[
-                                                        NonTermination
+                                                        Type
+                                                          (NonTermination)
                                                       ]->
                                                       .)),
                                               Variable
@@ -5958,7 +6566,8 @@ Value
                                                           ->
                                                           .
                                                             -[
-                                                              NonTermination
+                                                              Type
+                                                                (NonTermination)
                                                             ]->
                                                             .)),
                                                   subset_rec),
@@ -6019,7 +6628,8 @@ Value
                                         ((263,
                                           Effect
                                             ([
-                                              NonTermination
+                                              Type
+                                                (NonTermination)
                                             ],
                                               .)),
                                           Apply
@@ -6031,7 +6641,8 @@ Value
                                                     ->
                                                     .
                                                       -[
-                                                        NonTermination
+                                                        Type
+                                                          (NonTermination)
                                                       ]->
                                                       .)),
                                               Variable
@@ -6045,7 +6656,8 @@ Value
                                                           ->
                                                           .
                                                             -[
-                                                              NonTermination
+                                                              Type
+                                                                (NonTermination)
                                                             ]->
                                                             .)),
                                                   subset_rec),
@@ -6079,7 +6691,8 @@ Value
                                   ((265,
                                     Effect
                                       ([
-                                        NonTermination
+                                        Type
+                                          (NonTermination)
                                       ],
                                         .)),
                                     Variable
@@ -6087,14 +6700,19 @@ Value
                                         Effect
                                           ([
                                           ],
-                                            .)),
+                                            .
+                                              ->
+                                              .
+                                                ->
+                                                .)),
                                         andb),
                                     [
                                       Apply
                                         ((265,
                                           Effect
                                             ([
-                                              NonTermination
+                                              Type
+                                                (NonTermination)
                                             ],
                                               .)),
                                           Apply
@@ -6106,7 +6724,8 @@ Value
                                                     ->
                                                     .
                                                       -[
-                                                        NonTermination
+                                                        Type
+                                                          (NonTermination)
                                                       ]->
                                                       .)),
                                               Variable
@@ -6120,7 +6739,8 @@ Value
                                                           ->
                                                           .
                                                             -[
-                                                              NonTermination
+                                                              Type
+                                                                (NonTermination)
                                                             ]->
                                                             .)),
                                                   subset_rec),
@@ -6181,7 +6801,8 @@ Value
                                         ((265,
                                           Effect
                                             ([
-                                              NonTermination
+                                              Type
+                                                (NonTermination)
                                             ],
                                               .)),
                                           Apply
@@ -6193,7 +6814,8 @@ Value
                                                     ->
                                                     .
                                                       -[
-                                                        NonTermination
+                                                        Type
+                                                          (NonTermination)
                                                       ]->
                                                       .)),
                                               Variable
@@ -6207,7 +6829,8 @@ Value
                                                           ->
                                                           .
                                                             -[
-                                                              NonTermination
+                                                              Type
+                                                                (NonTermination)
                                                             ]->
                                                             .)),
                                                   subset_rec),
@@ -6245,15 +6868,18 @@ Value
 Value
   (non_rec, @.,
     [
-      ((subset, [ ], [ (s1, Type (t)); (s2, Type (t)) ], Type (bool)),
+      ((subset, [ ], [ (s1, Type (t)); (s2, Type (t)) ],
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (bool))),
         Apply
-          ((?, Effect ([ Counter; NonTermination ], .)),
+          ((?, Effect ([ Type (Counter); Type (NonTermination) ], .)),
             Variable
-              ((?, Effect ([ ], . -> . -> . -[ NonTermination ]-> .)),
+              ((?,
+                Effect
+                  ([ ], . -> . -> . -[ Type (NonTermination) ]-> .)),
                 subset_rec),
             [
               Apply
-                ((?, Effect ([ Counter ], .)),
+                ((?, Effect ([ Type (Counter) ], .)),
                   Variable
                     ((?,
                       Effect
@@ -6261,7 +6887,8 @@ Value
                         ],
                           .
                             -[
-                              Counter
+                              Type
+                                (Counter)
                             ]->
                             .)),
                       read_counter),
@@ -6314,7 +6941,9 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .)),
                               f);
                           Variable
                             ((269,
@@ -6341,7 +6970,9 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .)),
                                 f),
                             [
                               Variable
@@ -6375,7 +7006,9 @@ Value
                                   Effect
                                     ([
                                     ],
-                                      .)),
+                                      .
+                                        ->
+                                        .)),
                                   f);
                               Variable
                                 ((269,
@@ -6421,7 +7054,11 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .
+                                  ->
+                                  .)),
                           f);
                       Variable
                         ((275,
@@ -6441,7 +7078,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               f),
                           [
                             Variable
@@ -6476,7 +7117,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       f);
                                   Variable
                                     ((275,
@@ -6519,7 +7164,11 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .
+                                ->
+                                .)),
                         andb),
                     [
                       Apply
@@ -6533,7 +7182,9 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .)),
                               p),
                           [
                             Variable
@@ -6555,7 +7206,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               andb),
                           [
                             Apply
@@ -6581,7 +7236,9 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .)),
                                       p);
                                   Variable
                                     ((280,
@@ -6614,7 +7271,9 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .)),
                                       p);
                                   Variable
                                     ((280,
@@ -6650,7 +7309,11 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .
+                                ->
+                                .)),
                         orb),
                     [
                       Apply
@@ -6664,7 +7327,9 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .)),
                               p),
                           [
                             Variable
@@ -6686,7 +7351,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               orb),
                           [
                             Apply
@@ -6712,7 +7381,9 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .)),
                                       p);
                                   Variable
                                     ((285,
@@ -6745,7 +7416,9 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .)),
                                       p);
                                   Variable
                                     ((285,
@@ -6765,15 +7438,21 @@ Value
   (rec, @coq_rec,
     [
       ((filter, [ ], [ (p, (Type (elt) -> Type (bool))); (x, Type (t)) ],
-        Type (t)),
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Not_found)
+          ], Type (t))),
         Match
           ((?,
             Effect
               ([
-                Counter;
-                NonTermination;
-                OCaml.Invalid_argument;
-                OCaml.Not_found
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Invalid_argument);
+                Type (OCaml.Not_found)
               ], .)), Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (Empty),
@@ -6785,10 +7464,14 @@ Value
                   (292,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .))
                   l' =
@@ -6796,10 +7479,14 @@ Value
                     ((292,
                       Effect
                         ([
-                          Counter;
-                          NonTermination;
-                          OCaml.Invalid_argument;
-                          OCaml.Not_found
+                          Type
+                            (Counter);
+                          Type
+                            (NonTermination);
+                          Type
+                            (OCaml.Invalid_argument);
+                          Type
+                            (OCaml.Not_found)
                         ],
                           .)),
                       Variable
@@ -6811,10 +7498,14 @@ Value
                                 ->
                                 .
                                   -[
-                                    Counter;
-                                    NonTermination;
-                                    OCaml.Invalid_argument;
-                                    OCaml.Not_found
+                                    Type
+                                      (Counter);
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Invalid_argument);
+                                    Type
+                                      (OCaml.Not_found)
                                   ]->
                                   .)),
                           filter),
@@ -6824,7 +7515,9 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .)),
                             p);
                         Variable
                           ((292,
@@ -6839,10 +7532,14 @@ Value
                   (293,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .))
                   pv =
@@ -6857,7 +7554,9 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .)),
                           p),
                       [
                         Variable
@@ -6873,10 +7572,14 @@ Value
                   (294,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .))
                   r' =
@@ -6884,10 +7587,14 @@ Value
                     ((294,
                       Effect
                         ([
-                          Counter;
-                          NonTermination;
-                          OCaml.Invalid_argument;
-                          OCaml.Not_found
+                          Type
+                            (Counter);
+                          Type
+                            (NonTermination);
+                          Type
+                            (OCaml.Invalid_argument);
+                          Type
+                            (OCaml.Not_found)
                         ],
                           .)),
                       Variable
@@ -6899,10 +7606,14 @@ Value
                                 ->
                                 .
                                   -[
-                                    Counter;
-                                    NonTermination;
-                                    OCaml.Invalid_argument;
-                                    OCaml.Not_found
+                                    Type
+                                      (Counter);
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Invalid_argument);
+                                    Type
+                                      (OCaml.Not_found)
                                   ]->
                                   .)),
                           filter),
@@ -6912,7 +7623,9 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .)),
                             p);
                         Variable
                           ((294,
@@ -6927,10 +7640,14 @@ Value
                   ((295,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Variable
@@ -6944,9 +7661,12 @@ Value
                       ((295,
                         Effect
                           ([
-                            Counter;
-                            NonTermination;
-                            OCaml.Invalid_argument
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination);
+                            Type
+                              (OCaml.Invalid_argument)
                           ],
                             .)),
                         Variable
@@ -6960,9 +7680,12 @@ Value
                                     ->
                                     .
                                       -[
-                                        Counter;
-                                        NonTermination;
-                                        OCaml.Invalid_argument
+                                        Type
+                                          (Counter);
+                                        Type
+                                          (NonTermination);
+                                        Type
+                                          (OCaml.Invalid_argument)
                                       ]->
                                       .)),
                             join),
@@ -6993,10 +7716,14 @@ Value
                       ((295,
                         Effect
                           ([
-                            Counter;
-                            NonTermination;
-                            OCaml.Invalid_argument;
-                            OCaml.Not_found
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination);
+                            Type
+                              (OCaml.Invalid_argument);
+                            Type
+                              (OCaml.Not_found)
                           ],
                             .)),
                         Variable
@@ -7008,10 +7735,14 @@ Value
                                   ->
                                   .
                                     -[
-                                      Counter;
-                                      NonTermination;
-                                      OCaml.Invalid_argument;
-                                      OCaml.Not_found
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Invalid_argument);
+                                      Type
+                                        (OCaml.Not_found)
                                     ]->
                                     .)),
                             concat),
@@ -7039,15 +7770,21 @@ Value
   (rec, @coq_rec,
     [
       ((partition, [ ], [ (p, (Type (elt) -> Type (bool))); (x, Type (t)) ],
-        (Type (t) * Type (t))),
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Not_found)
+          ], (Type (t) * Type (t)))),
         Match
           ((?,
             Effect
               ([
-                Counter;
-                NonTermination;
-                OCaml.Invalid_argument;
-                OCaml.Not_found
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Invalid_argument);
+                Type (OCaml.Not_found)
               ], .)), Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (Empty),
@@ -7072,20 +7809,28 @@ Value
                   ((302,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Invalid_argument;
-                        OCaml.Not_found
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Invalid_argument);
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Apply
                       ((302,
                         Effect
                           ([
-                            Counter;
-                            NonTermination;
-                            OCaml.Invalid_argument;
-                            OCaml.Not_found
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination);
+                            Type
+                              (OCaml.Invalid_argument);
+                            Type
+                              (OCaml.Not_found)
                           ],
                             .)),
                         Variable
@@ -7097,10 +7842,14 @@ Value
                                   ->
                                   .
                                     -[
-                                      Counter;
-                                      NonTermination;
-                                      OCaml.Invalid_argument;
-                                      OCaml.Not_found
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Invalid_argument);
+                                      Type
+                                        (OCaml.Not_found)
                                     ]->
                                     .)),
                             partition),
@@ -7110,7 +7859,9 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .)),
                               p);
                           Variable
                             ((302,
@@ -7128,10 +7879,14 @@ Value
                           (303,
                             Effect
                               ([
-                                Counter;
-                                NonTermination;
-                                OCaml.Invalid_argument;
-                                OCaml.Not_found
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Invalid_argument);
+                                Type
+                                  (OCaml.Not_found)
                               ],
                                 .))
                           pv
@@ -7147,7 +7902,9 @@ Value
                                   Effect
                                     ([
                                     ],
-                                      .)),
+                                      .
+                                        ->
+                                        .)),
                                   p),
                               [
                                 Variable
@@ -7163,20 +7920,28 @@ Value
                           ((304,
                             Effect
                               ([
-                                Counter;
-                                NonTermination;
-                                OCaml.Invalid_argument;
-                                OCaml.Not_found
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Invalid_argument);
+                                Type
+                                  (OCaml.Not_found)
                               ],
                                 .)),
                             Apply
                               ((304,
                                 Effect
                                   ([
-                                    Counter;
-                                    NonTermination;
-                                    OCaml.Invalid_argument;
-                                    OCaml.Not_found
+                                    Type
+                                      (Counter);
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Invalid_argument);
+                                    Type
+                                      (OCaml.Not_found)
                                   ],
                                     .)),
                                 Variable
@@ -7188,10 +7953,14 @@ Value
                                           ->
                                           .
                                             -[
-                                              Counter;
-                                              NonTermination;
-                                              OCaml.Invalid_argument;
-                                              OCaml.Not_found
+                                              Type
+                                                (Counter);
+                                              Type
+                                                (NonTermination);
+                                              Type
+                                                (OCaml.Invalid_argument);
+                                              Type
+                                                (OCaml.Not_found)
                                             ]->
                                             .)),
                                     partition),
@@ -7201,7 +7970,9 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .)),
                                       p);
                                   Variable
                                     ((304,
@@ -7219,10 +7990,14 @@ Value
                                   ((305,
                                     Effect
                                       ([
-                                        Counter;
-                                        NonTermination;
-                                        OCaml.Invalid_argument;
-                                        OCaml.Not_found
+                                        Type
+                                          (Counter);
+                                        Type
+                                          (NonTermination);
+                                        Type
+                                          (OCaml.Invalid_argument);
+                                        Type
+                                          (OCaml.Not_found)
                                       ],
                                         .)),
                                     Variable
@@ -7236,19 +8011,26 @@ Value
                                       ((306,
                                         Effect
                                           ([
-                                            Counter;
-                                            NonTermination;
-                                            OCaml.Invalid_argument;
-                                            OCaml.Not_found
+                                            Type
+                                              (Counter);
+                                            Type
+                                              (NonTermination);
+                                            Type
+                                              (OCaml.Invalid_argument);
+                                            Type
+                                              (OCaml.Not_found)
                                           ],
                                             .)),
                                         Apply
                                           ((306,
                                             Effect
                                               ([
-                                                Counter;
-                                                NonTermination;
-                                                OCaml.Invalid_argument
+                                                Type
+                                                  (Counter);
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Invalid_argument)
                                               ],
                                                 .)),
                                             Variable
@@ -7262,9 +8044,12 @@ Value
                                                         ->
                                                         .
                                                           -[
-                                                            Counter;
-                                                            NonTermination;
-                                                            OCaml.Invalid_argument
+                                                            Type
+                                                              (Counter);
+                                                            Type
+                                                              (NonTermination);
+                                                            Type
+                                                              (OCaml.Invalid_argument)
                                                           ]->
                                                           .)),
                                                 join),
@@ -7295,10 +8080,14 @@ Value
                                           ((306,
                                             Effect
                                               ([
-                                                Counter;
-                                                NonTermination;
-                                                OCaml.Invalid_argument;
-                                                OCaml.Not_found
+                                                Type
+                                                  (Counter);
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Invalid_argument);
+                                                Type
+                                                  (OCaml.Not_found)
                                               ],
                                                 .)),
                                             Variable
@@ -7310,10 +8099,14 @@ Value
                                                       ->
                                                       .
                                                         -[
-                                                          Counter;
-                                                          NonTermination;
-                                                          OCaml.Invalid_argument;
-                                                          OCaml.Not_found
+                                                          Type
+                                                            (Counter);
+                                                          Type
+                                                            (NonTermination);
+                                                          Type
+                                                            (OCaml.Invalid_argument);
+                                                          Type
+                                                            (OCaml.Not_found)
                                                         ]->
                                                         .)),
                                                 concat),
@@ -7337,20 +8130,28 @@ Value
                                       ((307,
                                         Effect
                                           ([
-                                            Counter;
-                                            NonTermination;
-                                            OCaml.Invalid_argument;
-                                            OCaml.Not_found
+                                            Type
+                                              (Counter);
+                                            Type
+                                              (NonTermination);
+                                            Type
+                                              (OCaml.Invalid_argument);
+                                            Type
+                                              (OCaml.Not_found)
                                           ],
                                             .)),
                                         Apply
                                           ((307,
                                             Effect
                                               ([
-                                                Counter;
-                                                NonTermination;
-                                                OCaml.Invalid_argument;
-                                                OCaml.Not_found
+                                                Type
+                                                  (Counter);
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Invalid_argument);
+                                                Type
+                                                  (OCaml.Not_found)
                                               ],
                                                 .)),
                                             Variable
@@ -7362,10 +8163,14 @@ Value
                                                       ->
                                                       .
                                                         -[
-                                                          Counter;
-                                                          NonTermination;
-                                                          OCaml.Invalid_argument;
-                                                          OCaml.Not_found
+                                                          Type
+                                                            (Counter);
+                                                          Type
+                                                            (NonTermination);
+                                                          Type
+                                                            (OCaml.Invalid_argument);
+                                                          Type
+                                                            (OCaml.Not_found)
                                                         ]->
                                                         .)),
                                                 concat),
@@ -7389,9 +8194,12 @@ Value
                                           ((307,
                                             Effect
                                               ([
-                                                Counter;
-                                                NonTermination;
-                                                OCaml.Invalid_argument
+                                                Type
+                                                  (Counter);
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Invalid_argument)
                                               ],
                                                 .)),
                                             Variable
@@ -7405,9 +8213,12 @@ Value
                                                         ->
                                                         .
                                                           -[
-                                                            Counter;
-                                                            NonTermination;
-                                                            OCaml.Invalid_argument
+                                                            Type
+                                                              (Counter);
+                                                            Type
+                                                              (NonTermination);
+                                                            Type
+                                                              (OCaml.Invalid_argument)
                                                           ]->
                                                           .)),
                                                 join),
@@ -7459,7 +8270,11 @@ Value
                         Effect
                           ([
                           ],
-                            .)),
+                            .
+                              ->
+                              .
+                                ->
+                                .)),
                         Z.add),
                     [
                       Apply
@@ -7473,7 +8288,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               Z.add),
                           [
                             Apply
@@ -7638,17 +8457,20 @@ Value
 Value
   (non_rec, @.,
     [
-      ((choose, [ ], [ ], (Type (t) -> Type (elt))),
-        Variable ((323, Effect ([ ], . -[ OCaml.Not_found ]-> .)), min_elt))
+      ((choose, [ ], [ ],
+        (Type (t) -> Monad ([ Type (OCaml.Not_found) ], Type (elt)))),
+        Variable
+          ((323, Effect ([ ], . -[ Type (OCaml.Not_found) ]-> .)), min_elt))
     ])
 
 325
 Value
   (rec, @coq_rec,
     [
-      ((find, [ ], [ (x, Type (Ord.t)); (x_1, Type (t)) ], Type (elt)),
+      ((find, [ ], [ (x, Type (Ord.t)); (x_1, Type (t)) ],
+        Monad ([ Type (OCaml.Not_found) ], Type (elt))),
         Match
-          ((?, Effect ([ OCaml.Not_found ], .)),
+          ((?, Effect ([ Type (OCaml.Not_found) ], .)),
             Variable ((?, Effect ([ ], .)), x_1),
             [
               (Constructor (Empty),
@@ -7656,7 +8478,8 @@ Value
                   ((326,
                     Effect
                       ([
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Variable
@@ -7666,7 +8489,8 @@ Value
                           ],
                             .
                               -[
-                                OCaml.Not_found
+                                Type
+                                  (OCaml.Not_found)
                               ]->
                               .)),
                         OCaml.raise_Not_found),
@@ -7683,7 +8507,8 @@ Value
                   (328,
                     Effect
                       ([
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .))
                   c =
@@ -7700,7 +8525,9 @@ Value
                             ],
                               .
                                 ->
-                                .)),
+                                .
+                                  ->
+                                  .)),
                           Ord.compare),
                       [
                         Variable
@@ -7723,7 +8550,8 @@ Value
                   ((329,
                     Effect
                       ([
-                        OCaml.Not_found
+                        Type
+                          (OCaml.Not_found)
                       ],
                         .)),
                     Apply
@@ -7737,7 +8565,11 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .
+                                    ->
+                                    .)),
                             equiv_decb),
                         [
                           Variable
@@ -7766,7 +8598,8 @@ Value
                       ((330,
                         Effect
                           ([
-                            OCaml.Not_found
+                            Type
+                              (OCaml.Not_found)
                           ],
                             .)),
                         Variable
@@ -7778,7 +8611,8 @@ Value
                                   ->
                                   .
                                     -[
-                                      OCaml.Not_found
+                                      Type
+                                        (OCaml.Not_found)
                                     ]->
                                     .)),
                             find),
@@ -7807,7 +8641,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       OCaml.Pervasives.lt),
                                   [
                                     Variable
@@ -7847,10 +8685,21 @@ Value
 Value
   (non_rec, @.,
     [
-      ((of_sorted_list, [ ], [ (l, Type (list, Type (elt))) ], Type (t)),
+      ((of_sorted_list, [ ], [ (l, Type (list, Type (elt))) ],
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Assert_failure)
+          ], Type (t))),
         LetFun
           (334,
-            Effect ([ Counter; NonTermination; OCaml.Assert_failure ], .))
+            Effect
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Assert_failure)
+              ], .))
           (rec, @.,
             [
               ((sub_rec, [ ],
@@ -7862,13 +8711,29 @@ Value
                       (list,
                         Type
                           (elt)))
-                ], (Type (t) * Type (list, Type (elt)))),
+                ],
+                Monad
+                  ([
+                    Type
+                      (NonTermination);
+                    Type
+                      (OCaml.Assert_failure)
+                  ],
+                    (Type
+                      (t)
+                      *
+                      Type
+                        (list,
+                          Type
+                            (elt))))),
                 Match
                   ((?,
                     Effect
                       ([
-                        NonTermination;
-                        OCaml.Assert_failure
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Assert_failure)
                       ],
                         .)),
                     Variable
@@ -7885,7 +8750,8 @@ Value
                           ((?,
                             Effect
                               ([
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Variable
@@ -7895,7 +8761,8 @@ Value
                                   ],
                                     .
                                       -[
-                                        NonTermination
+                                        Type
+                                          (NonTermination)
                                       ]->
                                       .)),
                                 not_terminated),
@@ -7914,8 +8781,10 @@ Value
                           ((335,
                             Effect
                               ([
-                                NonTermination;
-                                OCaml.Assert_failure
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Assert_failure)
                               ],
                                 .)),
                             Tuple
@@ -8224,8 +9093,10 @@ Value
                                   (341,
                                     Effect
                                       ([
-                                        NonTermination;
-                                        OCaml.Assert_failure
+                                        Type
+                                          (NonTermination);
+                                        Type
+                                          (OCaml.Assert_failure)
                                       ],
                                         .))
                                   nl
@@ -8241,7 +9112,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           Z.div),
                                       [
                                         Variable
@@ -8264,16 +9139,20 @@ Value
                                   ((342,
                                     Effect
                                       ([
-                                        NonTermination;
-                                        OCaml.Assert_failure
+                                        Type
+                                          (NonTermination);
+                                        Type
+                                          (OCaml.Assert_failure)
                                       ],
                                         .)),
                                     Apply
                                       ((342,
                                         Effect
                                           ([
-                                            NonTermination;
-                                            OCaml.Assert_failure
+                                            Type
+                                              (NonTermination);
+                                            Type
+                                              (OCaml.Assert_failure)
                                           ],
                                             .)),
                                         Apply
@@ -8285,8 +9164,10 @@ Value
                                                   ->
                                                   .
                                                     -[
-                                                      NonTermination;
-                                                      OCaml.Assert_failure
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Assert_failure)
                                                     ]->
                                                     .)),
                                             Variable
@@ -8300,8 +9181,10 @@ Value
                                                         ->
                                                         .
                                                           -[
-                                                            NonTermination;
-                                                            OCaml.Assert_failure
+                                                            Type
+                                                              (NonTermination);
+                                                            Type
+                                                              (OCaml.Assert_failure)
                                                           ]->
                                                           .)),
                                                 sub_rec),
@@ -8338,8 +9221,10 @@ Value
                                           ((343,
                                             Effect
                                               ([
-                                                NonTermination;
-                                                OCaml.Assert_failure
+                                                Type
+                                                  (NonTermination);
+                                                Type
+                                                  (OCaml.Assert_failure)
                                               ],
                                                 .)),
                                             Variable
@@ -8356,7 +9241,8 @@ Value
                                                   ((344,
                                                     Effect
                                                       ([
-                                                        OCaml.Assert_failure
+                                                        Type
+                                                          (OCaml.Assert_failure)
                                                       ],
                                                         .)),
                                                     Variable
@@ -8366,7 +9252,8 @@ Value
                                                           ],
                                                             .
                                                               -[
-                                                                OCaml.Assert_failure
+                                                                Type
+                                                                  (OCaml.Assert_failure)
                                                               ]->
                                                               .)),
                                                         OCaml.assert),
@@ -8387,16 +9274,20 @@ Value
                                                   ((346,
                                                     Effect
                                                       ([
-                                                        NonTermination;
-                                                        OCaml.Assert_failure
+                                                        Type
+                                                          (NonTermination);
+                                                        Type
+                                                          (OCaml.Assert_failure)
                                                       ],
                                                         .)),
                                                     Apply
                                                       ((346,
                                                         Effect
                                                           ([
-                                                            NonTermination;
-                                                            OCaml.Assert_failure
+                                                            Type
+                                                              (NonTermination);
+                                                            Type
+                                                              (OCaml.Assert_failure)
                                                           ],
                                                             .)),
                                                         Apply
@@ -8408,8 +9299,10 @@ Value
                                                                   ->
                                                                   .
                                                                     -[
-                                                                      NonTermination;
-                                                                      OCaml.Assert_failure
+                                                                      Type
+                                                                        (NonTermination);
+                                                                      Type
+                                                                        (OCaml.Assert_failure)
                                                                     ]->
                                                                     .)),
                                                             Variable
@@ -8423,8 +9316,10 @@ Value
                                                                         ->
                                                                         .
                                                                           -[
-                                                                            NonTermination;
-                                                                            OCaml.Assert_failure
+                                                                            Type
+                                                                              (NonTermination);
+                                                                            Type
+                                                                              (OCaml.Assert_failure)
                                                                           ]->
                                                                           .)),
                                                                 sub_rec),
@@ -8449,7 +9344,11 @@ Value
                                                                   Effect
                                                                     ([
                                                                     ],
-                                                                      .)),
+                                                                      .
+                                                                        ->
+                                                                        .
+                                                                          ->
+                                                                          .)),
                                                                   Z.sub),
                                                               [
                                                                 Apply
@@ -8463,7 +9362,11 @@ Value
                                                                         Effect
                                                                           ([
                                                                           ],
-                                                                            .)),
+                                                                            .
+                                                                              ->
+                                                                              .
+                                                                                ->
+                                                                                .)),
                                                                         Z.sub),
                                                                     [
                                                                       Variable
@@ -8564,7 +9467,12 @@ Value
             ]) in
         LetFun
           (334,
-            Effect ([ Counter; NonTermination; OCaml.Assert_failure ], .))
+            Effect
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Assert_failure)
+              ], .))
           (non_rec, @.,
             [
               ((sub, [ ],
@@ -8575,14 +9483,33 @@ Value
                       (list,
                         Type
                           (elt)))
-                ], (Type (t) * Type (list, Type (elt)))),
+                ],
+                Monad
+                  ([
+                    Type
+                      (Counter);
+                    Type
+                      (NonTermination);
+                    Type
+                      (OCaml.Assert_failure)
+                  ],
+                    (Type
+                      (t)
+                      *
+                      Type
+                        (list,
+                          Type
+                            (elt))))),
                 Apply
                   ((?,
                     Effect
                       ([
-                        Counter;
-                        NonTermination;
-                        OCaml.Assert_failure
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination);
+                        Type
+                          (OCaml.Assert_failure)
                       ],
                         .)),
                     Variable
@@ -8596,8 +9523,10 @@ Value
                                 ->
                                 .
                                   -[
-                                    NonTermination;
-                                    OCaml.Assert_failure
+                                    Type
+                                      (NonTermination);
+                                    Type
+                                      (OCaml.Assert_failure)
                                   ]->
                                   .)),
                         sub_rec),
@@ -8606,7 +9535,8 @@ Value
                         ((?,
                           Effect
                             ([
-                              Counter
+                              Type
+                                (Counter)
                             ],
                               .)),
                           Variable
@@ -8616,7 +9546,8 @@ Value
                                 ],
                                   .
                                     -[
-                                      Counter
+                                      Type
+                                        (Counter)
                                     ]->
                                     .)),
                               read_counter),
@@ -8646,16 +9577,23 @@ Value
             ]) in
         Apply
           ((349,
-            Effect ([ Counter; NonTermination; OCaml.Assert_failure ], .)),
-            Variable ((349, Effect ([ ], .)), fst),
+            Effect
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Assert_failure)
+              ], .)), Variable ((349, Effect ([ ], . -> .)), fst),
             [
               Apply
                 ((349,
                   Effect
                     ([
-                      Counter;
-                      NonTermination;
-                      OCaml.Assert_failure
+                      Type
+                        (Counter);
+                      Type
+                        (NonTermination);
+                      Type
+                        (OCaml.Assert_failure)
                     ], .)),
                   Variable
                     ((349,
@@ -8666,9 +9604,12 @@ Value
                             ->
                             .
                               -[
-                                Counter;
-                                NonTermination;
-                                OCaml.Assert_failure
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination);
+                                Type
+                                  (OCaml.Assert_failure)
                               ]->
                               .)),
                       sub),
@@ -8684,7 +9625,9 @@ Value
                             Effect
                               ([
                               ],
-                                .)),
+                                .
+                                  ->
+                                  .)),
                             OCaml.List.length),
                         [
                           Variable

--- a/tests/ex34.monadise
+++ b/tests/ex34.monadise
@@ -89,7 +89,7 @@ Value
   (non_rec, @.,
     [
       ((bal, [ ], [ (l, Type (t)); (v, Type (elt)); (r, Type (t)) ],
-        Monad ([ OCaml.Invalid_argument ], Type (t))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t))),
         LetVar ? hl =
           Match
             (34, Variable (34, l),
@@ -475,7 +475,7 @@ Value
   (rec, @coq_rec,
     [
       ((add, [ ], [ (x, Type (elt)); (x_1, Type (t)) ],
-        Monad ([ OCaml.Invalid_argument ], Type (t))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t))),
         Match
           (?, Variable (?, x_1),
             [
@@ -632,7 +632,7 @@ Value
   (rec, @coq_rec,
     [
       ((add_min_element, [ ], [ (v, Type (elt)); (x, Type (t)) ],
-        Monad ([ OCaml.Invalid_argument ], Type (t))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t))),
         Match
           (?, Variable (?, x),
             [
@@ -691,7 +691,7 @@ Value
   (rec, @coq_rec,
     [
       ((add_max_element, [ ], [ (v, Type (elt)); (x, Type (t)) ],
-        Monad ([ OCaml.Invalid_argument ], Type (t))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t))),
         Match
           (?, Variable (?, x),
             [
@@ -755,7 +755,10 @@ Value
           (l, Type (t));
           (v, Type (elt));
           (r, Type (t))
-        ], Monad ([ NonTermination; OCaml.Invalid_argument ], Type (t))),
+        ],
+        Monad
+          ([ Type (NonTermination); Type (OCaml.Invalid_argument) ],
+            Type (t))),
         Match
           (?, Variable (?, counter),
             [
@@ -763,11 +766,14 @@ Value
                 Lift
                   (?,
                     [
-                      NonTermination
+                      Type
+                        (NonTermination)
                     ],
                     [
-                      NonTermination;
-                      OCaml.Invalid_argument
+                      Type
+                        (NonTermination);
+                      Type
+                        (OCaml.Invalid_argument)
                     ],
                     Apply
                       (?,
@@ -797,11 +803,14 @@ Value
                         Lift
                           (?,
                             [
-                              OCaml.Invalid_argument
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                             [
-                              NonTermination;
-                              OCaml.Invalid_argument
+                              Type
+                                (NonTermination);
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                             Apply
                               (99,
@@ -823,11 +832,14 @@ Value
                         Lift
                           (?,
                             [
-                              OCaml.Invalid_argument
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                             [
-                              NonTermination;
-                              OCaml.Invalid_argument
+                              Type
+                                (NonTermination);
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                             Apply
                               (100,
@@ -910,11 +922,14 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ],
                                     [
-                                      NonTermination;
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ],
                                     Apply
                                       (102,
@@ -987,11 +1002,14 @@ Value
                                     Lift
                                       (?,
                                         [
-                                          OCaml.Invalid_argument
+                                          Type
+                                            (OCaml.Invalid_argument)
                                         ],
                                         [
-                                          NonTermination;
-                                          OCaml.Invalid_argument
+                                          Type
+                                            (NonTermination);
+                                          Type
+                                            (OCaml.Invalid_argument)
                                         ],
                                         Apply
                                           (103,
@@ -1036,17 +1054,34 @@ Value
   (non_rec, @.,
     [
       ((join, [ ], [ (l, Type (t)); (v, Type (elt)); (r, Type (t)) ],
-        Monad ([ Counter; NonTermination; OCaml.Invalid_argument ], Type (t))),
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument)
+          ], Type (t))),
         Bind
           (?,
             Lift
-              (?, [ Counter ],
-                [ Counter; NonTermination; OCaml.Invalid_argument ],
+              (?, [ Type (Counter) ],
+                [
+                  Type (Counter);
+                  Type (NonTermination);
+                  Type (OCaml.Invalid_argument)
+                ],
                 Apply (?, Variable (?, read_counter), [ Tuple (?) ])),
             Some x,
             Lift
-              (?, [ NonTermination; OCaml.Invalid_argument ],
-                [ Counter; NonTermination; OCaml.Invalid_argument ],
+              (?,
+                [
+                  Type (NonTermination);
+                  Type (OCaml.Invalid_argument)
+                ],
+                [
+                  Type (Counter);
+                  Type (NonTermination);
+                  Type (OCaml.Invalid_argument)
+                ],
                 Apply
                   (?, Variable (?, join_rec),
                     [
@@ -1061,7 +1096,8 @@ Value
 Value
   (rec, @coq_rec,
     [
-      ((min_elt, [ ], [ (x, Type (t)) ], Monad ([ OCaml.Not_found ], Type (elt))),
+      ((min_elt, [ ], [ (x, Type (t)) ],
+        Monad ([ Type (OCaml.Not_found) ], Type (elt))),
         Match
           (?, Variable (?, x),
             [
@@ -1095,7 +1131,8 @@ Value
 Value
   (rec, @coq_rec,
     [
-      ((max_elt, [ ], [ (x, Type (t)) ], Monad ([ OCaml.Not_found ], Type (elt))),
+      ((max_elt, [ ], [ (x, Type (t)) ],
+        Monad ([ Type (OCaml.Not_found) ], Type (elt))),
         Match
           (?, Variable (?, x),
             [
@@ -1130,7 +1167,7 @@ Value
   (rec, @coq_rec,
     [
       ((remove_min_elt, [ ], [ (x, Type (t)) ],
-        Monad ([ OCaml.Invalid_argument ], Type (t))),
+        Monad ([ Type (OCaml.Invalid_argument) ], Type (t))),
         Match
           (?, Variable (?, x),
             [
@@ -1186,7 +1223,9 @@ Value
   (non_rec, @.,
     [
       ((merge, [ ], [ (t1, Type (t)); (t2, Type (t)) ],
-        Monad ([ OCaml.Invalid_argument; OCaml.Not_found ], Type (t))),
+        Monad
+          ([ Type (OCaml.Invalid_argument); Type (OCaml.Not_found) ],
+            Type (t))),
         Match
           (133, Tuple (133, Variable (133, t1), Variable (133, t2)),
             [
@@ -1200,11 +1239,14 @@ Value
                     Lift
                       (?,
                         [
-                          OCaml.Not_found
+                          Type
+                            (OCaml.Not_found)
                         ],
                         [
-                          OCaml.Invalid_argument;
-                          OCaml.Not_found
+                          Type
+                            (OCaml.Invalid_argument);
+                          Type
+                            (OCaml.Not_found)
                         ],
                         Apply
                           (136,
@@ -1223,11 +1265,14 @@ Value
                         Lift
                           (?,
                             [
-                              OCaml.Invalid_argument
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                             [
-                              OCaml.Invalid_argument;
-                              OCaml.Not_found
+                              Type
+                                (OCaml.Invalid_argument);
+                              Type
+                                (OCaml.Not_found)
                             ],
                             Apply
                               (136,
@@ -1244,11 +1289,14 @@ Value
                         Lift
                           (?,
                             [
-                              OCaml.Invalid_argument
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                             [
-                              OCaml.Invalid_argument;
-                              OCaml.Not_found
+                              Type
+                                (OCaml.Invalid_argument);
+                              Type
+                                (OCaml.Not_found)
                             ],
                             Apply
                               (136,
@@ -1276,10 +1324,10 @@ Value
       ((concat, [ ], [ (t1, Type (t)); (t2, Type (t)) ],
         Monad
           ([
-            Counter;
-            NonTermination;
-            OCaml.Invalid_argument;
-            OCaml.Not_found
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Not_found)
           ], Type (t))),
         Match
           (143, Tuple (143, Variable (143, t1), Variable (143, t2)),
@@ -1294,13 +1342,18 @@ Value
                     Lift
                       (?,
                         [
-                          OCaml.Not_found
+                          Type
+                            (OCaml.Not_found)
                         ],
                         [
-                          Counter;
-                          NonTermination;
-                          OCaml.Invalid_argument;
-                          OCaml.Not_found
+                          Type
+                            (Counter);
+                          Type
+                            (NonTermination);
+                          Type
+                            (OCaml.Invalid_argument);
+                          Type
+                            (OCaml.Not_found)
                         ],
                         Apply
                           (146,
@@ -1319,13 +1372,18 @@ Value
                         Lift
                           (?,
                             [
-                              OCaml.Invalid_argument
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                             [
-                              Counter;
-                              NonTermination;
-                              OCaml.Invalid_argument;
-                              OCaml.Not_found
+                              Type
+                                (Counter);
+                              Type
+                                (NonTermination);
+                              Type
+                                (OCaml.Invalid_argument);
+                              Type
+                                (OCaml.Not_found)
                             ],
                             Apply
                               (146,
@@ -1342,15 +1400,22 @@ Value
                         Lift
                           (?,
                             [
-                              Counter;
-                              NonTermination;
-                              OCaml.Invalid_argument
+                              Type
+                                (Counter);
+                              Type
+                                (NonTermination);
+                              Type
+                                (OCaml.Invalid_argument)
                             ],
                             [
-                              Counter;
-                              NonTermination;
-                              OCaml.Invalid_argument;
-                              OCaml.Not_found
+                              Type
+                                (Counter);
+                              Type
+                                (NonTermination);
+                              Type
+                                (OCaml.Invalid_argument);
+                              Type
+                                (OCaml.Not_found)
                             ],
                             Apply
                               (146,
@@ -1377,8 +1442,11 @@ Value
     [
       ((split, [ ], [ (x, Type (Ord.t)); (x_1, Type (t)) ],
         Monad
-          ([ Counter; NonTermination; OCaml.Invalid_argument ],
-            (Type (t) * Type (bool) * Type (t)))),
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument)
+          ], (Type (t) * Type (bool) * Type (t)))),
         Match
           (?, Variable (?, x_1),
             [
@@ -1680,7 +1748,9 @@ Value
   (rec, @coq_rec,
     [
       ((remove, [ ], [ (x, Type (Ord.t)); (x_1, Type (t)) ],
-        Monad ([ OCaml.Invalid_argument; OCaml.Not_found ], Type (t))),
+        Monad
+          ([ Type (OCaml.Invalid_argument); Type (OCaml.Not_found) ],
+            Type (t))),
         Match
           (?, Variable (?, x_1),
             [
@@ -1765,11 +1835,14 @@ Value
                             Lift
                               (?,
                                 [
-                                  OCaml.Invalid_argument
+                                  Type
+                                    (OCaml.Invalid_argument)
                                 ],
                                 [
-                                  OCaml.Invalid_argument;
-                                  OCaml.Not_found
+                                  Type
+                                    (OCaml.Invalid_argument);
+                                  Type
+                                    (OCaml.Not_found)
                                 ],
                                 Apply
                                   (184,
@@ -1807,11 +1880,14 @@ Value
                             Lift
                               (?,
                                 [
-                                  OCaml.Invalid_argument
+                                  Type
+                                    (OCaml.Invalid_argument)
                                 ],
                                 [
-                                  OCaml.Invalid_argument;
-                                  OCaml.Not_found
+                                  Type
+                                    (OCaml.Invalid_argument);
+                                  Type
+                                    (OCaml.Not_found)
                                 ],
                                 Apply
                                   (184,
@@ -1838,7 +1914,12 @@ Value
     [
       ((union_rec, [ ],
         [ (counter, Type (nat)); (s1, Type (t)); (s2, Type (t)) ],
-        Monad ([ Counter; NonTermination; OCaml.Invalid_argument ], Type (t))),
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument)
+          ], Type (t))),
         Match
           (?, Variable (?, counter),
             [
@@ -1846,12 +1927,16 @@ Value
                 Lift
                   (?,
                     [
-                      NonTermination
+                      Type
+                        (NonTermination)
                     ],
                     [
-                      Counter;
-                      NonTermination;
-                      OCaml.Invalid_argument
+                      Type
+                        (Counter);
+                      Type
+                        (NonTermination);
+                      Type
+                        (OCaml.Invalid_argument)
                     ],
                     Apply
                       (?,
@@ -1938,12 +2023,16 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ],
                                     [
-                                      Counter;
-                                      NonTermination;
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ],
                                     Apply
                                       (193,
@@ -2068,12 +2157,16 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ],
                                     [
-                                      Counter;
-                                      NonTermination;
-                                      OCaml.Invalid_argument
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Invalid_argument)
                                     ],
                                     Apply
                                       (198,
@@ -2189,12 +2282,21 @@ Value
   (non_rec, @.,
     [
       ((union, [ ], [ (s1, Type (t)); (s2, Type (t)) ],
-        Monad ([ Counter; NonTermination; OCaml.Invalid_argument ], Type (t))),
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument)
+          ], Type (t))),
         Bind
           (?,
             Lift
-              (?, [ Counter ],
-                [ Counter; NonTermination; OCaml.Invalid_argument ],
+              (?, [ Type (Counter) ],
+                [
+                  Type (Counter);
+                  Type (NonTermination);
+                  Type (OCaml.Invalid_argument)
+                ],
                 Apply (?, Variable (?, read_counter), [ Tuple (?) ])),
             Some x,
             Apply
@@ -2209,10 +2311,10 @@ Value
       ((inter, [ ], [ (s1, Type (t)); (s2, Type (t)) ],
         Monad
           ([
-            Counter;
-            NonTermination;
-            OCaml.Invalid_argument;
-            OCaml.Not_found
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Not_found)
           ], Type (t))),
         Match
           (204, Tuple (204, Variable (204, s1), Variable (204, s2)),
@@ -2227,15 +2329,22 @@ Value
                     Lift
                       (?,
                         [
-                          Counter;
-                          NonTermination;
-                          OCaml.Invalid_argument
+                          Type
+                            (Counter);
+                          Type
+                            (NonTermination);
+                          Type
+                            (OCaml.Invalid_argument)
                         ],
                         [
-                          Counter;
-                          NonTermination;
-                          OCaml.Invalid_argument;
-                          OCaml.Not_found
+                          Type
+                            (Counter);
+                          Type
+                            (NonTermination);
+                          Type
+                            (OCaml.Invalid_argument);
+                          Type
+                            (OCaml.Not_found)
                         ],
                         Apply
                           (208,
@@ -2352,15 +2461,22 @@ Value
                                     Lift
                                       (?,
                                         [
-                                          Counter;
-                                          NonTermination;
-                                          OCaml.Invalid_argument
+                                          Type
+                                            (Counter);
+                                          Type
+                                            (NonTermination);
+                                          Type
+                                            (OCaml.Invalid_argument)
                                         ],
                                         [
-                                          Counter;
-                                          NonTermination;
-                                          OCaml.Invalid_argument;
-                                          OCaml.Not_found
+                                          Type
+                                            (Counter);
+                                          Type
+                                            (NonTermination);
+                                          Type
+                                            (OCaml.Invalid_argument);
+                                          Type
+                                            (OCaml.Not_found)
                                         ],
                                         Apply
                                           (212,
@@ -2389,10 +2505,10 @@ Value
       ((diff, [ ], [ (s1, Type (t)); (s2, Type (t)) ],
         Monad
           ([
-            Counter;
-            NonTermination;
-            OCaml.Invalid_argument;
-            OCaml.Not_found
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Not_found)
           ], Type (t))),
         Match
           (216, Tuple (216, Variable (216, s1), Variable (216, s2)),
@@ -2407,15 +2523,22 @@ Value
                     Lift
                       (?,
                         [
-                          Counter;
-                          NonTermination;
-                          OCaml.Invalid_argument
+                          Type
+                            (Counter);
+                          Type
+                            (NonTermination);
+                          Type
+                            (OCaml.Invalid_argument)
                         ],
                         [
-                          Counter;
-                          NonTermination;
-                          OCaml.Invalid_argument;
-                          OCaml.Not_found
+                          Type
+                            (Counter);
+                          Type
+                            (NonTermination);
+                          Type
+                            (OCaml.Invalid_argument);
+                          Type
+                            (OCaml.Not_found)
                         ],
                         Apply
                           (220,
@@ -2480,15 +2603,22 @@ Value
                                     Lift
                                       (?,
                                         [
-                                          Counter;
-                                          NonTermination;
-                                          OCaml.Invalid_argument
+                                          Type
+                                            (Counter);
+                                          Type
+                                            (NonTermination);
+                                          Type
+                                            (OCaml.Invalid_argument)
                                         ],
                                         [
-                                          Counter;
-                                          NonTermination;
-                                          OCaml.Invalid_argument;
-                                          OCaml.Not_found
+                                          Type
+                                            (Counter);
+                                          Type
+                                            (NonTermination);
+                                          Type
+                                            (OCaml.Invalid_argument);
+                                          Type
+                                            (OCaml.Not_found)
                                         ],
                                         Apply
                                           (222,
@@ -2611,7 +2741,7 @@ Value
           (counter, Type (nat));
           (e1, Type (enumeration));
           (e2, Type (enumeration))
-        ], Monad ([ NonTermination ], Type (Z))),
+        ], Monad ([ Type (NonTermination) ], Type (Z))),
         Match
           (?, Variable (?, counter),
             [
@@ -2764,15 +2894,17 @@ Value
     [
       ((compare_aux, [ ],
         [ (e1, Type (enumeration)); (e2, Type (enumeration)) ],
-        Monad ([ Counter; NonTermination ], Type (Z))),
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (Z))),
         Bind
           (?,
             Lift
-              (?, [ Counter ], [ Counter; NonTermination ],
+              (?, [ Type (Counter) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply (?, Variable (?, read_counter), [ Tuple (?) ])),
             Some x,
             Lift
-              (?, [ NonTermination ], [ Counter; NonTermination ],
+              (?, [ Type (NonTermination) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply
                   (?, Variable (?, compare_aux_rec),
                     [
@@ -2787,7 +2919,7 @@ Value
   (non_rec, @.,
     [
       ((compare, [ ], [ (s1, Type (t)); (s2, Type (t)) ],
-        Monad ([ Counter; NonTermination ], Type (Z))),
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (Z))),
         Apply
           (247, Variable (247, compare_aux),
             [
@@ -2819,7 +2951,7 @@ Value
   (non_rec, @.,
     [
       ((equal, [ ], [ (s1, Type (t)); (s2, Type (t)) ],
-        Monad ([ Counter; NonTermination ], Type (bool))),
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (bool))),
         Bind
           (?,
             Apply
@@ -2838,7 +2970,7 @@ Value
     [
       ((subset_rec, [ ],
         [ (counter, Type (nat)); (s1, Type (t)); (s2, Type (t)) ],
-        Monad ([ NonTermination ], Type (bool))),
+        Monad ([ Type (NonTermination) ], Type (bool))),
         Match
           (?, Variable (?, counter),
             [
@@ -3167,15 +3299,17 @@ Value
   (non_rec, @.,
     [
       ((subset, [ ], [ (s1, Type (t)); (s2, Type (t)) ],
-        Monad ([ Counter; NonTermination ], Type (bool))),
+        Monad ([ Type (Counter); Type (NonTermination) ], Type (bool))),
         Bind
           (?,
             Lift
-              (?, [ Counter ], [ Counter; NonTermination ],
+              (?, [ Type (Counter) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply (?, Variable (?, read_counter), [ Tuple (?) ])),
             Some x,
             Lift
-              (?, [ NonTermination ], [ Counter; NonTermination ],
+              (?, [ Type (NonTermination) ],
+                [ Type (Counter); Type (NonTermination) ],
                 Apply
                   (?, Variable (?, subset_rec),
                     [
@@ -3399,10 +3533,10 @@ Value
       ((filter, [ ], [ (p, (Type (elt) -> Type (bool))); (x, Type (t)) ],
         Monad
           ([
-            Counter;
-            NonTermination;
-            OCaml.Invalid_argument;
-            OCaml.Not_found
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Not_found)
           ], Type (t))),
         Match
           (?, Variable (?, x),
@@ -3467,15 +3601,22 @@ Value
                             Lift
                               (?,
                                 [
-                                  Counter;
-                                  NonTermination;
-                                  OCaml.Invalid_argument
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Invalid_argument)
                                 ],
                                 [
-                                  Counter;
-                                  NonTermination;
-                                  OCaml.Invalid_argument;
-                                  OCaml.Not_found
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination);
+                                  Type
+                                    (OCaml.Invalid_argument);
+                                  Type
+                                    (OCaml.Not_found)
                                 ],
                                 Apply
                                   (295,
@@ -3516,10 +3657,10 @@ Value
       ((partition, [ ], [ (p, (Type (elt) -> Type (bool))); (x, Type (t)) ],
         Monad
           ([
-            Counter;
-            NonTermination;
-            OCaml.Invalid_argument;
-            OCaml.Not_found
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Invalid_argument);
+            Type (OCaml.Not_found)
           ], (Type (t) * Type (t)))),
         Match
           (?, Variable (?, x),
@@ -3613,15 +3754,22 @@ Value
                                                 Lift
                                                   (?,
                                                     [
-                                                      Counter;
-                                                      NonTermination;
-                                                      OCaml.Invalid_argument
+                                                      Type
+                                                        (Counter);
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Invalid_argument)
                                                     ],
                                                     [
-                                                      Counter;
-                                                      NonTermination;
-                                                      OCaml.Invalid_argument;
-                                                      OCaml.Not_found
+                                                      Type
+                                                        (Counter);
+                                                      Type
+                                                        (NonTermination);
+                                                      Type
+                                                        (OCaml.Invalid_argument);
+                                                      Type
+                                                        (OCaml.Not_found)
                                                     ],
                                                     Apply
                                                       (306,
@@ -3690,15 +3838,22 @@ Value
                                                     Lift
                                                       (?,
                                                         [
-                                                          Counter;
-                                                          NonTermination;
-                                                          OCaml.Invalid_argument
+                                                          Type
+                                                            (Counter);
+                                                          Type
+                                                            (NonTermination);
+                                                          Type
+                                                            (OCaml.Invalid_argument)
                                                         ],
                                                         [
-                                                          Counter;
-                                                          NonTermination;
-                                                          OCaml.Invalid_argument;
-                                                          OCaml.Not_found
+                                                          Type
+                                                            (Counter);
+                                                          Type
+                                                            (NonTermination);
+                                                          Type
+                                                            (OCaml.Invalid_argument);
+                                                          Type
+                                                            (OCaml.Not_found)
                                                         ],
                                                         Apply
                                                           (307,
@@ -3840,7 +3995,8 @@ Value
 Value
   (non_rec, @.,
     [
-      ((choose, [ ], [ ], (Type (t) -> Monad ([ OCaml.Not_found ], Type (elt)))),
+      ((choose, [ ], [ ],
+        (Type (t) -> Monad ([ Type (OCaml.Not_found) ], Type (elt)))),
         Variable (323, min_elt))
     ])
 
@@ -3849,7 +4005,7 @@ Value
   (rec, @coq_rec,
     [
       ((find, [ ], [ (x, Type (Ord.t)); (x_1, Type (t)) ],
-        Monad ([ OCaml.Not_found ], Type (elt))),
+        Monad ([ Type (OCaml.Not_found) ], Type (elt))),
         Match
           (?, Variable (?, x_1),
             [
@@ -3938,7 +4094,12 @@ Value
   (non_rec, @.,
     [
       ((of_sorted_list, [ ], [ (l, Type (list, Type (elt))) ],
-        Monad ([ Counter; NonTermination; OCaml.Assert_failure ], Type (t))),
+        Monad
+          ([
+            Type (Counter);
+            Type (NonTermination);
+            Type (OCaml.Assert_failure)
+          ], Type (t))),
         LetFun 334
           (rec, @.,
             [
@@ -3954,8 +4115,10 @@ Value
                 ],
                 Monad
                   ([
-                    NonTermination;
-                    OCaml.Assert_failure
+                    Type
+                      (NonTermination);
+                    Type
+                      (OCaml.Assert_failure)
                   ],
                     (Type
                       (t)
@@ -3975,11 +4138,14 @@ Value
                         Lift
                           (?,
                             [
-                              NonTermination
+                              Type
+                                (NonTermination)
                             ],
                             [
-                              NonTermination;
-                              OCaml.Assert_failure
+                              Type
+                                (NonTermination);
+                              Type
+                                (OCaml.Assert_failure)
                             ],
                             Apply
                               (?,
@@ -4211,11 +4377,14 @@ Value
                                                     Lift
                                                       (?,
                                                         [
-                                                          OCaml.Assert_failure
+                                                          Type
+                                                            (OCaml.Assert_failure)
                                                         ],
                                                         [
-                                                          NonTermination;
-                                                          OCaml.Assert_failure
+                                                          Type
+                                                            (NonTermination);
+                                                          Type
+                                                            (OCaml.Assert_failure)
                                                         ],
                                                         Apply
                                                           (344,
@@ -4327,9 +4496,12 @@ Value
                 ],
                 Monad
                   ([
-                    Counter;
-                    NonTermination;
-                    OCaml.Assert_failure
+                    Type
+                      (Counter);
+                    Type
+                      (NonTermination);
+                    Type
+                      (OCaml.Assert_failure)
                   ],
                     (Type
                       (t)
@@ -4343,12 +4515,16 @@ Value
                     Lift
                       (?,
                         [
-                          Counter
+                          Type
+                            (Counter)
                         ],
                         [
-                          Counter;
-                          NonTermination;
-                          OCaml.Assert_failure
+                          Type
+                            (Counter);
+                          Type
+                            (NonTermination);
+                          Type
+                            (OCaml.Assert_failure)
                         ],
                         Apply
                           (?,
@@ -4364,13 +4540,18 @@ Value
                     Lift
                       (?,
                         [
-                          NonTermination;
-                          OCaml.Assert_failure
+                          Type
+                            (NonTermination);
+                          Type
+                            (OCaml.Assert_failure)
                         ],
                         [
-                          Counter;
-                          NonTermination;
-                          OCaml.Assert_failure
+                          Type
+                            (Counter);
+                          Type
+                            (NonTermination);
+                          Type
+                            (OCaml.Assert_failure)
                         ],
                         Apply
                           (?,

--- a/tests/ex35.effects
+++ b/tests/ex35.effects
@@ -4,20 +4,21 @@
 Value
   (non_rec, @.,
     [
-      ((div, [ ], [ (n, Type (Z)) ], Type (Z)),
+      ((div, [ ], [ (n, Type (Z)) ], Monad ([ Type (Fail) ], Type (Z))),
         IfThenElse
-          ((6, Effect ([ Fail ], .)),
+          ((6, Effect ([ Type (Fail) ], .)),
             Apply
               ((6, Effect ([ ], .)),
-                Variable ((6, Effect ([ ], .)), equiv_decb),
+                Variable ((6, Effect ([ ], . -> . -> .)), equiv_decb),
                 [
                   Variable ((6, Effect ([ ], .)), n);
                   Constant ((6, Effect ([ ], .)), Int(0))
                 ]),
             Apply
-              ((7, Effect ([ Fail ], .)),
+              ((7, Effect ([ Type (Fail) ], .)),
                 Variable
-                  ((7, Effect ([ ], . -[ Fail ]-> .)), raise_Fail),
+                  ((7, Effect ([ ], . -[ Type (Fail) ]-> .)),
+                    raise_Fail),
                 [
                   Tuple
                     ((?, Effect ([ ], .)),
@@ -31,7 +32,7 @@ Value
                 ]),
             Apply
               ((9, Effect ([ ], .)),
-                Variable ((9, Effect ([ ], .)), Z.div),
+                Variable ((9, Effect ([ ], . -> . -> .)), Z.div),
                 [
                   Constant ((9, Effect ([ ], .)), Int(256));
                   Variable ((9, Effect ([ ], .)), n)

--- a/tests/ex35.monadise
+++ b/tests/ex35.monadise
@@ -4,7 +4,7 @@
 Value
   (non_rec, @.,
     [
-      ((div, [ ], [ (n, Type (Z)) ], Monad ([ Fail ], Type (Z))),
+      ((div, [ ], [ (n, Type (Z)) ], Monad ([ Type (Fail) ], Type (Z))),
         IfThenElse
           (6,
             Apply

--- a/tests/ex36.effects
+++ b/tests/ex36.effects
@@ -7,7 +7,8 @@ Value
       ((all_eqb, [ ], [ (x, Type (bool)); (y, Type (bool)); (z, Type (bool)) ],
         Type (bool)),
         Apply
-          ((5, Effect ([ ], .)), Variable ((5, Effect ([ ], .)), andb),
+          ((5, Effect ([ ], .)),
+            Variable ((5, Effect ([ ], . -> . -> .)), andb),
             [
               Apply
                 ((5, Effect ([ ], .)),
@@ -16,7 +17,11 @@ Value
                       Effect
                         ([
                         ],
-                          .)),
+                          .
+                            ->
+                            .
+                              ->
+                              .)),
                       op_eq_eq),
                   [
                     Variable
@@ -41,7 +46,11 @@ Value
                       Effect
                         ([
                         ],
-                          .)),
+                          .
+                            ->
+                            .
+                              ->
+                              .)),
                       op_eq_eq),
                   [
                     Variable
@@ -70,7 +79,8 @@ Value
     [
       ((all_equal, [ A ], [ (x, A); (y, A); (z, A) ], Type (bool)),
         Apply
-          ((10, Effect ([ ], .)), Variable ((10, Effect ([ ], .)), andb),
+          ((10, Effect ([ ], .)),
+            Variable ((10, Effect ([ ], . -> . -> .)), andb),
             [
               Apply
                 ((10, Effect ([ ], .)),
@@ -79,7 +89,11 @@ Value
                       Effect
                         ([
                         ],
-                          .)),
+                          .
+                            ->
+                            .
+                              ->
+                              .)),
                       op_eq),
                   [
                     Variable
@@ -104,7 +118,11 @@ Value
                       Effect
                         ([
                         ],
-                          .)),
+                          .
+                            ->
+                            .
+                              ->
+                              .)),
                       op_eq),
                   [
                     Variable

--- a/tests/ex37.effects
+++ b/tests/ex37.effects
@@ -8,11 +8,15 @@
   Value
     (non_rec, @.,
       [
-        ((c, [ A ], [ (x, Type (string)) ], A),
+        ((c, [ A ], [ (x, Type (string)) ], Monad ([ Type (OCaml.Failure) ], A)),
           Apply
-            ((6, Effect ([ OCaml.Failure ], .)),
+            ((6, Effect ([ Type (OCaml.Failure) ], .)),
               Variable
-                ((6, Effect ([ ], . -[ OCaml.Failure ]-> .)),
+                ((6,
+                  Effect
+                    ([ ],
+                      . -[ Type (OCaml.Failure) ]->
+                        .)),
                   OCaml.Pervasives.failwith),
               [ Variable ((6, Effect ([ ], .)), A/x) ]))
       ])
@@ -25,7 +29,8 @@ Value
     [
       ((b, [ ], [ ], Type (Z)),
         Apply
-          ((11, Effect ([ ], .)), Variable ((11, Effect ([ ], .)), Z.add),
+          ((11, Effect ([ ], .)),
+            Variable ((11, Effect ([ ], . -> . -> .)), Z.add),
             [
               Variable ((11, Effect ([ ], .)), a);
               Constant ((11, Effect ([ ], .)), Int(2))
@@ -36,18 +41,22 @@ Value
 Value
   (non_rec, @.,
     [
-      ((d, [ A ], [ (b, Type (bool)) ], A),
+      ((d, [ A ], [ (b, Type (bool)) ], Monad ([ Type (OCaml.Failure) ], A)),
         IfThenElse
-          ((13, Effect ([ OCaml.Failure ], .)),
+          ((13, Effect ([ Type (OCaml.Failure) ], .)),
             Variable ((13, Effect ([ ], .)), b),
             Apply
-              ((13, Effect ([ OCaml.Failure ], .)),
+              ((13, Effect ([ Type (OCaml.Failure) ], .)),
                 Variable
-                  ((13, Effect ([ ], . -[ OCaml.Failure ]-> .)), c),
+                  ((13,
+                    Effect ([ ], . -[ Type (OCaml.Failure) ]-> .)),
+                    c),
                 [ Constant ((13, Effect ([ ], .)), String("true")) ]),
             Apply
-              ((13, Effect ([ OCaml.Failure ], .)),
+              ((13, Effect ([ Type (OCaml.Failure) ], .)),
                 Variable
-                  ((13, Effect ([ ], . -[ OCaml.Failure ]-> .)), c),
+                  ((13,
+                    Effect ([ ], . -[ Type (OCaml.Failure) ]-> .)),
+                    c),
                 [ Constant ((13, Effect ([ ], .)), String("false")) ])))
     ])

--- a/tests/ex37.monadise
+++ b/tests/ex37.monadise
@@ -5,7 +5,7 @@
   Value
     (non_rec, @.,
       [
-        ((c, [ A ], [ (x, Type (string)) ], Monad ([ OCaml.Failure ], A)),
+        ((c, [ A ], [ (x, Type (string)) ], Monad ([ Type (OCaml.Failure) ], A)),
           Apply
             (6, Variable (6, OCaml.Pervasives.failwith),
               [ Variable (6, A/x) ]))
@@ -27,7 +27,7 @@ Value
 Value
   (non_rec, @.,
     [
-      ((d, [ A ], [ (b, Type (bool)) ], Monad ([ OCaml.Failure ], A)),
+      ((d, [ A ], [ (b, Type (bool)) ], Monad ([ Type (OCaml.Failure) ], A)),
         IfThenElse
           (13, Variable (13, b),
             Apply

--- a/tests/ex38.effects
+++ b/tests/ex38.effects
@@ -7,7 +7,7 @@ Value
   (non_rec, @.,
     [
       ((f, [ A; B ], [ ], (A -> (B -> A))),
-        Variable ((4, Effect ([ ], .)), Tests.DependEx38.f))
+        Variable ((4, Effect ([ ], . -> . -> .)), Tests.DependEx38.f))
     ])
 
 6

--- a/tests/ex39.effects
+++ b/tests/ex39.effects
@@ -4,7 +4,8 @@ Require [ OCaml.List ]
 Value
   (non_rec, @.,
     [
-      ((get_local_ref, [ ], [ (tt (= tt_1), Type (unit)) ], Type (Z)),
+      ((get_local_ref, [ ], [ (tt (= tt_1), Type (unit)) ],
+        Monad ([ Type (OCaml.Effect.State.state, Type (Z)) ], Type (Z))),
         LetVar (4, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .))
           x =
           Apply
@@ -41,7 +42,8 @@ Value
 Value
   (non_rec, @.,
     [
-      ((set_local_ref, [ ], [ (tt (= tt_1), Type (unit)) ], Type (Z)),
+      ((set_local_ref, [ ], [ (tt (= tt_1), Type (unit)) ],
+        Monad ([ Type (OCaml.Effect.State.state, Type (Z)) ], Type (Z))),
         LetVar (8, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .))
           x =
           Apply
@@ -105,7 +107,7 @@ Value
     [
       ((add_multiple_by_refs, [ ],
         [ (a, Type (Z)); (b, Type (Z)); (c, Type (Z)); (d, Type (Z)) ],
-        Type (Z)),
+        Monad ([ Type (OCaml.Effect.State.state, Type (Z)) ], Type (Z))),
         LetVar (13, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .))
           x =
           Apply
@@ -159,7 +161,11 @@ Value
                           Effect
                             ([
                             ],
-                              .)),
+                              .
+                                ->
+                                .
+                                  ->
+                                  .)),
                           Z.add),
                       [
                         Apply
@@ -269,7 +275,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               Z.add),
                           [
                             Apply
@@ -360,7 +370,11 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .
+                                        ->
+                                        .)),
                                 Z.add),
                             [
                               Apply
@@ -460,7 +474,7 @@ Value
   (non_rec, @.,
     [
       ((set_ref, [ ], [ (x, Type (OCaml.Effect.State.t, Type (Z))) ],
-        Type (unit)),
+        Monad ([ Type (OCaml.Effect.State.state, Type (Z)) ], Type (unit))),
         Apply
           ((21, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
             Variable
@@ -485,7 +499,8 @@ Value
 Value
   (non_rec, @.,
     [
-      ((get_ref, [ ], [ (x, Type (OCaml.Effect.State.t, Type (Z))) ], Type (Z)),
+      ((get_ref, [ ], [ (x, Type (OCaml.Effect.State.t, Type (Z))) ],
+        Monad ([ Type (OCaml.Effect.State.state, Type (Z)) ], Type (Z))),
         Apply
           ((24, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
             Variable
@@ -507,7 +522,7 @@ Value
   (non_rec, @.,
     [
       ((update_ref, [ ], [ (x, Type (OCaml.Effect.State.t, Type (Z))) ],
-        Type (unit)),
+        Monad ([ Type (OCaml.Effect.State.state, Type (Z)) ], Type (unit))),
         Apply
           ((27, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
             Variable
@@ -538,7 +553,11 @@ Value
                       Effect
                         ([
                         ],
-                          .)),
+                          .
+                            ->
+                            .
+                              ->
+                              .)),
                       Z.add),
                   [
                     Apply
@@ -590,7 +609,9 @@ Value
   (non_rec, @.,
     [
       ((new_ref, [ ], [ (x, Type (unit)) ],
-        Type (OCaml.Effect.State.t, Type (Z))),
+        Monad
+          ([ Type (OCaml.Effect.State.state, Type (Z)) ],
+            Type (OCaml.Effect.State.t, Type (Z)))),
         Apply
           ((30, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
             Variable
@@ -613,11 +634,17 @@ Value
 Value
   (non_rec, @.,
     [
-      ((set_r, [ ], [ (x, Type (unit)) ], Type (unit)),
+      ((set_r, [ ], [ (x, Type (unit)) ],
+        Monad
+          ([ Type (OCaml.Effect.State.state, Type (Z)); Type (r_state) ],
+            Type (unit))),
         Apply
           ((34,
             Effect
-              ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], .)),
+              ([
+                Type (OCaml.Effect.State.state, Type (Z));
+                Type (r_state)
+              ], .)),
             Variable
               ((34,
                 Effect
@@ -638,7 +665,8 @@ Value
                         (OCaml.Effect.State.state,
                           Type
                             (Z));
-                      r_state
+                      Type
+                        (r_state)
                     ], .)),
                   r)
             ]))
@@ -648,11 +676,17 @@ Value
 Value
   (non_rec, @.,
     [
-      ((get_r, [ ], [ (x, Type (unit)) ], Type (Z)),
+      ((get_r, [ ], [ (x, Type (unit)) ],
+        Monad
+          ([ Type (OCaml.Effect.State.state, Type (Z)); Type (r_state) ],
+            Type (Z))),
         Apply
           ((36,
             Effect
-              ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], .)),
+              ([
+                Type (OCaml.Effect.State.state, Type (Z));
+                Type (r_state)
+              ], .)),
             Variable
               ((36,
                 Effect
@@ -673,7 +707,8 @@ Value
                         (OCaml.Effect.State.state,
                           Type
                             (Z));
-                      r_state
+                      Type
+                        (r_state)
                     ], .)),
                   r)
             ]))
@@ -683,17 +718,24 @@ Value
 Value
   (non_rec, @.,
     [
-      ((r_add_15, [ ], [ (x, Type (unit)) ], Type (Z)),
+      ((r_add_15, [ ], [ (x, Type (unit)) ],
+        Monad
+          ([ Type (OCaml.Effect.State.state, Type (Z)); Type (r_state) ],
+            Type (Z))),
         LetVar
           (39,
             Effect
-              ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], .))
-          i =
+              ([
+                Type (OCaml.Effect.State.state, Type (Z));
+                Type (r_state)
+              ], .)) i =
           Apply
             ((39,
               Effect
-                ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ],
-                  .)),
+                ([
+                  Type (OCaml.Effect.State.state, Type (Z));
+                  Type (r_state)
+                ], .)),
               Variable
                 ((39,
                   Effect
@@ -704,19 +746,22 @@ Value
                             (OCaml.Effect.State.state,
                               Type
                                 (Z));
-                          r_state
+                          Type (r_state)
                         ]-> .)), get_r),
               [ Constructor ((39, Effect ([ ], .)), tt) ]) in
         Sequence
           ((40,
             Effect
-              ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], .)),
+              ([
+                Type (OCaml.Effect.State.state, Type (Z));
+                Type (r_state)
+              ], .)),
             Apply
               ((40,
                 Effect
                   ([
                     Type (OCaml.Effect.State.state, Type (Z));
-                    r_state
+                    Type (r_state)
                   ], .)),
                 Variable
                   ((40,
@@ -728,7 +773,7 @@ Value
                               (OCaml.Effect.State.state,
                                 Type
                                   (Z));
-                            r_state
+                            Type (r_state)
                           ]-> .)), set_r),
                 [ Constructor ((40, Effect ([ ], .)), tt) ]),
             LetVar
@@ -736,14 +781,14 @@ Value
                 Effect
                   ([
                     Type (OCaml.Effect.State.state, Type (Z));
-                    r_state
+                    Type (r_state)
                   ], .)) j =
               Apply
                 ((41,
                   Effect
                     ([
                       Type (OCaml.Effect.State.state, Type (Z));
-                      r_state
+                      Type (r_state)
                     ], .)),
                   Variable
                     ((41,
@@ -755,7 +800,7 @@ Value
                                 (OCaml.Effect.State.state,
                                   Type
                                     (Z));
-                              r_state
+                              Type (r_state)
                             ]-> .)), get_r),
                   [ Constructor ((41, Effect ([ ], .)), tt) ]) in
             Sequence
@@ -763,7 +808,7 @@ Value
                 Effect
                   ([
                     Type (OCaml.Effect.State.state, Type (Z));
-                    r_state
+                    Type (r_state)
                   ], .)),
                 Apply
                   ((42,
@@ -773,7 +818,7 @@ Value
                           (OCaml.Effect.State.state,
                             Type
                               (Z));
-                        r_state
+                        Type (r_state)
                       ], .)),
                     Variable
                       ((42,
@@ -797,7 +842,8 @@ Value
                                 (OCaml.Effect.State.state,
                                   Type
                                     (Z));
-                              r_state
+                              Type
+                                (r_state)
                             ],
                               .)),
                           r);
@@ -812,7 +858,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               Z.add),
                           [
                             Variable
@@ -839,7 +889,7 @@ Value
                           (OCaml.Effect.State.state,
                             Type
                               (Z));
-                        r_state
+                        Type (r_state)
                       ], .)),
                     Variable
                       ((43,
@@ -862,7 +912,8 @@ Value
                                 (OCaml.Effect.State.state,
                                   Type
                                     (Z));
-                              r_state
+                              Type
+                                (r_state)
                             ],
                               .)),
                           r)
@@ -874,7 +925,13 @@ Value
   (non_rec, @.,
     [
       ((mixed_type, [ ], [ (x, Type (unit)) ],
-        (Type (bool) * Type (string) * Type (Z))),
+        Monad
+          ([
+            Type (OCaml.Effect.State.state, Type (Z));
+            Type (OCaml.Effect.State.state, Type (bool));
+            Type (OCaml.Effect.State.state, Type (string));
+            Type (r_state)
+          ], (Type (bool) * Type (string) * Type (Z)))),
         LetVar
           (46,
             Effect
@@ -882,7 +939,7 @@ Value
                 Type (OCaml.Effect.State.state, Type (Z));
                 Type (OCaml.Effect.State.state, Type (bool));
                 Type (OCaml.Effect.State.state, Type (string));
-                r_state
+                Type (r_state)
               ], .)) b =
           Apply
             ((46,
@@ -907,7 +964,7 @@ Value
                 Type (OCaml.Effect.State.state, Type (Z));
                 Type (OCaml.Effect.State.state, Type (bool));
                 Type (OCaml.Effect.State.state, Type (string));
-                r_state
+                Type (r_state)
               ], .)) str =
           Apply
             ((47,
@@ -932,11 +989,22 @@ Value
                 Type (OCaml.Effect.State.state, Type (Z));
                 Type (OCaml.Effect.State.state, Type (bool));
                 Type (OCaml.Effect.State.state, Type (string));
-                r_state
+                Type (r_state)
               ], .))
           (non_rec, @.,
             [
-              ((update, [ ], [ (x_1, Type (unit)) ], Type (unit)),
+              ((update, [ ], [ (x_1, Type (unit)) ],
+                Monad
+                  ([
+                    Type
+                      (OCaml.Effect.State.state,
+                        Type
+                          (bool));
+                    Type
+                      (OCaml.Effect.State.state,
+                        Type
+                          (string))
+                  ], Type (unit))),
                 Match
                   ((?,
                     Effect
@@ -1092,7 +1160,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           String.append),
                                       [
                                         Constant
@@ -1146,7 +1218,7 @@ Value
                 Type (OCaml.Effect.State.state, Type (Z));
                 Type (OCaml.Effect.State.state, Type (bool));
                 Type (OCaml.Effect.State.state, Type (string));
-                r_state
+                Type (r_state)
               ], .)),
             Apply
               ((51,
@@ -1178,7 +1250,7 @@ Value
                     Type (OCaml.Effect.State.state, Type (Z));
                     Type (OCaml.Effect.State.state, Type (bool));
                     Type (OCaml.Effect.State.state, Type (string));
-                    r_state
+                    Type (r_state)
                   ], .)),
                 Apply
                   ((52,
@@ -1225,7 +1297,7 @@ Value
                           (OCaml.Effect.State.state,
                             Type
                               (string));
-                        r_state
+                        Type (r_state)
                       ], .)),
                     Apply
                       ((53,
@@ -1280,7 +1352,7 @@ Value
                               (OCaml.Effect.State.state,
                                 Type
                                   (string));
-                            r_state
+                            Type (r_state)
                           ], .)),
                         Apply
                           ((54,
@@ -1350,7 +1422,7 @@ Value
                                   (OCaml.Effect.State.state,
                                     Type
                                       (Z));
-                                r_state
+                                Type (r_state)
                               ], .)),
                             Variable
                               ((54,
@@ -1373,7 +1445,8 @@ Value
                                         (OCaml.Effect.State.state,
                                           Type
                                             (Z));
-                                      r_state
+                                      Type
+                                        (r_state)
                                     ],
                                       .)),
                                   r)
@@ -1385,14 +1458,19 @@ Value
   (non_rec, @.,
     [
       ((partials_test, [ ], [ (x, Type (unit)) ],
-        Type (OCaml.Effect.State.t, Type (Z))),
+        Monad
+          ([
+            Type (OCaml.Effect.State.state, Type (Z));
+            Type (OCaml.Effect.State.state, Type (list, Type (Z)));
+            Type (r_state)
+          ], Type (OCaml.Effect.State.t, Type (Z)))),
         Match
           ((?,
             Effect
               ([
                 Type (OCaml.Effect.State.state, Type (Z));
                 Type (OCaml.Effect.State.state, Type (list, Type (Z)));
-                r_state
+                Type (r_state)
               ], .)), Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (tt),
@@ -1410,7 +1488,8 @@ Value
                               (list,
                                 Type
                                   (Z)));
-                        r_state
+                        Type
+                          (r_state)
                       ],
                         .))
                   (non_rec, @.,
@@ -1428,10 +1507,17 @@ Value
                             Type
                               (Z))
                         ],
-                        Type
-                          (OCaml.Effect.State.t,
+                        Monad
+                          ([
                             Type
-                              (Z))),
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (Z))
+                          ],
+                            Type
+                              (OCaml.Effect.State.t,
+                                Type
+                                  (Z)))),
                         Sequence
                           ((58,
                             Effect
@@ -1507,7 +1593,8 @@ Value
                               (list,
                                 Type
                                   (Z)));
-                        r_state
+                        Type
+                          (r_state)
                       ],
                         .))
                   f1_test =
@@ -1519,7 +1606,8 @@ Value
                             (OCaml.Effect.State.state,
                               Type
                                 (Z));
-                          r_state
+                          Type
+                            (r_state)
                         ],
                           .
                             -[
@@ -1554,7 +1642,8 @@ Value
                                   (OCaml.Effect.State.state,
                                     Type
                                       (Z));
-                                r_state
+                                Type
+                                  (r_state)
                               ],
                                 .)),
                             r)
@@ -1646,10 +1735,23 @@ Value
                                 Type
                                   (string)))
                         ],
-                        Type
-                          (OCaml.Effect.State.t,
+                        Monad
+                          ([
                             Type
-                              (Z))),
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (Z));
+                            Type
+                              (OCaml.Effect.State.state,
+                                Type
+                                  (list,
+                                    Type
+                                      (Z)))
+                          ],
+                            Type
+                              (OCaml.Effect.State.t,
+                                Type
+                                  (Z)))),
                         Apply
                           ((63,
                             Effect
@@ -1698,7 +1800,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       Z.add),
                                   [
                                     Apply
@@ -1718,7 +1824,9 @@ Value
                                             Effect
                                               ([
                                               ],
-                                                .)),
+                                                .
+                                                  ->
+                                                  .)),
                                             OCaml.List.length),
                                         [
                                           Apply
@@ -1770,7 +1878,9 @@ Value
                                             Effect
                                               ([
                                               ],
-                                                .)),
+                                                .
+                                                  ->
+                                                  .)),
                                             OCaml.List.length),
                                         [
                                           Variable
@@ -2098,7 +2208,9 @@ Value
   (non_rec, @.,
     [
       ((multiple_returns_test, [ ], [ (x, Type (unit)) ],
-        (Type (Z) * Type (OCaml.Effect.State.t, Type (Z)))),
+        Monad
+          ([ Type (OCaml.Effect.State.state, Type (Z)) ],
+            (Type (Z) * Type (OCaml.Effect.State.t, Type (Z))))),
         Match
           ((?, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
             Variable ((?, Effect ([ ], .)), x),
@@ -2129,18 +2241,39 @@ Value
                             Type
                               (Z))
                         ],
-                        (Type
-                          (Z)
-                          ->
-                          (Type
-                            (OCaml.Effect.State.t,
-                              Type
-                                (Z))
-                            ->
+                        Monad
+                          ([
                             Type
-                              (OCaml.Effect.State.t,
+                              (OCaml.Effect.State.state,
                                 Type
-                                  (Z))))),
+                                  (Z))
+                          ],
+                            (Type
+                              (Z)
+                              ->
+                              Monad
+                                ([
+                                  Type
+                                    (OCaml.Effect.State.state,
+                                      Type
+                                        (Z))
+                                ],
+                                  (Type
+                                    (OCaml.Effect.State.t,
+                                      Type
+                                        (Z))
+                                    ->
+                                    Monad
+                                      ([
+                                        Type
+                                          (OCaml.Effect.State.state,
+                                            Type
+                                              (Z))
+                                      ],
+                                        Type
+                                          (OCaml.Effect.State.t,
+                                            Type
+                                              (Z)))))))),
                         Sequence
                           ((70,
                             Effect
@@ -2294,7 +2427,11 @@ Value
                                                   Effect
                                                     ([
                                                     ],
-                                                      .)),
+                                                      .
+                                                        ->
+                                                        .
+                                                          ->
+                                                          .)),
                                                   Z.add),
                                               [
                                                 Apply
@@ -2458,7 +2595,11 @@ Value
                                                           Effect
                                                             ([
                                                             ],
-                                                              .)),
+                                                              .
+                                                                ->
+                                                                .
+                                                                  ->
+                                                                  .)),
                                                           Z.mul),
                                                       [
                                                         Constant
@@ -2957,7 +3098,12 @@ Value
           (y, Type (OCaml.Effect.State.t, B));
           (a, A);
           (b, B)
-        ], Type (unit)),
+        ],
+        Monad
+          ([
+            Type (OCaml.Effect.State.state, A);
+            Type (OCaml.Effect.State.state, B)
+          ], Type (unit))),
         Sequence
           ((88,
             Effect
@@ -3008,7 +3154,8 @@ Value
   (non_rec, @.,
     [
       ((resolves_test1, [ A ],
-        [ (x, Type (OCaml.Effect.State.t, A)); (a, A); (b, A) ], Type (unit)),
+        [ (x, Type (OCaml.Effect.State.t, A)); (a, A); (b, A) ],
+        Monad ([ Type (OCaml.Effect.State.state, A) ], Type (unit))),
         Apply
           ((92, Effect ([ Type (OCaml.Effect.State.state, A) ], .)),
             Variable
@@ -3045,7 +3192,12 @@ Value
           (y, Type (OCaml.Effect.State.t, A));
           (a, Type (Z));
           (b, A)
-        ], Type (unit)),
+        ],
+        Monad
+          ([
+            Type (OCaml.Effect.State.state, A);
+            Type (OCaml.Effect.State.state, Type (Z))
+          ], Type (unit))),
         Apply
           ((95,
             Effect
@@ -3088,7 +3240,7 @@ Value
           (y, Type (OCaml.Effect.State.t, Type (Z)));
           (a, Type (Z));
           (b, Type (Z))
-        ], Type (unit)),
+        ], Monad ([ Type (OCaml.Effect.State.state, Type (Z)) ], Type (unit))),
         Apply
           ((98, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
             Variable

--- a/tests/ex39.monadise
+++ b/tests/ex39.monadise
@@ -256,13 +256,16 @@ Value
     [
       ((set_r, [ ], [ (x, Type (unit)) ],
         Monad
-          ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ],
+          ([ Type (OCaml.Effect.State.state, Type (Z)); Type (r_state) ],
             Type (unit))),
         Bind
           (?, Variable (34, r), Some x_1,
             Lift
               (?, [ Type (OCaml.Effect.State.state, Type (Z)) ],
-                [ Type (OCaml.Effect.State.state, Type (Z)); r_state ],
+                [
+                  Type (OCaml.Effect.State.state, Type (Z));
+                  Type (r_state)
+                ],
                 Apply
                   (34, Variable (34, set_ref), [ Variable (?, x_1) ]))))
     ])
@@ -273,12 +276,16 @@ Value
     [
       ((get_r, [ ], [ (x, Type (unit)) ],
         Monad
-          ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], Type (Z))),
+          ([ Type (OCaml.Effect.State.state, Type (Z)); Type (r_state) ],
+            Type (Z))),
         Bind
           (?, Variable (36, r), Some x_1,
             Lift
               (?, [ Type (OCaml.Effect.State.state, Type (Z)) ],
-                [ Type (OCaml.Effect.State.state, Type (Z)); r_state ],
+                [
+                  Type (OCaml.Effect.State.state, Type (Z));
+                  Type (r_state)
+                ],
                 Apply
                   (36, Variable (36, get_ref), [ Variable (?, x_1) ]))))
     ])
@@ -289,7 +296,8 @@ Value
     [
       ((r_add_15, [ ], [ (x, Type (unit)) ],
         Monad
-          ([ Type (OCaml.Effect.State.state, Type (Z)); r_state ], Type (Z))),
+          ([ Type (OCaml.Effect.State.state, Type (Z)); Type (r_state) ],
+            Type (Z))),
         Bind
           (?, Apply (39, Variable (39, get_r), [ Constructor (39, tt) ]),
             Some i,
@@ -320,7 +328,7 @@ Value
                                     (OCaml.Effect.State.state,
                                       Type
                                         (Z));
-                                  r_state
+                                  Type (r_state)
                                 ],
                                 Apply
                                   (42,
@@ -360,7 +368,7 @@ Value
                                     (OCaml.Effect.State.state,
                                       Type
                                         (Z));
-                                  r_state
+                                  Type (r_state)
                                 ],
                                 Apply
                                   (43,
@@ -384,7 +392,7 @@ Value
             Type (OCaml.Effect.State.state, Type (Z));
             Type (OCaml.Effect.State.state, Type (bool));
             Type (OCaml.Effect.State.state, Type (string));
-            r_state
+            Type (r_state)
           ], (Type (bool) * Type (string) * Type (Z)))),
         Bind
           (?,
@@ -394,7 +402,7 @@ Value
                   Type (OCaml.Effect.State.state, Type (Z));
                   Type (OCaml.Effect.State.state, Type (bool));
                   Type (OCaml.Effect.State.state, Type (string));
-                  r_state
+                  Type (r_state)
                 ],
                 Apply
                   (46, Variable (46, OCaml.Pervasives.ref),
@@ -419,7 +427,7 @@ Value
                         (OCaml.Effect.State.state,
                           Type
                             (string));
-                      r_state
+                      Type (r_state)
                     ],
                     Apply
                       (47, Variable (47, OCaml.Pervasives.ref),
@@ -591,7 +599,7 @@ Value
                             (OCaml.Effect.State.state,
                               Type
                                 (string));
-                          r_state
+                          Type (r_state)
                         ],
                         Apply
                           (51, Variable (51, update),
@@ -624,7 +632,7 @@ Value
                                 (OCaml.Effect.State.state,
                                   Type
                                     (string));
-                              r_state
+                              Type (r_state)
                             ],
                             Apply
                               (52,
@@ -661,7 +669,7 @@ Value
                                     (OCaml.Effect.State.state,
                                       Type
                                         (string));
-                                  r_state
+                                  Type (r_state)
                                 ],
                                 Apply
                                   (53,
@@ -696,7 +704,8 @@ Value
                                         (OCaml.Effect.State.state,
                                           Type
                                             (string));
-                                      r_state
+                                      Type
+                                        (r_state)
                                     ],
                                     Apply
                                       (54,
@@ -732,7 +741,8 @@ Value
                                             (OCaml.Effect.State.state,
                                               Type
                                                 (string));
-                                          r_state
+                                          Type
+                                            (r_state)
                                         ],
                                         Apply
                                           (54,
@@ -754,7 +764,8 @@ Value
                                                 (OCaml.Effect.State.state,
                                                   Type
                                                     (Z));
-                                              r_state
+                                              Type
+                                                (r_state)
                                             ],
                                             [
                                               Type
@@ -769,7 +780,8 @@ Value
                                                 (OCaml.Effect.State.state,
                                                   Type
                                                     (string));
-                                              r_state
+                                              Type
+                                                (r_state)
                                             ],
                                             Bind
                                               (?,
@@ -791,7 +803,8 @@ Value
                                                         (OCaml.Effect.State.state,
                                                           Type
                                                             (Z));
-                                                      r_state
+                                                      Type
+                                                        (r_state)
                                                     ],
                                                     Apply
                                                       (54,
@@ -829,7 +842,7 @@ Value
           ([
             Type (OCaml.Effect.State.state, Type (Z));
             Type (OCaml.Effect.State.state, Type (list, Type (Z)));
-            r_state
+            Type (r_state)
           ], Type (OCaml.Effect.State.t, Type (Z)))),
         Match
           (?, Variable (?, x),
@@ -894,7 +907,8 @@ Value
                             (OCaml.Effect.State.state,
                               Type
                                 (Z));
-                          r_state
+                          Type
+                            (r_state)
                         ],
                         [
                           Type
@@ -907,7 +921,8 @@ Value
                                 (list,
                                   Type
                                     (Z)));
-                          r_state
+                          Type
+                            (r_state)
                         ],
                         Bind
                           (?,
@@ -955,7 +970,8 @@ Value
                                 (list,
                                   Type
                                     (Z)));
-                          r_state
+                          Type
+                            (r_state)
                         ],
                         Bind
                           (?,

--- a/tests/ex40.effects
+++ b/tests/ex40.effects
@@ -4,12 +4,17 @@
 Value
   (non_rec, @.,
     [
-      ((b, [ ], [ (x, Type (unit)) ], Type (OCaml.Effect.State.t, Type (Z))),
+      ((b, [ ], [ (x, Type (unit)) ],
+        Monad
+          ([ Type (OCaml.Effect.State.state, Type (Z)); Type (a_state) ],
+            Type (OCaml.Effect.State.t, Type (Z)))),
         Match
           ((?,
             Effect
-              ([ Type (OCaml.Effect.State.state, Type (Z)); a_state ], .)),
-            Variable ((?, Effect ([ ], .)), x),
+              ([
+                Type (OCaml.Effect.State.state, Type (Z));
+                Type (a_state)
+              ], .)), Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (tt),
                 Variable
@@ -20,7 +25,8 @@ Value
                           (OCaml.Effect.State.state,
                             Type
                               (Z));
-                        a_state
+                        Type
+                          (a_state)
                       ],
                         .)),
                     a))
@@ -36,13 +42,18 @@ Reference
 Value
   (non_rec, @.,
     [
-      ((c, [ ], [ (x, Type (unit)) ], Type (OCaml.Effect.State.t, Type (string))),
+      ((c, [ ], [ (x, Type (unit)) ],
+        Monad
+          ([
+            Type (OCaml.Effect.State.state, Type (string));
+            Type (a_state_1)
+          ], Type (OCaml.Effect.State.t, Type (string)))),
         Match
           ((?,
             Effect
               ([
                 Type (OCaml.Effect.State.state, Type (string));
-                a_state_1
+                Type (a_state_1)
               ], .)), Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (tt),
@@ -54,7 +65,8 @@ Value
                           (OCaml.Effect.State.state,
                             Type
                               (string));
-                        a_state_1
+                        Type
+                          (a_state_1)
                       ],
                         .)),
                     a_1))
@@ -92,7 +104,8 @@ Value
     [
       ((g, [ A ], [ (x, A); (y, A) ], Type (bool)),
         Apply
-          ((14, Effect ([ ], .)), Variable ((14, Effect ([ ], .)), op_eq),
+          ((14, Effect ([ ], .)),
+            Variable ((14, Effect ([ ], . -> . -> .)), op_eq),
             [
               Variable ((14, Effect ([ ], .)), x);
               Variable ((14, Effect ([ ], .)), y)
@@ -107,7 +120,8 @@ Value
     [
       ((h, [ A ], [ (x, A); (y, A) ], Type (bool)),
         Apply
-          ((16, Effect ([ ], .)), Variable ((16, Effect ([ ], .)), op_eq_1),
+          ((16, Effect ([ ], .)),
+            Variable ((16, Effect ([ ], . -> . -> .)), op_eq_1),
             [
               Variable ((16, Effect ([ ], .)), x);
               Variable ((16, Effect ([ ], .)), y)

--- a/tests/ex40.monadise
+++ b/tests/ex40.monadise
@@ -6,7 +6,7 @@ Value
     [
       ((b, [ ], [ (x, Type (unit)) ],
         Monad
-          ([ Type (OCaml.Effect.State.state, Type (Z)); a_state ],
+          ([ Type (OCaml.Effect.State.state, Type (Z)); Type (a_state) ],
             Type (OCaml.Effect.State.t, Type (Z)))),
         Match (?, Variable (?, x), [ (Constructor (tt), Variable (4, a)) ]))
     ])
@@ -19,8 +19,10 @@ Value
     [
       ((c, [ ], [ (x, Type (unit)) ],
         Monad
-          ([ Type (OCaml.Effect.State.state, Type (string)); a_state_1 ],
-            Type (OCaml.Effect.State.t, Type (string)))),
+          ([
+            Type (OCaml.Effect.State.state, Type (string));
+            Type (a_state_1)
+          ], Type (OCaml.Effect.State.t, Type (string)))),
         Match (?, Variable (?, x), [ (Constructor (tt), Variable (6, a_1)) ]))
     ])
 

--- a/tests/ex42.effects
+++ b/tests/ex42.effects
@@ -2,7 +2,8 @@
 Value
   (non_rec, @.,
     [
-      ((x, [ ], [ (a, Type (Z)); (b, Type (Z)) ], Type (Z)),
+      ((x, [ ], [ (a, Type (Z)); (b, Type (Z)) ],
+        Monad ([ Type (OCaml.Effect.State.state, Type (Z)) ], Type (Z))),
         LetVar (3, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .))
           y =
           Apply
@@ -66,7 +67,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               Z.add),
                           [
                             Apply
@@ -133,7 +138,10 @@ Value
 Value
   (non_rec, @.,
     [
-      ((nested, [ ], [ (x, Type (Z)); (y, Type (Z)) ], Type (list, Type (bool))),
+      ((nested, [ ], [ (x, Type (Z)); (y, Type (Z)) ],
+        Monad
+          ([ Type (OCaml.Effect.State.state, Type (list, Type (bool))) ],
+            Type (list, Type (bool)))),
         LetVar
           (10,
             Effect
@@ -434,18 +442,22 @@ Value
 Value
   (non_rec, @.,
     [
-      ((raises, [ ], [ (x, Type (Z)) ], Type (unit)),
+      ((raises, [ ], [ (x, Type (Z)) ],
+        Monad ([ Type (OCaml.Failure) ], Type (unit))),
         For
-          ((20, Effect ([ OCaml.Failure ], .)), i, true,
+          ((20, Effect ([ Type (OCaml.Failure) ], .)), i, true,
             Constant ((20, Effect ([ ], .)), Int(0)),
             Variable ((20, Effect ([ ], .)), x),
             Coerce
-              ((?, Effect ([ OCaml.Failure ], .)),
+              ((?, Effect ([ Type (OCaml.Failure) ], .)),
                 Apply
-                  ((21, Effect ([ OCaml.Failure ], .)),
+                  ((21, Effect ([ Type (OCaml.Failure) ], .)),
                     Variable
                       ((21,
-                        Effect ([ ], . -[ OCaml.Failure ]-> .)),
+                        Effect
+                          ([ ],
+                            . -[ Type (OCaml.Failure) ]->
+                              .)),
                         OCaml.Pervasives.failwith),
                     [
                       Constant
@@ -462,16 +474,23 @@ Value
 Value
   (non_rec, @.,
     [
-      ((complex_raises, [ ], [ (x, Type (Z)) ], Type (unit)),
-        LetFun (25, Effect ([ OCaml.Failure ], .))
+      ((complex_raises, [ ], [ (x, Type (Z)) ],
+        Monad ([ Type (OCaml.Failure) ], Type (unit))),
+        LetFun (25, Effect ([ Type (OCaml.Failure) ], .))
           (non_rec, @.,
             [
-              ((f, [ A; B ], [ (a, A) ], (A * Type (Z) * B)),
+              ((f, [ A; B ], [ (a, A) ],
+                Monad
+                  ([
+                    Type
+                      (OCaml.Failure)
+                  ], (A * Type (Z) * B))),
                 Tuple
                   ((25,
                     Effect
                       ([
-                        OCaml.Failure
+                        Type
+                          (OCaml.Failure)
                       ],
                         .)),
                     Variable
@@ -492,7 +511,8 @@ Value
                       ((25,
                         Effect
                           ([
-                            OCaml.Failure
+                            Type
+                              (OCaml.Failure)
                           ],
                             .)),
                         Variable
@@ -502,7 +522,8 @@ Value
                               ],
                                 .
                                   -[
-                                    OCaml.Failure
+                                    Type
+                                      (OCaml.Failure)
                                   ]->
                                   .)),
                             OCaml.Pervasives.failwith),
@@ -517,17 +538,19 @@ Value
                         ])))
             ]) in
         For
-          ((26, Effect ([ OCaml.Failure ], .)), i, true,
+          ((26, Effect ([ Type (OCaml.Failure) ], .)), i, true,
             Constant ((26, Effect ([ ], .)), Int(0)),
             Variable ((26, Effect ([ ], .)), x),
             Coerce
-              ((?, Effect ([ OCaml.Failure ], .)),
+              ((?, Effect ([ Type (OCaml.Failure) ], .)),
                 Apply
-                  ((27, Effect ([ OCaml.Failure ], .)),
+                  ((27, Effect ([ Type (OCaml.Failure) ], .)),
                     Variable
                       ((27,
-                        Effect ([ ], . -[ OCaml.Failure ]-> .)),
-                        f),
+                        Effect
+                          ([ ],
+                            . -[ Type (OCaml.Failure) ]->
+                              .)), f),
                     [ Constructor ((27, Effect ([ ], .)), true) ]),
                 (Type (bool) * Type (Z) * ()))))
     ])
@@ -538,7 +561,7 @@ Value
     [
       ((argument_effects, [ ],
         [ (x, Type (OCaml.Effect.State.t, Type (Z))); (y, Type (Z)) ],
-        Type (Z)),
+        Monad ([ Type (OCaml.Effect.State.state, Type (Z)) ], Type (Z))),
         LetVar (31, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .))
           y =
           Apply
@@ -697,7 +720,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       Z.add),
                                   [
                                     Apply
@@ -787,7 +814,11 @@ Value
                                   Effect
                                     ([
                                     ],
-                                      .)),
+                                      .
+                                        ->
+                                        .
+                                          ->
+                                          .)),
                                   Z.sub),
                               [
                                 Apply

--- a/tests/ex42.monadise
+++ b/tests/ex42.monadise
@@ -205,7 +205,8 @@ Value
 Value
   (non_rec, @.,
     [
-      ((raises, [ ], [ (x, Type (Z)) ], Monad ([ OCaml.Failure ], Type (unit))),
+      ((raises, [ ], [ (x, Type (Z)) ],
+        Monad ([ Type (OCaml.Failure) ], Type (unit))),
         Apply
           (20, Variable (?, OCaml.Basics.for_to),
             [
@@ -227,7 +228,8 @@ Value
                           ]),
                       Monad
                         ([
-                          OCaml.Failure
+                          Type
+                            (OCaml.Failure)
                         ],
                           ())))
             ]))
@@ -238,18 +240,16 @@ Value
   (non_rec, @.,
     [
       ((complex_raises, [ ], [ (x, Type (Z)) ],
-        Monad ([ OCaml.Failure ], Type (unit))),
+        Monad ([ Type (OCaml.Failure) ], Type (unit))),
         LetFun 25
           (non_rec, @.,
             [
               ((f, [ A; B ], [ (a, A) ],
                 Monad
-                  ([ OCaml.Failure ],
-                    (A *
-                      Type
-                        (Z)
-                      *
-                      B))),
+                  ([
+                    Type
+                      (OCaml.Failure)
+                  ], (A * Type (Z) * B))),
                 Bind
                   (?,
                     Apply
@@ -299,7 +299,8 @@ Value
                           ]),
                       Monad
                         ([
-                          OCaml.Failure
+                          Type
+                            (OCaml.Failure)
                         ],
                           (Type
                             (bool)

--- a/tests/ex43.effects
+++ b/tests/ex43.effects
@@ -4,14 +4,20 @@ Require [ OCaml.List ]
 Value
   (non_rec, @.,
     [
-      ((slow_div, [ ], [ (a, Type (Z)); (b, Type (Z)) ], Type (Z)),
+      ((slow_div, [ ], [ (a, Type (Z)); (b, Type (Z)) ],
+        Monad
+          ([
+            Type (OCaml.Effect.State.state, Type (Z));
+            Type (Counter);
+            Type (NonTermination)
+          ], Type (Z))),
         LetVar
           (3,
             Effect
               ([
                 Type (OCaml.Effect.State.state, Type (Z));
-                Counter;
-                NonTermination
+                Type (Counter);
+                Type (NonTermination)
               ], .)) y =
           Apply
             ((3, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
@@ -32,8 +38,8 @@ Value
             Effect
               ([
                 Type (OCaml.Effect.State.state, Type (Z));
-                Counter;
-                NonTermination
+                Type (Counter);
+                Type (NonTermination)
               ], .)) c =
           Apply
             ((4, Effect ([ Type (OCaml.Effect.State.state, Type (Z)) ], .)),
@@ -54,16 +60,16 @@ Value
             Effect
               ([
                 Type (OCaml.Effect.State.state, Type (Z));
-                Counter;
-                NonTermination
+                Type (Counter);
+                Type (NonTermination)
               ], .)),
             While
               ((5,
                 Effect
                   ([
                     Type (OCaml.Effect.State.state, Type (Z));
-                    Counter;
-                    NonTermination
+                    Type (Counter);
+                    Type (NonTermination)
                   ], .)),
                 Apply
                   ((5,
@@ -75,7 +81,8 @@ Value
                               (Z))
                       ], .)),
                     Variable
-                      ((5, Effect ([ ], .)), OCaml.Pervasives.le),
+                      ((5, Effect ([ ], . -> . -> .)),
+                        OCaml.Pervasives.le),
                     [
                       Apply
                         ((5,
@@ -92,7 +99,11 @@ Value
                               Effect
                                 ([
                                 ],
-                                  .)),
+                                  .
+                                    ->
+                                    .
+                                      ->
+                                      .)),
                               Z.add),
                           [
                             Apply
@@ -186,7 +197,11 @@ Value
                                   Effect
                                     ([
                                     ],
-                                      .)),
+                                      .
+                                        ->
+                                        .
+                                          ->
+                                          .)),
                                   Z.add),
                               [
                                 Apply
@@ -270,7 +285,11 @@ Value
                                   Effect
                                     ([
                                     ],
-                                      .)),
+                                      .
+                                        ->
+                                        .
+                                          ->
+                                          .)),
                                   Z.add),
                               [
                                 Apply
@@ -337,7 +356,23 @@ Value
 Value
   (non_rec, @.,
     [
-      ((nested, [ ], [ (x, Type (unit)) ], Type (list, Type (Z))),
+      ((nested, [ ], [ (x, Type (unit)) ],
+        Monad
+          ([
+            Type (OCaml.Effect.State.state, Type (list, Type (Z)));
+            Type
+              (OCaml.Effect.State.state,
+                Type
+                  (list,
+                    Type
+                      (OCaml.Effect.State.t,
+                        Type
+                          (list,
+                            Type
+                              (Z)))));
+            Type (Counter);
+            Type (NonTermination)
+          ], Type (list, Type (Z)))),
         Match
           ((?,
             Effect
@@ -353,8 +388,8 @@ Value
                               (list,
                                 Type
                                   (Z)))));
-                Counter;
-                NonTermination
+                Type (Counter);
+                Type (NonTermination)
               ], .)), Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (tt),
@@ -378,8 +413,10 @@ Value
                                       (list,
                                         Type
                                           (Z)))));
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .))
                   a =
@@ -703,8 +740,10 @@ Value
                                       (list,
                                         Type
                                           (Z)))));
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .))
                   b =
@@ -766,8 +805,10 @@ Value
                                       (list,
                                         Type
                                           (Z)))));
-                        Counter;
-                        NonTermination
+                        Type
+                          (Counter);
+                        Type
+                          (NonTermination)
                       ],
                         .)),
                     While
@@ -790,8 +831,10 @@ Value
                                           (list,
                                             Type
                                               (Z)))));
-                            Counter;
-                            NonTermination
+                            Type
+                              (Counter);
+                            Type
+                              (NonTermination)
                           ],
                             .)),
                         Apply
@@ -815,7 +858,11 @@ Value
                                 Effect
                                   ([
                                   ],
-                                    .)),
+                                    .
+                                      ->
+                                      .
+                                        ->
+                                        .)),
                                 OCaml.Pervasives.gt),
                             [
                               Apply
@@ -839,7 +886,9 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .)),
                                       OCaml.List.length),
                                   [
                                     Apply
@@ -916,8 +965,10 @@ Value
                                               (list,
                                                 Type
                                                   (Z)))));
-                                Counter;
-                                NonTermination
+                                Type
+                                  (Counter);
+                                Type
+                                  (NonTermination)
                               ],
                                 .)),
                             Apply
@@ -999,8 +1050,10 @@ Value
                                                       (list,
                                                         Type
                                                           (Z)))));
-                                        Counter;
-                                        NonTermination
+                                        Type
+                                          (Counter);
+                                        Type
+                                          (NonTermination)
                                       ],
                                         .)),
                                     While
@@ -1013,8 +1066,10 @@ Value
                                                   (list,
                                                     Type
                                                       (Z)));
-                                            Counter;
-                                            NonTermination
+                                            Type
+                                              (Counter);
+                                            Type
+                                              (NonTermination)
                                           ],
                                             .)),
                                         Apply
@@ -1034,7 +1089,11 @@ Value
                                                 Effect
                                                   ([
                                                   ],
-                                                    .)),
+                                                    .
+                                                      ->
+                                                      .
+                                                        ->
+                                                        .)),
                                                 OCaml.Pervasives.gt),
                                             [
                                               Apply
@@ -1054,7 +1113,9 @@ Value
                                                       Effect
                                                         ([
                                                         ],
-                                                          .)),
+                                                          .
+                                                            ->
+                                                            .)),
                                                       OCaml.List.length),
                                                   [
                                                     Apply
@@ -1420,17 +1481,28 @@ Value
 Value
   (non_rec, @.,
     [
-      ((raises, [ ], [ (b, Type (bool)) ], Type (unit)),
+      ((raises, [ ], [ (b, Type (bool)) ],
+        Monad
+          ([ Type (Counter); Type (NonTermination); Type (OCaml.Failure) ],
+            Type (unit))),
         While
-          ((30, Effect ([ Counter; NonTermination; OCaml.Failure ], .)),
-            Variable ((30, Effect ([ ], .)), b),
+          ((30,
+            Effect
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Failure)
+              ], .)), Variable ((30, Effect ([ ], .)), b),
             Coerce
-              ((?, Effect ([ OCaml.Failure ], .)),
+              ((?, Effect ([ Type (OCaml.Failure) ], .)),
                 Apply
-                  ((31, Effect ([ OCaml.Failure ], .)),
+                  ((31, Effect ([ Type (OCaml.Failure) ], .)),
                     Variable
                       ((31,
-                        Effect ([ ], . -[ OCaml.Failure ]-> .)),
+                        Effect
+                          ([ ],
+                            . -[ Type (OCaml.Failure) ]->
+                              .)),
                         OCaml.Pervasives.failwith),
                     [
                       Constant
@@ -1447,16 +1519,32 @@ Value
 Value
   (non_rec, @.,
     [
-      ((complex_raises, [ ], [ (b, Type (bool)) ], Type (unit)),
-        LetFun (35, Effect ([ Counter; NonTermination; OCaml.Failure ], .))
+      ((complex_raises, [ ], [ (b, Type (bool)) ],
+        Monad
+          ([ Type (Counter); Type (NonTermination); Type (OCaml.Failure) ],
+            Type (unit))),
+        LetFun
+          (35,
+            Effect
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Failure)
+              ], .))
           (non_rec, @.,
             [
-              ((f, [ A; B ], [ (a, A) ], (A * Type (Z) * B)),
+              ((f, [ A; B ], [ (a, A) ],
+                Monad
+                  ([
+                    Type
+                      (OCaml.Failure)
+                  ], (A * Type (Z) * B))),
                 Tuple
                   ((35,
                     Effect
                       ([
-                        OCaml.Failure
+                        Type
+                          (OCaml.Failure)
                       ],
                         .)),
                     Variable
@@ -1477,7 +1565,8 @@ Value
                       ((35,
                         Effect
                           ([
-                            OCaml.Failure
+                            Type
+                              (OCaml.Failure)
                           ],
                             .)),
                         Variable
@@ -1487,7 +1576,8 @@ Value
                               ],
                                 .
                                   -[
-                                    OCaml.Failure
+                                    Type
+                                      (OCaml.Failure)
                                   ]->
                                   .)),
                             OCaml.Pervasives.failwith),
@@ -1502,16 +1592,23 @@ Value
                         ])))
             ]) in
         While
-          ((36, Effect ([ Counter; NonTermination; OCaml.Failure ], .)),
-            Variable ((36, Effect ([ ], .)), b),
+          ((36,
+            Effect
+              ([
+                Type (Counter);
+                Type (NonTermination);
+                Type (OCaml.Failure)
+              ], .)), Variable ((36, Effect ([ ], .)), b),
             Coerce
-              ((?, Effect ([ OCaml.Failure ], .)),
+              ((?, Effect ([ Type (OCaml.Failure) ], .)),
                 Apply
-                  ((37, Effect ([ OCaml.Failure ], .)),
+                  ((37, Effect ([ Type (OCaml.Failure) ], .)),
                     Variable
                       ((37,
-                        Effect ([ ], . -[ OCaml.Failure ]-> .)),
-                        f),
+                        Effect
+                          ([ ],
+                            . -[ Type (OCaml.Failure) ]->
+                              .)), f),
                     [ Constructor ((37, Effect ([ ], .)), true) ]),
                 (Type (bool) * Type (Z) * ()))))
     ])
@@ -1522,14 +1619,19 @@ Value
     [
       ((argument_effects, [ ],
         [ (x, Type (OCaml.Effect.State.t, Type (Z))); (y, Type (Z)) ],
-        Type (Z)),
+        Monad
+          ([
+            Type (OCaml.Effect.State.state, Type (Z));
+            Type (Counter);
+            Type (NonTermination)
+          ], Type (Z))),
         LetVar
           (41,
             Effect
               ([
                 Type (OCaml.Effect.State.state, Type (Z));
-                Counter;
-                NonTermination
+                Type (Counter);
+                Type (NonTermination)
               ], .)) y =
           Apply
             ((41,
@@ -1551,8 +1653,8 @@ Value
             Effect
               ([
                 Type (OCaml.Effect.State.state, Type (Z));
-                Counter;
-                NonTermination
+                Type (Counter);
+                Type (NonTermination)
               ], .)) z =
           Apply
             ((42,
@@ -1574,8 +1676,8 @@ Value
             Effect
               ([
                 Type (OCaml.Effect.State.state, Type (Z));
-                Counter;
-                NonTermination
+                Type (Counter);
+                Type (NonTermination)
               ], .)) i =
           Apply
             ((43,
@@ -1597,16 +1699,16 @@ Value
             Effect
               ([
                 Type (OCaml.Effect.State.state, Type (Z));
-                Counter;
-                NonTermination
+                Type (Counter);
+                Type (NonTermination)
               ], .)),
             While
               ((44,
                 Effect
                   ([
                     Type (OCaml.Effect.State.state, Type (Z));
-                    Counter;
-                    NonTermination
+                    Type (Counter);
+                    Type (NonTermination)
                   ], .)),
                 Apply
                   ((44,
@@ -1618,7 +1720,7 @@ Value
                               (Z))
                       ], .)),
                     Variable
-                      ((44, Effect ([ ], .)),
+                      ((44, Effect ([ ], . -> . -> .)),
                         OCaml.Pervasives.le),
                     [
                       Apply
@@ -1696,8 +1798,8 @@ Value
                           (OCaml.Effect.State.state,
                             Type
                               (Z));
-                        Counter;
-                        NonTermination
+                        Type (Counter);
+                        Type (NonTermination)
                       ], .)) j =
                   Apply
                     ((45,
@@ -1737,8 +1839,8 @@ Value
                           (OCaml.Effect.State.state,
                             Type
                               (Z));
-                        Counter;
-                        NonTermination
+                        Type (Counter);
+                        Type (NonTermination)
                       ], .)),
                     While
                       ((46,
@@ -1748,8 +1850,8 @@ Value
                               (OCaml.Effect.State.state,
                                 Type
                                   (Z));
-                            Counter;
-                            NonTermination
+                            Type (Counter);
+                            Type (NonTermination)
                           ], .)),
                         Apply
                           ((46,
@@ -1761,7 +1863,9 @@ Value
                                       (Z))
                               ], .)),
                             Variable
-                              ((46, Effect ([ ], .)),
+                              ((46,
+                                Effect
+                                  ([ ], . -> . -> .)),
                                 OCaml.Pervasives.le),
                             [
                               Apply
@@ -1886,7 +1990,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           Z.add),
                                       [
                                         Apply
@@ -1977,7 +2085,11 @@ Value
                                           Effect
                                             ([
                                             ],
-                                              .)),
+                                              .
+                                                ->
+                                                .
+                                                  ->
+                                                  .)),
                                           Z.add),
                                       [
                                         Apply
@@ -2076,7 +2188,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       Z.sub),
                                   [
                                     Apply
@@ -2166,7 +2282,11 @@ Value
                                       Effect
                                         ([
                                         ],
-                                          .)),
+                                          .
+                                            ->
+                                            .
+                                              ->
+                                              .)),
                                       Z.add),
                                   [
                                     Apply

--- a/tests/ex43.monadise
+++ b/tests/ex43.monadise
@@ -8,8 +8,8 @@ Value
         Monad
           ([
             Type (OCaml.Effect.State.state, Type (Z));
-            Counter;
-            NonTermination
+            Type (Counter);
+            Type (NonTermination)
           ], Type (Z))),
         Bind
           (?,
@@ -17,8 +17,8 @@ Value
               (?, [ Type (OCaml.Effect.State.state, Type (Z)) ],
                 [
                   Type (OCaml.Effect.State.state, Type (Z));
-                  Counter;
-                  NonTermination
+                  Type (Counter);
+                  Type (NonTermination)
                 ],
                 Apply
                   (3, Variable (3, OCaml.Pervasives.ref),
@@ -29,8 +29,8 @@ Value
                   (?, [ Type (OCaml.Effect.State.state, Type (Z)) ],
                     [
                       Type (OCaml.Effect.State.state, Type (Z));
-                      Counter;
-                      NonTermination
+                      Type (Counter);
+                      Type (NonTermination)
                     ],
                     Apply
                       (4, Variable (4, OCaml.Pervasives.ref),
@@ -52,7 +52,8 @@ Value
                                   (OCaml.Effect.State.state,
                                     Type
                                       (Z));
-                                NonTermination
+                                Type
+                                  (NonTermination)
                               ],
                                 ())),
                             Match
@@ -66,14 +67,16 @@ Value
                                     Lift
                                       (?,
                                         [
-                                          NonTermination
+                                          Type
+                                            (NonTermination)
                                         ],
                                         [
                                           Type
                                             (OCaml.Effect.State.state,
                                               Type
                                                 (Z));
-                                          NonTermination
+                                          Type
+                                            (NonTermination)
                                         ],
                                         Apply
                                           (?,
@@ -103,7 +106,8 @@ Value
                                                 (OCaml.Effect.State.state,
                                                   Type
                                                     (Z));
-                                              NonTermination
+                                              Type
+                                                (NonTermination)
                                             ],
                                             Bind
                                               (?,
@@ -175,7 +179,8 @@ Value
                                                         (OCaml.Effect.State.state,
                                                           Type
                                                             (Z));
-                                                      NonTermination
+                                                      Type
+                                                        (NonTermination)
                                                     ],
                                                     Bind
                                                       (?,
@@ -293,14 +298,14 @@ Value
                     Bind
                       (?,
                         Lift
-                          (?, [ Counter ],
+                          (?, [ Type (Counter) ],
                             [
                               Type
                                 (OCaml.Effect.State.state,
                                   Type
                                     (Z));
-                              Counter;
-                              NonTermination
+                              Type (Counter);
+                              Type (NonTermination)
                             ],
                             Apply
                               (?,
@@ -315,15 +320,15 @@ Value
                                 (OCaml.Effect.State.state,
                                   Type
                                     (Z));
-                              NonTermination
+                              Type (NonTermination)
                             ],
                             [
                               Type
                                 (OCaml.Effect.State.state,
                                   Type
                                     (Z));
-                              Counter;
-                              NonTermination
+                              Type (Counter);
+                              Type (NonTermination)
                             ],
                             Apply
                               (?, Variable (?, while),
@@ -345,8 +350,8 @@ Value
                             (OCaml.Effect.State.state,
                               Type
                                 (Z));
-                          Counter;
-                          NonTermination
+                          Type (Counter);
+                          Type (NonTermination)
                         ],
                         Apply
                           (9,
@@ -374,8 +379,8 @@ Value
                           (list,
                             Type
                               (Z)))));
-            Counter;
-            NonTermination
+            Type (Counter);
+            Type (NonTermination)
           ], Type (list, Type (Z)))),
         Match
           (?, Variable (?, x),
@@ -420,8 +425,10 @@ Value
                                         (list,
                                           Type
                                             (Z)))));
-                          Counter;
-                          NonTermination
+                          Type
+                            (Counter);
+                          Type
+                            (NonTermination)
                         ],
                         Bind
                           (?,
@@ -653,8 +660,10 @@ Value
                                             (list,
                                               Type
                                                 (Z)))));
-                              Counter;
-                              NonTermination
+                              Type
+                                (Counter);
+                              Type
+                                (NonTermination)
                             ],
                             Apply
                               (13,
@@ -701,8 +710,10 @@ Value
                                                       (list,
                                                         Type
                                                           (Z)))));
-                                        Counter;
-                                        NonTermination
+                                        Type
+                                          (Counter);
+                                        Type
+                                          (NonTermination)
                                       ],
                                         ())),
                                     Match
@@ -716,7 +727,8 @@ Value
                                             Lift
                                               (?,
                                                 [
-                                                  NonTermination
+                                                  Type
+                                                    (NonTermination)
                                                 ],
                                                 [
                                                   Type
@@ -735,8 +747,10 @@ Value
                                                                 (list,
                                                                   Type
                                                                     (Z)))));
-                                                  Counter;
-                                                  NonTermination
+                                                  Type
+                                                    (Counter);
+                                                  Type
+                                                    (NonTermination)
                                                 ],
                                                 Apply
                                                   (?,
@@ -784,8 +798,10 @@ Value
                                                                     (list,
                                                                       Type
                                                                         (Z)))));
-                                                      Counter;
-                                                      NonTermination
+                                                      Type
+                                                        (Counter);
+                                                      Type
+                                                        (NonTermination)
                                                     ],
                                                     Bind
                                                       (?,
@@ -874,8 +890,10 @@ Value
                                                                                 (list,
                                                                                   Type
                                                                                     (Z)))));
-                                                                  Counter;
-                                                                  NonTermination
+                                                                  Type
+                                                                    (Counter);
+                                                                  Type
+                                                                    (NonTermination)
                                                                 ],
                                                                 Apply
                                                                   (15,
@@ -917,8 +935,10 @@ Value
                                                                                     (list,
                                                                                       Type
                                                                                         (Z)));
-                                                                              Counter;
-                                                                              NonTermination
+                                                                              Type
+                                                                                (Counter);
+                                                                              Type
+                                                                                (NonTermination)
                                                                             ],
                                                                             [
                                                                               Type
@@ -937,8 +957,10 @@ Value
                                                                                             (list,
                                                                                               Type
                                                                                                 (Z)))));
-                                                                              Counter;
-                                                                              NonTermination
+                                                                              Type
+                                                                                (Counter);
+                                                                              Type
+                                                                                (NonTermination)
                                                                             ],
                                                                             LetFun
                                                                               18
@@ -961,7 +983,8 @@ Value
                                                                                               (list,
                                                                                                 Type
                                                                                                   (Z)));
-                                                                                        NonTermination
+                                                                                        Type
+                                                                                          (NonTermination)
                                                                                       ],
                                                                                         ())),
                                                                                     Match
@@ -975,7 +998,8 @@ Value
                                                                                             Lift
                                                                                               (?,
                                                                                                 [
-                                                                                                  NonTermination
+                                                                                                  Type
+                                                                                                    (NonTermination)
                                                                                                 ],
                                                                                                 [
                                                                                                   Type
@@ -984,7 +1008,8 @@ Value
                                                                                                         (list,
                                                                                                           Type
                                                                                                             (Z)));
-                                                                                                  NonTermination
+                                                                                                  Type
+                                                                                                    (NonTermination)
                                                                                                 ],
                                                                                                 Apply
                                                                                                   (?,
@@ -1018,7 +1043,8 @@ Value
                                                                                                             (list,
                                                                                                               Type
                                                                                                                 (Z)));
-                                                                                                      NonTermination
+                                                                                                      Type
+                                                                                                        (NonTermination)
                                                                                                     ],
                                                                                                     Bind
                                                                                                       (?,
@@ -1091,7 +1117,8 @@ Value
                                                                                                                     (list,
                                                                                                                       Type
                                                                                                                         (Z)));
-                                                                                                              NonTermination
+                                                                                                              Type
+                                                                                                                (NonTermination)
                                                                                                             ],
                                                                                                             Bind
                                                                                                               (?,
@@ -1207,7 +1234,8 @@ Value
                                                                                 Lift
                                                                                   (?,
                                                                                     [
-                                                                                      Counter
+                                                                                      Type
+                                                                                        (Counter)
                                                                                     ],
                                                                                     [
                                                                                       Type
@@ -1216,8 +1244,10 @@ Value
                                                                                             (list,
                                                                                               Type
                                                                                                 (Z)));
-                                                                                      Counter;
-                                                                                      NonTermination
+                                                                                      Type
+                                                                                        (Counter);
+                                                                                      Type
+                                                                                        (NonTermination)
                                                                                     ],
                                                                                     Apply
                                                                                       (?,
@@ -1240,7 +1270,8 @@ Value
                                                                                             (list,
                                                                                               Type
                                                                                                 (Z)));
-                                                                                      NonTermination
+                                                                                      Type
+                                                                                        (NonTermination)
                                                                                     ],
                                                                                     [
                                                                                       Type
@@ -1249,8 +1280,10 @@ Value
                                                                                             (list,
                                                                                               Type
                                                                                                 (Z)));
-                                                                                      Counter;
-                                                                                      NonTermination
+                                                                                      Type
+                                                                                        (Counter);
+                                                                                      Type
+                                                                                        (NonTermination)
                                                                                     ],
                                                                                     Apply
                                                                                       (?,
@@ -1294,8 +1327,10 @@ Value
                                                                                             (list,
                                                                                               Type
                                                                                                 (Z)))));
-                                                                              Counter;
-                                                                              NonTermination
+                                                                              Type
+                                                                                (Counter);
+                                                                              Type
+                                                                                (NonTermination)
                                                                             ],
                                                                             Apply
                                                                               (25,
@@ -1335,7 +1370,8 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      Counter
+                                      Type
+                                        (Counter)
                                     ],
                                     [
                                       Type
@@ -1354,8 +1390,10 @@ Value
                                                     (list,
                                                       Type
                                                         (Z)))));
-                                      Counter;
-                                      NonTermination
+                                      Type
+                                        (Counter);
+                                      Type
+                                        (NonTermination)
                                     ],
                                     Apply
                                       (?,
@@ -1407,8 +1445,10 @@ Value
                                                 (list,
                                                   Type
                                                     (Z)))));
-                                  Counter;
-                                  NonTermination
+                                  Type
+                                    (Counter);
+                                  Type
+                                    (NonTermination)
                                 ],
                                 Apply
                                   (27,
@@ -1428,15 +1468,19 @@ Value
   (non_rec, @.,
     [
       ((raises, [ ], [ (b, Type (bool)) ],
-        Monad ([ Counter; NonTermination; OCaml.Failure ], Type (unit))),
+        Monad
+          ([ Type (Counter); Type (NonTermination); Type (OCaml.Failure) ],
+            Type (unit))),
         LetFun 30
           (rec, @.,
             [
               ((while, [ ], [ (counter, Type (nat)) ],
                 Monad
                   ([
-                    NonTermination;
-                    OCaml.Failure
+                    Type
+                      (NonTermination);
+                    Type
+                      (OCaml.Failure)
                   ], ())),
                 Match
                   (?,
@@ -1449,11 +1493,14 @@ Value
                         Lift
                           (?,
                             [
-                              NonTermination
+                              Type
+                                (NonTermination)
                             ],
                             [
-                              NonTermination;
-                              OCaml.Failure
+                              Type
+                                (NonTermination);
+                              Type
+                                (OCaml.Failure)
                             ],
                             Apply
                               (?,
@@ -1486,11 +1533,14 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      OCaml.Failure
+                                      Type
+                                        (OCaml.Failure)
                                     ],
                                     [
-                                      NonTermination;
-                                      OCaml.Failure
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Failure)
                                     ],
                                     Coerce
                                       (?,
@@ -1506,7 +1556,8 @@ Value
                                             ]),
                                         Monad
                                           ([
-                                            OCaml.Failure
+                                            Type
+                                              (OCaml.Failure)
                                           ],
                                             ()))),
                                 None,
@@ -1530,14 +1581,22 @@ Value
         Bind
           (?,
             Lift
-              (?, [ Counter ],
-                [ Counter; NonTermination; OCaml.Failure ],
+              (?, [ Type (Counter) ],
+                [
+                  Type (Counter);
+                  Type (NonTermination);
+                  Type (OCaml.Failure)
+                ],
                 Apply
                   (?, Variable (?, read_counter),
                     [ Constructor (?, tt) ])), Some counter,
             Lift
-              (?, [ NonTermination; OCaml.Failure ],
-                [ Counter; NonTermination; OCaml.Failure ],
+              (?, [ Type (NonTermination); Type (OCaml.Failure) ],
+                [
+                  Type (Counter);
+                  Type (NonTermination);
+                  Type (OCaml.Failure)
+                ],
                 Apply
                   (?, Variable (?, while), [ Variable (?, counter) ]))))
     ])
@@ -1547,18 +1606,18 @@ Value
   (non_rec, @.,
     [
       ((complex_raises, [ ], [ (b, Type (bool)) ],
-        Monad ([ Counter; NonTermination; OCaml.Failure ], Type (unit))),
+        Monad
+          ([ Type (Counter); Type (NonTermination); Type (OCaml.Failure) ],
+            Type (unit))),
         LetFun 35
           (non_rec, @.,
             [
               ((f, [ A; B ], [ (a, A) ],
                 Monad
-                  ([ OCaml.Failure ],
-                    (A *
-                      Type
-                        (Z)
-                      *
-                      B))),
+                  ([
+                    Type
+                      (OCaml.Failure)
+                  ], (A * Type (Z) * B))),
                 Bind
                   (?,
                     Apply
@@ -1593,8 +1652,10 @@ Value
               ((while, [ ], [ (counter, Type (nat)) ],
                 Monad
                   ([
-                    NonTermination;
-                    OCaml.Failure
+                    Type
+                      (NonTermination);
+                    Type
+                      (OCaml.Failure)
                   ], ())),
                 Match
                   (?,
@@ -1607,11 +1668,14 @@ Value
                         Lift
                           (?,
                             [
-                              NonTermination
+                              Type
+                                (NonTermination)
                             ],
                             [
-                              NonTermination;
-                              OCaml.Failure
+                              Type
+                                (NonTermination);
+                              Type
+                                (OCaml.Failure)
                             ],
                             Apply
                               (?,
@@ -1644,11 +1708,14 @@ Value
                                 Lift
                                   (?,
                                     [
-                                      OCaml.Failure
+                                      Type
+                                        (OCaml.Failure)
                                     ],
                                     [
-                                      NonTermination;
-                                      OCaml.Failure
+                                      Type
+                                        (NonTermination);
+                                      Type
+                                        (OCaml.Failure)
                                     ],
                                     Coerce
                                       (?,
@@ -1664,7 +1731,8 @@ Value
                                             ]),
                                         Monad
                                           ([
-                                            OCaml.Failure
+                                            Type
+                                              (OCaml.Failure)
                                           ],
                                             (Type
                                               (bool)
@@ -1694,14 +1762,22 @@ Value
         Bind
           (?,
             Lift
-              (?, [ Counter ],
-                [ Counter; NonTermination; OCaml.Failure ],
+              (?, [ Type (Counter) ],
+                [
+                  Type (Counter);
+                  Type (NonTermination);
+                  Type (OCaml.Failure)
+                ],
                 Apply
                   (?, Variable (?, read_counter),
                     [ Constructor (?, tt) ])), Some counter,
             Lift
-              (?, [ NonTermination; OCaml.Failure ],
-                [ Counter; NonTermination; OCaml.Failure ],
+              (?, [ Type (NonTermination); Type (OCaml.Failure) ],
+                [
+                  Type (Counter);
+                  Type (NonTermination);
+                  Type (OCaml.Failure)
+                ],
                 Apply
                   (?, Variable (?, while), [ Variable (?, counter) ]))))
     ])
@@ -1715,8 +1791,8 @@ Value
         Monad
           ([
             Type (OCaml.Effect.State.state, Type (Z));
-            Counter;
-            NonTermination
+            Type (Counter);
+            Type (NonTermination)
           ], Type (Z))),
         Bind
           (?,
@@ -1724,8 +1800,8 @@ Value
               (?, [ Type (OCaml.Effect.State.state, Type (Z)) ],
                 [
                   Type (OCaml.Effect.State.state, Type (Z));
-                  Counter;
-                  NonTermination
+                  Type (Counter);
+                  Type (NonTermination)
                 ],
                 Apply
                   (41, Variable (41, OCaml.Pervasives.ref),
@@ -1736,8 +1812,8 @@ Value
                   (?, [ Type (OCaml.Effect.State.state, Type (Z)) ],
                     [
                       Type (OCaml.Effect.State.state, Type (Z));
-                      Counter;
-                      NonTermination
+                      Type (Counter);
+                      Type (NonTermination)
                     ],
                     Apply
                       (42, Variable (42, OCaml.Pervasives.ref),
@@ -1757,8 +1833,8 @@ Value
                             (OCaml.Effect.State.state,
                               Type
                                 (Z));
-                          Counter;
-                          NonTermination
+                          Type (Counter);
+                          Type (NonTermination)
                         ],
                         Apply
                           (43,
@@ -1783,8 +1859,10 @@ Value
                                       (OCaml.Effect.State.state,
                                         Type
                                           (Z));
-                                    Counter;
-                                    NonTermination
+                                    Type
+                                      (Counter);
+                                    Type
+                                      (NonTermination)
                                   ],
                                     ())),
                                 Match
@@ -1798,15 +1876,18 @@ Value
                                         Lift
                                           (?,
                                             [
-                                              NonTermination
+                                              Type
+                                                (NonTermination)
                                             ],
                                             [
                                               Type
                                                 (OCaml.Effect.State.state,
                                                   Type
                                                     (Z));
-                                              Counter;
-                                              NonTermination
+                                              Type
+                                                (Counter);
+                                              Type
+                                                (NonTermination)
                                             ],
                                             Apply
                                               (?,
@@ -1836,8 +1917,10 @@ Value
                                                     (OCaml.Effect.State.state,
                                                       Type
                                                         (Z));
-                                                  Counter;
-                                                  NonTermination
+                                                  Type
+                                                    (Counter);
+                                                  Type
+                                                    (NonTermination)
                                                 ],
                                                 Bind
                                                   (?,
@@ -1906,8 +1989,10 @@ Value
                                                                 (OCaml.Effect.State.state,
                                                                   Type
                                                                     (Z));
-                                                              Counter;
-                                                              NonTermination
+                                                              Type
+                                                                (Counter);
+                                                              Type
+                                                                (NonTermination)
                                                             ],
                                                             Apply
                                                               (45,
@@ -1942,7 +2027,8 @@ Value
                                                                           (OCaml.Effect.State.state,
                                                                             Type
                                                                               (Z));
-                                                                        NonTermination
+                                                                        Type
+                                                                          (NonTermination)
                                                                       ],
                                                                         ())),
                                                                     Match
@@ -1956,14 +2042,16 @@ Value
                                                                             Lift
                                                                               (?,
                                                                                 [
-                                                                                  NonTermination
+                                                                                  Type
+                                                                                    (NonTermination)
                                                                                 ],
                                                                                 [
                                                                                   Type
                                                                                     (OCaml.Effect.State.state,
                                                                                       Type
                                                                                         (Z));
-                                                                                  NonTermination
+                                                                                  Type
+                                                                                    (NonTermination)
                                                                                 ],
                                                                                 Apply
                                                                                   (?,
@@ -1993,7 +2081,8 @@ Value
                                                                                         (OCaml.Effect.State.state,
                                                                                           Type
                                                                                             (Z));
-                                                                                      NonTermination
+                                                                                      Type
+                                                                                        (NonTermination)
                                                                                     ],
                                                                                     Bind
                                                                                       (?,
@@ -2060,7 +2149,8 @@ Value
                                                                                                 (OCaml.Effect.State.state,
                                                                                                   Type
                                                                                                     (Z));
-                                                                                              NonTermination
+                                                                                              Type
+                                                                                                (NonTermination)
                                                                                             ],
                                                                                             Bind
                                                                                               (?,
@@ -2181,15 +2271,18 @@ Value
                                                                 Lift
                                                                   (?,
                                                                     [
-                                                                      Counter
+                                                                      Type
+                                                                        (Counter)
                                                                     ],
                                                                     [
                                                                       Type
                                                                         (OCaml.Effect.State.state,
                                                                           Type
                                                                             (Z));
-                                                                      Counter;
-                                                                      NonTermination
+                                                                      Type
+                                                                        (Counter);
+                                                                      Type
+                                                                        (NonTermination)
                                                                     ],
                                                                     Apply
                                                                       (?,
@@ -2210,15 +2303,18 @@ Value
                                                                         (OCaml.Effect.State.state,
                                                                           Type
                                                                             (Z));
-                                                                      NonTermination
+                                                                      Type
+                                                                        (NonTermination)
                                                                     ],
                                                                     [
                                                                       Type
                                                                         (OCaml.Effect.State.state,
                                                                           Type
                                                                             (Z));
-                                                                      Counter;
-                                                                      NonTermination
+                                                                      Type
+                                                                        (Counter);
+                                                                      Type
+                                                                        (NonTermination)
                                                                     ],
                                                                     Apply
                                                                       (?,
@@ -2244,8 +2340,10 @@ Value
                                                                     (OCaml.Effect.State.state,
                                                                       Type
                                                                         (Z));
-                                                                  Counter;
-                                                                  NonTermination
+                                                                  Type
+                                                                    (Counter);
+                                                                  Type
+                                                                    (NonTermination)
                                                                 ],
                                                                 Bind
                                                                   (?,
@@ -2363,14 +2461,15 @@ Value
                         Bind
                           (?,
                             Lift
-                              (?, [ Counter ],
+                              (?, [ Type (Counter) ],
                                 [
                                   Type
                                     (OCaml.Effect.State.state,
                                       Type
                                         (Z));
-                                  Counter;
-                                  NonTermination
+                                  Type (Counter);
+                                  Type
+                                    (NonTermination)
                                 ],
                                 Apply
                                   (?,
@@ -2403,8 +2502,8 @@ Value
                                 (OCaml.Effect.State.state,
                                   Type
                                     (Z));
-                              Counter;
-                              NonTermination
+                              Type (Counter);
+                              Type (NonTermination)
                             ],
                             Apply
                               (53,

--- a/tests/ex44.effects
+++ b/tests/ex44.effects
@@ -5,7 +5,7 @@ Value
       ((temp, [ ], [ ], Type (unit)),
         Apply
           ((3, Effect ([ ], .)),
-            Variable ((3, Effect ([ ], .)), OCaml.Pervasives.ignore),
+            Variable ((3, Effect ([ ], . -> .)), OCaml.Pervasives.ignore),
             [
               Apply
                 ((3, Effect ([ ], .)),
@@ -14,7 +14,11 @@ Value
                       Effect
                         ([
                         ],
-                          .)),
+                          .
+                            ->
+                            .
+                              ->
+                              .)),
                       Z.add),
                   [
                     Constant
@@ -365,10 +369,19 @@ Value
     [
       ((f (= f_1), [ A ], [ ], (A -> Type (Z))),
         Match
-          ((30, Effect ([ ], .)), Variable ((30, Effect ([ ], .)), c_val),
+          ((30, Effect ([ ], . -> .)),
+            Variable ((30, Effect ([ ], .)), c_val),
             [
               (Record ((f, f (= f_1))),
-                Variable ((30, Effect ([ ], .)), f_1))
+                Variable
+                  ((30,
+                    Effect
+                      ([
+                      ],
+                        .
+                          ->
+                          .)),
+                    f_1))
             ]))
     ])
 
@@ -406,6 +419,10 @@ Value
     [
       ((g, [ A ], [ ], (A -> Type (Z))),
         Match
-          ((36, Effect ([ ], .)), Variable ((36, Effect ([ ], .)), d_val),
-            [ (Constructor (F, g), Variable ((36, Effect ([ ], .)), g)) ]))
+          ((36, Effect ([ ], . -> .)),
+            Variable ((36, Effect ([ ], .)), d_val),
+            [
+              (Constructor (F, g),
+                Variable ((36, Effect ([ ], . -> .)), g))
+            ]))
     ])


### PR DESCRIPTION
This PR
* reworks `Effect.t` and `Effect.Type.t` so that they both use `Type.t`
* reworks `Effect.Descriptor.t` so that it can be recursively defined with `Type.t`
  - this means that, in the future, effects may include types which themselves have effects, etc.
* tweaks the types output in some explicit code to have the correct types
* removes `Effect.PureType.t`
* uses type unification to place effects
  - this allows effects to be wrapped in tuples (although the corresponding match statements don't yet support it), and can be extended to records and inductive types if/when necessary
* removes `FullEnvi.Value.Function` and its helper methods
* removes some dead code (most notably `Interface.Shape`)