### PR TITLE
Add basic support for try ... with _ -> ...

### DIFF
--- a/src/builtins.ml
+++ b/src/builtins.ml
@@ -22,6 +22,7 @@ let _list = BoundName.of_name [] "list"
 let _assert = BoundName.of_name ["OCaml"] "assert"
 
 let _exception = BoundName.of_name ["OCaml"] "exception"
+let _exn = BoundName.of_name ["OCaml"] "exn"
 let _Match_failure = BoundName.of_name ["OCaml"] "Match_failure"
 let _match_failure = BoundName.of_name ["OCaml"] "match_failure"
 let _assert_failure = BoundName.of_name ["OCaml"] "assert_failure"
@@ -55,6 +56,7 @@ module Localize = struct
   let _assert env = FullEnvi.localize env _assert
 
   let _exception env = FullEnvi.localize env _exception
+  let _exn env = FullEnvi.localize env _exn
   let _Match_failure env = FullEnvi.localize env _Match_failure
   let _match_failure env = FullEnvi.localize env _match_failure
   let _assert_failure env = FullEnvi.localize env _assert_failure

--- a/src/effect.ml
+++ b/src/effect.ml
@@ -50,6 +50,17 @@ module Descriptor = struct
       no_args = d.no_args |> List.filter (fun y -> CommonType.compare x y <> 0)
     }
 
+  let find_candidate (f : CommonType.t -> CommonType.t -> CommonType.t option)
+    (x : CommonType.t) (d : t) : CommonType.t =
+    let rec find_candidate dl =
+      match dl with
+      | [] -> failwith "Could not find a candidate descriptor."
+      | d :: dl ->
+        match f d x with
+        | Some d -> d
+        | None -> find_candidate dl in
+    find_candidate d.no_args
+
   let elements (d : t) : BoundName.t list =
     d.no_args |> List.map (fun typ ->
       match typ with

--- a/src/effect.ml
+++ b/src/effect.ml
@@ -72,7 +72,10 @@ module Descriptor = struct
       match l with
       | [] -> 0
       | x :: xs -> if f x then 0 else 1 + find_index xs f in
-    find_index d.no_args (fun y -> CommonType.compare x y = 0)
+    find_index d.no_args (fun y -> CommonType.compare x y = 0) +
+      match d.with_args with
+      | [] -> 0
+      | _ -> 1
 
   let set_unioned_arg (arg : Name.t) (d : t) : t =
     { d with args_arg = Some arg }

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -518,6 +518,23 @@ let rec of_expression (env : unit FullEnvi.t) (typ_vars : Name.t Name.Map.t)
         let env = Pattern.add_to_env p env in
         let e2 = of_expression env typ_vars e2 in
         (p, e2))])
+  | Texp_try (e1, [{c_lhs = {pat_desc = Tpat_any}; c_rhs = e2}]) ->
+    let e1 = of_expression env typ_vars e1 in
+    let typ1 = snd @@ annotation e1 in
+    let typ_sum = Type.Apply (Localize._sum env, [typ1; Type.Variable "_"]) in
+    let match_d = Type.Apply (Localize._exception env, [Type.Variable "_"]) in
+    Match (a, Run ((Loc.Unknown, typ_sum), match_d,
+      Effect.Descriptor.pure, e1), [
+        (let p = Pattern.Constructor (typ_sum, Localize._inl env,
+          [Pattern.Variable (typ1, FullEnvi.Var.coq_name "x" env)]) in
+        let env = Pattern.add_to_env p env in
+        let x = FullEnvi.Var.bound l (PathName.of_name [] "x") env in
+        (p, Variable ((Loc.Unknown, typ), x)));
+        (let p = Pattern.Constructor (typ_sum, Localize._inr env,
+          [Pattern.Any (Type.Variable "_")]) in
+        let env = Pattern.add_to_env p env in
+        let e2 = of_expression env typ_vars e2 in
+        (p, e2))])
   | Texp_for (_, p, e1, e2, dir, e) ->
     let down = match dir with
       | Asttypes.Upto -> true
@@ -1108,6 +1125,8 @@ let rec effects (env : Type.t FullEnvi.t) (e : (Loc.t * Type.t) t)
     let e = effects env e in
     let (d_e, typ_e) = Effect.split @@ snd @@ annotation e in
     let exn = Type.Variable "_" in
+    let x =
+      Effect.Descriptor.find_candidate (Type.unify_monad_opt env) x d_e in
     let typ = Type.unify_monad env typ @@
       Effect.join (Effect.Descriptor.remove x d_e) @@
       Type.Apply (Localize._sum env, [typ_e; exn]) in

--- a/src/type.ml
+++ b/src/type.ml
@@ -192,6 +192,10 @@ let unify_monad ?collapse:(collapse=true) (env : 'a FullEnvi.t) (typ1 : t)
         | None -> d1) in
   unify_monad env f typ1 typ2
 
+(* TODO: rewrite as non-throwing and use to implement unify_monad. *)
+let unify_monad_opt (env : 'a FullEnvi.t) (typ1 : t) (typ2 : t) : t option =
+  try Some (unify_monad env typ1 typ2) with _ -> None
+
 let union (env : 'a FullEnvi.t) (typs : t list) : t =
   List.fold_left (unify_monad env) Effect.Type.pure typs
 

--- a/tests/ex19.effects
+++ b/tests/ex19.effects
@@ -283,3 +283,53 @@ Value
                     Int(12)))
             ]))
     ])
+
+17
+Value
+  (non_rec, @.,
+    [
+      ((x4, [ ], [ ], Type (Z)),
+        Match
+          ((18, Effect ([ ], .)),
+            Run
+              ((?, Effect ([ ], .)),
+                Type (OCaml/exception, Type (OCaml/failure)), [ ],
+                Apply
+                  ((18,
+                    Effect
+                      ([
+                        Type
+                          (OCaml/exception,
+                            Type
+                              (OCaml/failure))
+                      ], .)),
+                    Variable
+                      ((18,
+                        Effect
+                          ([ ],
+                            .
+                              -[
+                                Type
+                                  (OCaml/exception,
+                                    Type
+                                      (OCaml/failure))
+                              ]-> .)),
+                        OCaml/Pervasives.failwith),
+                    [
+                      Constant
+                        ((18,
+                          Effect
+                            ([
+                            ],
+                              .)),
+                          String("arg"))
+                    ])),
+            [
+              (Constructor (inl, x),
+                Variable ((?, Effect ([ ], .)), Ex19/x));
+              (Constructor (inr, Any),
+                Constant
+                  ((19, Effect ([ ], .)),
+                    Int(12)))
+            ]))
+    ])

--- a/tests/ex19.exp
+++ b/tests/ex19.exp
@@ -109,3 +109,21 @@ Value
                 Constant (15, Int(12)))
             ]))
     ])
+
+17
+Value
+  (non_rec, @.,
+    [
+      ((x4, [ ], [ ], Type (Z)),
+        Match
+          (18,
+            Run
+              (?, Type (OCaml/exception, _), [ ],
+                Apply
+                  (18, Variable (18, OCaml/Pervasives.failwith),
+                    [ Constant (18, String("arg")) ])),
+            [
+              (Constructor (inl, x), Variable (?, Ex19/x));
+              (Constructor (inr, Any), Constant (19, Int(12)))
+            ]))
+    ])

--- a/tests/ex19.interface
+++ b/tests/ex19.interface
@@ -7,7 +7,8 @@
       [ "Exception", "Error", "error" ],
       [ "Var", "x1", [] ],
       [ "Var", "x2", [ [ [ [ "Apply", "OCaml.exception", [ "Apply", "OCaml.failure" ] ] ] ] ] ],
-      [ "Var", "x3", [ [ [ [ "Apply", "OCaml.exception", [ "Apply", "OCaml.failure" ] ] ] ] ] ]
+      [ "Var", "x3", [ [ [ [ "Apply", "OCaml.exception", [ "Apply", "OCaml.failure" ] ] ] ] ] ],
+      [ "Var", "x4", [] ]
     ]
   ]
 }

--- a/tests/ex19.ml
+++ b/tests/ex19.ml
@@ -13,3 +13,7 @@ let x2 _ =
 let x3 b =
   try (if b then failwith "arg" else raise Error) with
   | Error -> 12
+
+let x4 =
+  try failwith "arg" with
+  | _ -> 12

--- a/tests/ex19.monadise
+++ b/tests/ex19.monadise
@@ -176,3 +176,21 @@ Value
                             Int(12))))
                 ])))
     ])
+
+17
+Value
+  (non_rec, @.,
+    [
+      ((x4, [ ], [ ], Type (Z)),
+        Match
+          (18,
+            Run
+              (?, Type (OCaml/exception, Type (OCaml/failure)), [ ],
+                Apply
+                  (18, Variable (18, OCaml/Pervasives.failwith),
+                    [ Constant (18, String("arg")) ])),
+            [
+              (Constructor (inl, x), Variable (?, Ex19/x));
+              (Constructor (inr, Any), Constant (19, Int(12)))
+            ]))
+    ])

--- a/tests/ex19.v
+++ b/tests/ex19.v
@@ -33,3 +33,9 @@ Definition x3 (b : bool) : M [ exception failure ] Z :=
   | inl x => ret x
   | inr (Error tt) => ret 12
   end.
+
+Definition x4 : Z :=
+  match Exception.run 0 (Pervasives.failwith "arg" % string) tt with
+  | inl x => x
+  | inr _ => 12
+  end.


### PR DESCRIPTION
This PR
* adds basic support for `try ... with _ -> ...` and `try ... with variable -> ...`
* updates `Effect.Descriptor.index` so that it returns the correct value when there are complex effects present
* adds a test for `try ... with _ -> ...` and updates the expected test output