### PR TITLE
Basic implementation of open types and type extensions

### DIFF
--- a/OCaml/Basics.v
+++ b/OCaml/Basics.v
@@ -71,6 +71,8 @@ Module Z.
     compare_is_sound := Z.compare_spec |}.
 End Z.
 
+Definition exn := Effect.Open_Type.t.
+
 Definition exception (A : Type) : Effect.t :=
   Effect.make unit A.
 

--- a/OCaml/Effect.v
+++ b/OCaml/Effect.v
@@ -188,6 +188,14 @@ Definition lift {A : Type} (es : list Effect.t) (bs : string)
   (x : M _ A) : M _ A :=
   of_raw (Raw.lift es bs (to_raw x)).
 
+Module Open_Type.
+  Fixpoint t (es : list Type) : Type :=
+    match es with
+    | [] => unit
+    | T :: es => T + t es
+    end.
+End Open_Type.
+
 Module Exception.
   Fixpoint remove_nth (es : list Effect.t) (n : nat) : list Effect.t :=
     match es with

--- a/src/boundName.ml
+++ b/src/boundName.ml
@@ -21,6 +21,12 @@ let pp (x : t) : SmartPrint.t =
 let stable_compare (x : t) (y : t) : int =
   compare x.full_path y.full_path
 
+type t' = t
+module Set = Set.Make(struct
+  type t = t'
+  let compare = stable_compare
+end)
+
 let to_coq (x : t) : SmartPrint.t =
   PathName.to_coq x.local_path
 

--- a/src/commonType.ml
+++ b/src/commonType.ml
@@ -23,6 +23,7 @@ module TypeDefinition = struct
     | Record of CoqName.t * Name.t list * (CoqName.t * typ) list
     | Synonym of CoqName.t * Name.t list * typ
     | Abstract of CoqName.t * Name.t list
+    | Open of CoqName.t
 end
 
 type t = typ

--- a/src/commonType.ml
+++ b/src/commonType.ml
@@ -1,5 +1,6 @@
 open SmartPrint
 open Yojson.Basic
+open Utils
 
 module Type = struct
   type typ =
@@ -7,6 +8,7 @@ module Type = struct
     | Arrow of typ * typ
     | Tuple of typ list
     | Apply of BoundName.t * typ list
+    | OpenApply of BoundName.t * typ list * BoundName.t list
     | Monad of desc * typ
 
   and desc = {
@@ -36,6 +38,11 @@ let rec pp (typ : t) : SmartPrint.t =
   | Apply (x, typs) ->
     nest (!^ "Type" ^^ nest (parens (
       separate (!^ "," ^^ space) (BoundName.pp x :: List.map pp typs))))
+  | OpenApply (x, typs, typ_defs) ->
+    nest (!^ "OpenApply" ^^ nest (parens (
+      separate (!^ "," ^^ space) (BoundName.pp x ::
+        braces (separate (!^ "," ^^ space) (List.map BoundName.pp typ_defs)) ::
+        List.map pp typs))))
   | Monad (d, typ) -> nest (!^ "Monad" ^^ OCaml.tuple [pp_desc d; pp typ])
 
 and pp_desc (d : desc) : SmartPrint.t =
@@ -47,33 +54,34 @@ let rec compare (typ1 : t) (typ2 : t) : int =
   | Variable _, _ -> -1
   | _, Variable _ -> 1
   | Arrow (typ1a, typ1b), Arrow (typ2a, typ2b) ->
-    compare_list [typ1a; typ1b] [typ2a; typ2b]
+    compare_list compare [typ1a; typ1b] [typ2a; typ2b]
   | Arrow _, _ -> -1
   | _, Arrow _ -> 1
-  | Tuple typs1, Tuple typs2 -> compare_list typs1 typs2
+  | Tuple typs1, Tuple typs2 -> compare_list compare typs1 typs2
   | Tuple _, _ -> -1
   | _, Tuple _ -> 1
   | Apply (x, typs1), Apply (y, typs2) ->
     let cmp = BoundName.stable_compare x y in
-    if cmp = 0 then compare_list typs1 typs2 else cmp
+    if cmp = 0 then compare_list compare typs1 typs2 else cmp
   | Apply _, _ -> -1
   | _, Apply _ -> 1
+  | OpenApply (x, typs1, typ_defs1), OpenApply (y, typs2, typ_defs2) ->
+    let cmp = BoundName.stable_compare x y in
+    if cmp = 0 then
+      let cmp = compare_list compare typs1 typs2 in
+      if cmp = 0 then
+        compare_list BoundName.stable_compare typ_defs1 typ_defs2
+      else cmp
+    else cmp
+  | OpenApply _, _ -> -1
+  | _, OpenApply _ -> 1
   | Monad (d1, typ1), Monad (d2, typ2) ->
     let cmp = compare_desc d1 d2 in
     if cmp = 0 then compare typ1 typ2 else cmp
 
-and compare_list (typs1 : t list) (typs2 : t list) : int =
-  match typs1, typs2 with
-  | [], [] -> 0
-  | [], _ -> -1
-  | _, [] -> 1
-  | typ1 :: typs1, typ2 :: typs2 ->
-    let cmp = compare typ1 typ2 in
-    if cmp = 0 then compare_list typs1 typs2 else cmp
-
 and compare_desc (d1 : desc) (d2 : desc) : int =
-  let cmp = compare_list d1.with_args d2.with_args in
-  if cmp = 0 then compare_list d1.no_args d2.no_args else cmp
+  let cmp = compare_list compare d1.with_args d2.with_args in
+  if cmp = 0 then compare_list compare d1.no_args d2.no_args else cmp
 
 module Set = Set.Make (struct
   type t = typ
@@ -96,6 +104,10 @@ let rec unify (typ1 : t) (typ2 : t) : t Name.Map.t =
   | Apply (x1, typs1), Apply (x2, typs2) ->
     List.fold_left2 (fun var_map typ1 typ2 -> union var_map (unify typ1 typ2))
       Name.Map.empty typs1 typs2
+  | OpenApply (x1, typs1, typ_defs1), OpenApply (x2, typs2, typ_defs2) ->
+    List.fold_left2 (fun var_map typ1 typ2 ->
+        union var_map (unify typ1 typ2))
+      Name.Map.empty typs1 typs2
   | _, _ -> failwith "Could not unify types"
 
 let rec unify_monad (f : desc -> desc option -> desc) (typ1 : t) (typ2 : t)
@@ -113,6 +125,10 @@ let rec unify_monad (f : desc -> desc option -> desc) (typ1 : t) (typ2 : t)
     Monad (f d1 (Some d2), unify_monad typ1 typ2)
   | Monad (d, typ1), typ2 | typ1, Monad (d, typ2) ->
     Monad (f d None, unify_monad typ1 typ2)
+  | OpenApply (x1, typs1, typ_defs1), OpenApply (x2, typs2, typ_defs2) ->
+    let typ_defs = BoundName.Set.elements @@ BoundName.Set.union
+      (BoundName.Set.of_list typ_defs1) (BoundName.Set.of_list typ_defs2) in
+    OpenApply (x1, List.map2 unify_monad typs1 typs2, typ_defs)
   | _, Variable y -> typ1
   | Variable x, _ -> typ2
   | _, _ -> failwith "Could not unify types"
@@ -123,6 +139,8 @@ let rec map (f : BoundName.t -> BoundName.t) (typ : t) : t =
   | Arrow (typ_x, typ_y) -> Arrow (map f typ_x, map f typ_y)
   | Tuple typs -> Tuple (List.map (map f) typs)
   | Apply (path, typs) -> Apply (f path, List.map (map f) typs)
+  | OpenApply (x, typs, typ_defs) ->
+    OpenApply (x, List.map (map f) typs, List.map f typ_defs)
   | Monad (d, typ) -> Monad (d, map f typ)
 
 let rec map_vars (f : Name.t -> t) (typ : t) : t =
@@ -131,6 +149,8 @@ let rec map_vars (f : Name.t -> t) (typ : t) : t =
   | Arrow (typ1, typ2) -> Arrow (map_vars f typ1, map_vars f typ2)
   | Tuple typs -> Tuple (List.map (map_vars f) typs)
   | Apply (x, typs) -> Apply (x, List.map (map_vars f) typs)
+  | OpenApply (x, typs, typ_defs) ->
+    OpenApply (x, List.map (map_vars f) typs, typ_defs)
   | Monad (d, typ) -> Monad (map_desc_vars f d, map_vars f typ)
 
 and map_desc_vars (f : Name.t -> t) (d : desc) : desc =
@@ -144,6 +164,7 @@ let rec typ_args (typ : t) : Name.Set.t =
   | Variable x -> Name.Set.singleton x
   | Arrow (typ1, typ2) -> typ_args_of_typs [typ1; typ2]
   | Tuple typs | Apply (_, typs) -> typ_args_of_typs typs
+  | OpenApply (x, typs, typ_defs) -> typ_args_of_typs typs
   | Monad (d, typ) -> Name.Set.union (desc_typ_args d) (typ_args typ)
 
 and typ_args_of_typs (typs : t list) : Name.Set.t =
@@ -161,6 +182,10 @@ let rec to_json (typ : t) : json =
   | Tuple typs -> `List (`String "Tuple" :: List.map to_json typs)
   | Apply (path, typs) ->
     `List (`String "Apply" :: BoundName.to_json path :: List.map to_json typs)
+  | OpenApply (path, typs, typ_defs) ->
+    `List [`String "OpenApply"; BoundName.to_json path;
+      `List (List.map to_json typs);
+      `List (List.map BoundName.to_json typ_defs)]
   | Monad (descriptor, typ) ->
     `List [`String "Monad"; desc_to_json descriptor; to_json typ]
 
@@ -181,6 +206,9 @@ let rec of_json (json : json) : t =
   | `List (`String "Tuple" :: typs) -> Tuple (List.map of_json typs)
   | `List (`String "Apply" :: path :: typs) ->
     Apply (BoundName.of_json path, List.map of_json typs)
+  | `List [`String "OpenApply"; path; `List typs; `List typ_defs] ->
+    OpenApply (BoundName.of_json path, List.map of_json typs,
+      List.map BoundName.of_json typ_defs)
   | `List [`String "Monad"; descriptor; typ] ->
     Monad (desc_of_json descriptor, of_json typ)
   | _ -> failwith "Invalid JSON for Type."
@@ -213,5 +241,9 @@ let rec to_coq (a_to_coq : desc -> SmartPrint.t) (paren : bool) (typ : t)
   | Apply (path, typs) ->
     Pp.parens (paren && typs <> []) @@ nest @@ separate space
       (BoundName.to_coq path :: List.map (to_coq true) typs)
+  | OpenApply (path, typs, typ_defs) ->
+    Pp.parens paren @@ nest @@
+      BoundName.to_coq path ^^ OCaml.list (fun name ->
+        to_coq false (Apply (name, typs))) typ_defs
   | Monad (d, typ) ->
     Pp.parens paren @@ nest (!^ "M" ^^ a_to_coq d ^^ to_coq true typ)

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -465,7 +465,8 @@ let rec of_expression (env : unit FullEnvi.t) (typ_vars : Name.t Name.Map.t)
   | Texp_tuple es -> Tuple (a, List.map (of_expression env typ_vars) es)
   | Texp_construct (x, _, es) ->
     let x = FullEnvi.Constructor.bound l (PathName.of_loc x) env in
-    Constructor (a, x, List.map (of_expression env typ_vars) es)
+    let typ = Type.set_type_extension l env typ x in
+    Constructor ((l, typ), x, List.map (of_expression env typ_vars) es)
   | Texp_record { fields; extended_expression } ->
     Record (a, Array.to_list fields |> List.map (fun (label, definition) ->
       match definition with

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -465,8 +465,19 @@ let rec of_expression (env : unit FullEnvi.t) (typ_vars : Name.t Name.Map.t)
   | Texp_tuple es -> Tuple (a, List.map (of_expression env typ_vars) es)
   | Texp_construct (x, _, es) ->
     let x = FullEnvi.Constructor.bound l (PathName.of_loc x) env in
-    let typ = Type.set_type_extension l env typ x in
-    Constructor ((l, typ), x, List.map (of_expression env typ_vars) es)
+    begin match typ with
+    | Type.OpenApply (name, typs, _) ->
+      let (true_typ, _) = FullEnvi.Constructor.find l x env in
+      let true_typ = FullEnvi.Typ.localize env true_typ.PathName.path
+        true_typ.PathName.base in
+      let true_typ_full = Type.Apply (true_typ, typs) in
+      let typ = Type.OpenApply (name, typs, [true_typ]) in
+      Constructor ((Loc.Unknown, typ),
+        FullEnvi.Constructor.localize env [] "inl",
+      [Constructor ((l, true_typ_full), x,
+        List.map (of_expression env typ_vars) es)])
+    | _ -> Constructor (a, x, List.map (of_expression env typ_vars) es)
+    end
   | Texp_record { fields; extended_expression } ->
     Record (a, Array.to_list fields |> List.map (fun (label, definition) ->
       match definition with

--- a/src/kerneltypes.ml
+++ b/src/kerneltypes.ml
@@ -1,0 +1,18 @@
+module Type = struct
+  type 'a t' =
+    | Variable of Name.t
+    | Arrow of 'a t' * 'a t'
+    | Tuple of 'a t' list
+    | Apply of BoundName.t * 'a t' list
+    | OpenApply of BoundName.t * 'a t' list * BoundName.t list
+    | Monad of 'a * 'a t'
+end
+
+module TypeDefinition = struct
+  type 'a t' =
+    | Inductive of CoqName.t * Name.t list * (CoqName.t * 'a Type.t' list) list
+    | Record of CoqName.t * Name.t list * (CoqName.t * 'a Type.t') list
+    | Synonym of CoqName.t * Name.t list * 'a Type.t'
+    | Abstract of CoqName.t * Name.t list
+    | Open of CoqName.t
+end

--- a/src/pervasivesModule.ml
+++ b/src/pervasivesModule.ml
@@ -117,7 +117,7 @@ let env_with_effects (interfaces : (Name.t * string) list)
       Type.Variable "A")))
   (* Predefined exceptions *)
   |> Descriptor.add [] "exception" ()
-  |> Typ.add [] "exn" (TypeDefinition.Abstract (CoqName.Name "exn", []))
+  |> Typ.add [] "exn" (TypeDefinition.Open (CoqName.Name "exn"))
   |> add_exn [] "Match_failure"
   |> add_exn [] "Assert_failure"
   |> add_exn [] "Invalid_argument"

--- a/src/type.ml
+++ b/src/type.ml
@@ -39,7 +39,10 @@ let rec of_type_expr_new_typ_vars (env : 'a FullEnvi.t) (loc : Loc.t)
   | Tconstr (path, typs, _) ->
     let (typs, typ_vars, new_typ_vars) = of_typs_exprs_new_free_vars env loc typ_vars typs in
     let x = FullEnvi.Typ.bound loc (PathName.of_type_path loc path) env in
-    (Apply (x, typs), typ_vars, new_typ_vars)
+    let typ = match FullEnvi.Typ.find loc x env with
+      | Open _ -> OpenApply (x, typs, [])
+      | _ -> Apply (x, typs) in
+    (typ, typ_vars, new_typ_vars)
   | Tlink typ -> of_type_expr_new_typ_vars env loc typ_vars typ
   | Tpoly (typ, []) -> of_type_expr_new_typ_vars env loc typ_vars typ
   | _ ->

--- a/src/type.ml
+++ b/src/type.ml
@@ -92,15 +92,10 @@ let is_function (typ : t) : bool =
 
 let equal (typ1 : t) (typ2 : t) : bool = CommonType.equal typ1 typ2
 
-let set_type_extension (loc : Loc.t) (env : 'a FullEnvi.t) (typ : t)
-  (constr : BoundName.t) : t =
+let is_open (typ : t) : bool =
   match typ with
-  | OpenApply (name, open_typs, []) ->
-    let (typ, index) = FullEnvi.Constructor.find loc constr env in
-    let bound_typ = FullEnvi.Typ.localize env typ.PathName.path
-      typ.PathName.base in
-    OpenApply (name, open_typs, [bound_typ])
-  | _ -> typ
+  | OpenApply _ -> true
+  | _ -> false
 
 let unify (typ1 : t) (typ2 : t) : t Name.Map.t = CommonType.unify typ1 typ2
 

--- a/src/type.ml
+++ b/src/type.ml
@@ -92,6 +92,16 @@ let is_function (typ : t) : bool =
 
 let equal (typ1 : t) (typ2 : t) : bool = CommonType.equal typ1 typ2
 
+let set_type_extension (loc : Loc.t) (env : 'a FullEnvi.t) (typ : t)
+  (constr : BoundName.t) : t =
+  match typ with
+  | OpenApply (name, open_typs, []) ->
+    let (typ, index) = FullEnvi.Constructor.find loc constr env in
+    let bound_typ = FullEnvi.Typ.localize env typ.PathName.path
+      typ.PathName.base in
+    OpenApply (name, open_typs, [bound_typ])
+  | _ -> typ
+
 let unify (typ1 : t) (typ2 : t) : t Name.Map.t = CommonType.unify typ1 typ2
 
 let map_vars (f : Name.t -> t) (typ : t) : t = CommonType.map_vars f typ

--- a/src/typeExt.ml
+++ b/src/typeExt.ml
@@ -35,4 +35,4 @@ let update_env (ext : t) (env : 'a FullEnvi.t) : 'a FullEnvi.t =
   TypeDefinition.update_env ext.typ_def env
 
 let to_coq (ext : t) : SmartPrint.t =
-  TypeDefinition.to_coq ext.typ_def
+  !^ "Polymorphic" ^^ TypeDefinition.to_coq ext.typ_def

--- a/src/typeExt.ml
+++ b/src/typeExt.ml
@@ -1,0 +1,38 @@
+open Types
+open Typedtree
+open SmartPrint
+open Utils
+
+type t = {
+  typ : BoundName.t;
+  typ_def : TypeDefinition.t;
+}
+
+let of_ocaml (env : 'a FullEnvi.t) (loc : Loc.t) (typext : type_extension) : t =
+  let path = PathName.of_path loc typext.tyext_path in
+  let typ = FullEnvi.Typ.bound loc path env in
+  let (x, x_bound, env) = FullEnvi.Typ.fresh path.PathName.base
+    (Abstract (CoqName.Name path.PathName.base, [])) env in
+  let typ_args = typext.tyext_params |> List.map (fun (arg, _) ->
+    Type.of_type_expr_variable loc arg.ctyp_type) in
+  let constructors = typext.tyext_constructors |> ((0, env) |>
+    map_with_acc (fun (index, env) { ext_id = constr; ext_type = exttyp } ->
+      let typs =
+        match exttyp.ext_args with
+        | Cstr_tuple typs -> typs
+        | Cstr_record _ -> Error.raise loc "Unhandled named constructor parameters." in
+      let constr = Name.of_ident constr in
+      let typs = List.map (fun typ -> Type.of_type_expr env loc typ) typs in
+      let (constr, _, env) = FullEnvi.Constructor.create constr
+        (x_bound.BoundName.full_path, index) env in
+      ((1 + index, env), (constr, typs)))) in
+  { typ; typ_def = TypeDefinition.Inductive (x, typ_args, constructors) }
+
+let pp (ext : t) : SmartPrint.t =
+  OCaml.tuple [BoundName.pp ext.typ; TypeDefinition.pp ext.typ_def]
+
+let update_env (ext : t) (env : 'a FullEnvi.t) : 'a FullEnvi.t =
+  TypeDefinition.update_env ext.typ_def env
+
+let to_coq (ext : t) : SmartPrint.t =
+  TypeDefinition.to_coq ext.typ_def

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -71,3 +71,13 @@ let rec map_with_acc (f : 'a -> 'b -> 'a * 'c) (a : 'a) (l : 'b list)
   | x :: l ->
     let (a, x) = f a x in
     x :: map_with_acc f a l
+
+let rec compare_list (compare : 'a -> 'a -> int) (l1 : 'a list) (l2 : 'a list)
+  : int =
+  match l1, l2 with
+  | [], [] -> 0
+  | [], _ -> -1
+  | _, [] -> 1
+  | a :: l1, b :: l2 ->
+    let cmp = compare a b in
+    if cmp = 0 then compare_list compare l1 l2 else cmp

--- a/tests/ex46.effects
+++ b/tests/ex46.effects
@@ -1,0 +1,109 @@
+2 Open t
+
+4
+Value
+  (non_rec, @.,
+    [
+      ((f, [ ], [ (x, Type (unit)) ],
+        Monad ([ Type (OCaml.Assert_failure) ], OpenApply (t, {}))),
+        Match
+          ((4, Effect ([ Type (OCaml.Assert_failure) ], .)),
+            Variable ((?, Effect ([ ], .)), x),
+            [
+              (Constructor (tt),
+                Apply
+                  ((4,
+                    Effect
+                      ([
+                        Type
+                          (OCaml.Assert_failure)
+                      ],
+                        .)),
+                    Variable
+                      ((4,
+                        Effect
+                          ([
+                          ],
+                            .
+                              -[
+                                Type
+                                  (OCaml.Assert_failure)
+                              ]->
+                              .)),
+                        OCaml.assert),
+                    [
+                      Constructor
+                        ((4,
+                          Effect
+                            ([
+                            ],
+                              .)),
+                          false)
+                    ]))
+            ]))
+    ])
+
+6 Open u
+
+8
+Value
+  (non_rec, @.,
+    [
+      ((g, [ A ], [ (x, A) ],
+        Monad ([ Type (OCaml.Failure) ], OpenApply (u, {}, A))),
+        Apply
+          ((8, Effect ([ Type (OCaml.Failure) ], .)),
+            Variable
+              ((8, Effect ([ ], . -[ Type (OCaml.Failure) ]-> .)),
+                OCaml.Pervasives.failwith),
+            [ Constant ((8, Effect ([ ], .)), String("fail")) ]))
+    ])
+
+10 TypeExt
+(t,
+  Inductive t_1:
+    ([ ], [ (Test1, [ ]); (Test2, [ Type (bool) ]) ]))
+
+12 TypeExt
+(t,
+  Inductive t_2:
+    ([ ], [ (Test3, [ Type (Z) ]); (Test4, [ Type (option, Type (Z)) ]) ]))
+
+14 TypeExt
+(u,
+  Inductive u_1:
+    ([ b ], [ (Test5, [ b ]); (Test6, [ Type (Z) ]) ]))
+
+16
+Value
+  (non_rec, @.,
+    [
+      ((x, [ ], [ ], OpenApply (t, {t_1})),
+        Constructor
+          ((?, Effect ([ ], .)), inl,
+            Constructor ((16, Effect ([ ], .)), Test1)))
+    ])
+
+18
+Value
+  (non_rec, @.,
+    [
+      ((y, [ ], [ ], OpenApply (u, {u_1}, Type (Z))),
+        Constructor
+          ((?, Effect ([ ], .)), inl,
+            Constructor
+              ((18, Effect ([ ], .)), Test5,
+                Constant ((18, Effect ([ ], .)), Int(5)))))
+    ])
+
+20
+Value
+  (non_rec, @.,
+    [
+      ((z, [ A ], [ ], OpenApply (u, {u_1}, A)),
+        Constructor
+          ((?, Effect ([ ], .)), inl,
+            Constructor
+              ((20, Effect ([ ], .)), Test6,
+                Constant ((20, Effect ([ ], .)), Int(6)))))
+    ])

--- a/tests/ex46.effects
+++ b/tests/ex46.effects
@@ -5,10 +5,14 @@ Value
   (non_rec, @.,
     [
       ((f, [ ], [ (x, Type (unit)) ],
-        Monad ([ Type (OCaml.Assert_failure) ], OpenApply (t, {}))),
+        Monad
+          ([ Type (OCaml.exception, Type (OCaml.assert_failure)) ],
+            OpenApply (t, {}))),
         Match
-          ((4, Effect ([ Type (OCaml.Assert_failure) ], .)),
-            Variable ((?, Effect ([ ], .)), x),
+          ((4,
+            Effect
+              ([ Type (OCaml.exception, Type (OCaml.assert_failure)) ],
+                .)), Variable ((?, Effect ([ ], .)), x),
             [
               (Constructor (tt),
                 Apply
@@ -16,7 +20,9 @@ Value
                     Effect
                       ([
                         Type
-                          (OCaml.Assert_failure)
+                          (OCaml.exception,
+                            Type
+                              (OCaml.assert_failure))
                       ],
                         .)),
                     Variable
@@ -27,7 +33,9 @@ Value
                             .
                               -[
                                 Type
-                                  (OCaml.Assert_failure)
+                                  (OCaml.exception,
+                                    Type
+                                      (OCaml.assert_failure))
                               ]->
                               .)),
                         OCaml.assert),
@@ -50,12 +58,22 @@ Value
   (non_rec, @.,
     [
       ((g, [ A ], [ (x, A) ],
-        Monad ([ Type (OCaml.Failure) ], OpenApply (u, {}, A))),
+        Monad
+          ([ Type (OCaml.exception, Type (OCaml.failure)) ],
+            OpenApply (u, {}, A))),
         Apply
-          ((8, Effect ([ Type (OCaml.Failure) ], .)),
+          ((8, Effect ([ Type (OCaml.exception, Type (OCaml.failure)) ], .)),
             Variable
-              ((8, Effect ([ ], . -[ Type (OCaml.Failure) ]-> .)),
-                OCaml.Pervasives.failwith),
+              ((8,
+                Effect
+                  ([ ],
+                    .
+                      -[
+                        Type
+                          (OCaml.exception,
+                            Type
+                              (OCaml.failure))
+                      ]-> .)), OCaml.Pervasives.failwith),
             [ Constant ((8, Effect ([ ], .)), String("fail")) ]))
     ])
 
@@ -106,4 +124,16 @@ Value
             Constructor
               ((20, Effect ([ ], .)), Test6,
                 Constant ((20, Effect ([ ], .)), Int(6)))))
+    ])
+
+22
+Value
+  (non_rec, @.,
+    [
+      ((failure, [ ], [ ], OpenApply (OCaml.exn, {OCaml.failure})),
+        Constructor
+          ((?, Effect ([ ], .)), inl,
+            Constructor
+              ((22, Effect ([ ], .)), OCaml.Failure,
+                Constant ((22, Effect ([ ], .)), String("")))))
     ])

--- a/tests/ex46.exp
+++ b/tests/ex46.exp
@@ -72,3 +72,13 @@ Value
       ((z, [ A ], [ ], OpenApply (u, {}, A)),
         Constructor (?, inl, Constructor (20, Test6, Constant (20, Int(6)))))
     ])
+
+22
+Value
+  (non_rec, @.,
+    [
+      ((failure, [ ], [ ], OpenApply (OCaml.exn, {})),
+        Constructor
+          (?, inl,
+            Constructor (22, OCaml.Failure, Constant (22, String("")))))
+    ])

--- a/tests/ex46.exp
+++ b/tests/ex46.exp
@@ -1,0 +1,74 @@
+2 Open t
+
+4
+Value
+  (non_rec, @.,
+    [
+      ((f, [ ], [ (x, Type (unit)) ], OpenApply (t, {})),
+        Match
+          (4, Variable (?, x),
+            [
+              (Constructor (tt),
+                Apply
+                  (4,
+                    Variable
+                      (4,
+                        OCaml.assert),
+                    [
+                      Constructor
+                        (4,
+                          false)
+                    ]))
+            ]))
+    ])
+
+6 Open u
+
+8
+Value
+  (non_rec, @.,
+    [
+      ((g, [ A ], [ (x, A) ], OpenApply (u, {}, A)),
+        Apply
+          (8, Variable (8, OCaml.Pervasives.failwith),
+            [ Constant (8, String("fail")) ]))
+    ])
+
+10 TypeExt
+(t,
+  Inductive t_1:
+    ([ ], [ (Test1, [ ]); (Test2, [ Type (bool) ]) ]))
+
+12 TypeExt
+(t,
+  Inductive t_2:
+    ([ ], [ (Test3, [ Type (Z) ]); (Test4, [ Type (option, Type (Z)) ]) ]))
+
+14 TypeExt
+(u,
+  Inductive u_1:
+    ([ b ], [ (Test5, [ b ]); (Test6, [ Type (Z) ]) ]))
+
+16
+Value
+  (non_rec, @.,
+    [
+      ((x, [ ], [ ], OpenApply (t, {})),
+        Constructor (?, inl, Constructor (16, Test1)))
+    ])
+
+18
+Value
+  (non_rec, @.,
+    [
+      ((y, [ ], [ ], OpenApply (u, {}, Type (Z))),
+        Constructor (?, inl, Constructor (18, Test5, Constant (18, Int(5)))))
+    ])
+
+20
+Value
+  (non_rec, @.,
+    [
+      ((z, [ A ], [ ], OpenApply (u, {}, A)),
+        Constructor (?, inl, Constructor (20, Test6, Constant (20, Int(6)))))
+    ])

--- a/tests/ex46.interface
+++ b/tests/ex46.interface
@@ -5,9 +5,9 @@
     "Ex46",
     [
       [ "Typ", [ "Open", "t" ] ],
-      [ "Var", "f", [ [ [ "OCaml.Assert_failure" ] ] ] ],
+      [ "Var", "f", [ [ [ [ "Apply", "OCaml.exception", [ "Apply", "OCaml.assert_failure" ] ] ] ] ] ],
       [ "Typ", [ "Open", "u" ] ],
-      [ "Var", "g", [ [ [ "OCaml.Failure" ] ] ] ],
+      [ "Var", "g", [ [ [ [ "Apply", "OCaml.exception", [ "Apply", "OCaml.failure" ] ] ] ] ] ],
       [ "TypeExt", "t", [ "Inductive", "t_1", [], [ [ "Test1", [] ], [ "Test2", [ [ "Apply", "bool" ] ] ] ] ] ],
       [
         "TypeExt",
@@ -26,7 +26,8 @@
       ],
       [ "Var", "x", [] ],
       [ "Var", "y", [] ],
-      [ "Var", "z", [] ]
+      [ "Var", "z", [] ],
+      [ "Var", "failure", [] ]
     ]
   ]
 }

--- a/tests/ex46.interface
+++ b/tests/ex46.interface
@@ -1,0 +1,32 @@
+{
+  "version": "2",
+  "content": [
+    "Interface",
+    "Ex46",
+    [
+      [ "Typ", [ "Open", "t" ] ],
+      [ "Var", "f", [ [ [ "OCaml.Assert_failure" ] ] ] ],
+      [ "Typ", [ "Open", "u" ] ],
+      [ "Var", "g", [ [ [ "OCaml.Failure" ] ] ] ],
+      [ "TypeExt", "t", [ "Inductive", "t_1", [], [ [ "Test1", [] ], [ "Test2", [ [ "Apply", "bool" ] ] ] ] ] ],
+      [
+        "TypeExt",
+        "t",
+        [
+          "Inductive",
+          "t_2",
+          [],
+          [ [ "Test3", [ [ "Apply", "Z" ] ] ], [ "Test4", [ [ "Apply", "option", [ "Apply", "Z" ] ] ] ] ]
+        ]
+      ],
+      [
+        "TypeExt",
+        "u",
+        [ "Inductive", "u_1", [ "b" ], [ [ "Test5", [ [ "Variable", "b" ] ] ], [ "Test6", [ [ "Apply", "Z" ] ] ] ] ]
+      ],
+      [ "Var", "x", [] ],
+      [ "Var", "y", [] ],
+      [ "Var", "z", [] ]
+    ]
+  ]
+}

--- a/tests/ex46.ml
+++ b/tests/ex46.ml
@@ -18,3 +18,5 @@ let x = Test1
 let y = Test5 5
 
 let z = Test6 6
+
+let failure = Failure ""

--- a/tests/ex46.ml
+++ b/tests/ex46.ml
@@ -1,0 +1,20 @@
+(** Open type definitions *)
+type t = ..
+
+let f () : t = assert false
+
+type 'a u = ..
+
+let g (x : 'a) : 'a u = failwith "fail"
+
+type t += Test1 | Test2 of bool
+
+type t += Test3 of int | Test4 of int option
+
+type 'b u += Test5 of 'b | Test6 of int
+
+let x = Test1
+
+let y = Test5 5
+
+let z = Test6 6

--- a/tests/ex46.monadise
+++ b/tests/ex46.monadise
@@ -5,7 +5,9 @@ Value
   (non_rec, @.,
     [
       ((f, [ ], [ (x, Type (unit)) ],
-        Monad ([ Type (OCaml.Assert_failure) ], OpenApply (t, {}))),
+        Monad
+          ([ Type (OCaml.exception, Type (OCaml.assert_failure)) ],
+            OpenApply (t, {}))),
         Match
           (4, Variable (?, x),
             [
@@ -30,7 +32,9 @@ Value
   (non_rec, @.,
     [
       ((g, [ A ], [ (x, A) ],
-        Monad ([ Type (OCaml.Failure) ], OpenApply (u, {}, A))),
+        Monad
+          ([ Type (OCaml.exception, Type (OCaml.failure)) ],
+            OpenApply (u, {}, A))),
         Apply
           (8, Variable (8, OCaml.Pervasives.failwith),
             [ Constant (8, String("fail")) ]))
@@ -73,4 +77,14 @@ Value
     [
       ((z, [ A ], [ ], OpenApply (u, {u_1}, A)),
         Constructor (?, inl, Constructor (20, Test6, Constant (20, Int(6)))))
+    ])
+
+22
+Value
+  (non_rec, @.,
+    [
+      ((failure, [ ], [ ], OpenApply (OCaml.exn, {OCaml.failure})),
+        Constructor
+          (?, inl,
+            Constructor (22, OCaml.Failure, Constant (22, String("")))))
     ])

--- a/tests/ex46.monadise
+++ b/tests/ex46.monadise
@@ -1,0 +1,76 @@
+2 Open t
+
+4
+Value
+  (non_rec, @.,
+    [
+      ((f, [ ], [ (x, Type (unit)) ],
+        Monad ([ Type (OCaml.Assert_failure) ], OpenApply (t, {}))),
+        Match
+          (4, Variable (?, x),
+            [
+              (Constructor (tt),
+                Apply
+                  (4,
+                    Variable
+                      (4,
+                        OCaml.assert),
+                    [
+                      Constructor
+                        (4,
+                          false)
+                    ]))
+            ]))
+    ])
+
+6 Open u
+
+8
+Value
+  (non_rec, @.,
+    [
+      ((g, [ A ], [ (x, A) ],
+        Monad ([ Type (OCaml.Failure) ], OpenApply (u, {}, A))),
+        Apply
+          (8, Variable (8, OCaml.Pervasives.failwith),
+            [ Constant (8, String("fail")) ]))
+    ])
+
+10 TypeExt
+(t,
+  Inductive t_1:
+    ([ ], [ (Test1, [ ]); (Test2, [ Type (bool) ]) ]))
+
+12 TypeExt
+(t,
+  Inductive t_2:
+    ([ ], [ (Test3, [ Type (Z) ]); (Test4, [ Type (option, Type (Z)) ]) ]))
+
+14 TypeExt
+(u,
+  Inductive u_1:
+    ([ b ], [ (Test5, [ b ]); (Test6, [ Type (Z) ]) ]))
+
+16
+Value
+  (non_rec, @.,
+    [
+      ((x, [ ], [ ], OpenApply (t, {t_1})),
+        Constructor (?, inl, Constructor (16, Test1)))
+    ])
+
+18
+Value
+  (non_rec, @.,
+    [
+      ((y, [ ], [ ], OpenApply (u, {u_1}, Type (Z))),
+        Constructor (?, inl, Constructor (18, Test5, Constant (18, Int(5)))))
+    ])
+
+20
+Value
+  (non_rec, @.,
+    [
+      ((z, [ A ], [ ], OpenApply (u, {u_1}, A)),
+        Constructor (?, inl, Constructor (20, Test6, Constant (20, Int(6)))))
+    ])

--- a/tests/ex46.v
+++ b/tests/ex46.v
@@ -6,14 +6,14 @@ Import ListNotations.
 
 Definition t := Effect.Open_Type.t.
 
-Definition f (x : unit) : M [ OCaml.Assert_failure ] (t [ ]) :=
+Definition f (x : unit) : M [ OCaml.exception OCaml.assert_failure ] (t [ ]) :=
   match x with
   | tt => OCaml.assert false
   end.
 
 Definition u := Effect.Open_Type.t.
 
-Definition g {A : Type} (x : A) : M [ OCaml.Failure ] (u [ ]) :=
+Definition g {A : Type} (x : A) : M [ OCaml.exception OCaml.failure ] (u [ ]) :=
   OCaml.Pervasives.failwith "fail" % string.
 
 Polymorphic
@@ -38,3 +38,6 @@ Definition x : t [ t_1 : Type ] := inl Test1.
 Definition y : u [ u_1 Z ] := inl (Test5 5).
 
 Definition z {A : Type} : u [ u_1 A ] := inl (Test6 6).
+
+Definition failure : OCaml.exn [ OCaml.failure : Type ] :=
+  inl (OCaml.Failure "" % string).

--- a/tests/ex46.v
+++ b/tests/ex46.v
@@ -1,0 +1,40 @@
+Require Import OCaml.OCaml.
+
+Local Open Scope Z_scope.
+Local Open Scope type_scope.
+Import ListNotations.
+
+Definition t := Effect.Open_Type.t.
+
+Definition f (x : unit) : M [ OCaml.Assert_failure ] (t [ ]) :=
+  match x with
+  | tt => OCaml.assert false
+  end.
+
+Definition u := Effect.Open_Type.t.
+
+Definition g {A : Type} (x : A) : M [ OCaml.Failure ] (u [ ]) :=
+  OCaml.Pervasives.failwith "fail" % string.
+
+Polymorphic
+Inductive t_1 : Type :=
+| Test1 : t_1
+| Test2 : bool -> t_1.
+
+Polymorphic
+Inductive t_2 : Type :=
+| Test3 : Z -> t_2
+| Test4 : (option Z) -> t_2.
+
+Polymorphic
+Inductive u_1 (b : Type) : Type :=
+| Test5 : b -> u_1 b
+| Test6 : Z -> u_1 b.
+Arguments Test5 {b} _.
+Arguments Test6 {b} _.
+
+Definition x : t [ t_1 : Type ] := inl Test1.
+
+Definition y : u [ u_1 Z ] := inl (Test5 5).
+
+Definition z {A : Type} : u [ u_1 A ] := inl (Test6 6).


### PR DESCRIPTION
This PR
* interprets open types
* adds a new type constructor (`OpenApply`) for open types
* registers type extensions as a new type definition, via `TypeExt`
* massages open type constructors so that they construct the intended type (by inserting explicit `inl` constructors)
* adds `exn` as an open type
* adds tests, updates the expected test output

NB: The type inference isn't complete, so this can't be used to support `raise` or `try ... with ...` yet.